### PR TITLE
Use only first element of tag array in routes.

### DIFF
--- a/config/dynamic-routes.js
+++ b/config/dynamic-routes.js
@@ -18,12 +18,12 @@ const uniqueTags = getUniqueTags(articles);
 //   [ '/tags/family/page/1', '/tags/family/page/2', '/tags/family/page/3' ],
 // ]
 const deepTagArray = uniqueTags.map((tag) => {
-  const localArticles = getArticlesTaggedWith(tag);
+  const localArticles = getArticlesTaggedWith(tag[0]);
   const localArticleCount = localArticles.length;
   const tagPages = [...Array(Math.ceil(localArticleCount / perPage))];
 
   const tagPathGroup = [];
-  tagPages.map((_, i) => tagPathGroup.push(`/tags/${tag}/page/${i + 1}`));
+  tagPages.map((_, i) => tagPathGroup.push(`/tags/${tag[0]}/page/${i + 1}`));
 
   // tagPathGroup is an array of paths.
   // Example: [ '/tags/cmo/page/1', '/tags/cmo/page/2', '/tags/cmo/page/3' ]
@@ -33,6 +33,6 @@ const deepTagArray = uniqueTags.map((tag) => {
 export default () => [].concat(
   articleSlugs.map((slug) => `/blog/${slug}`),
   articlePages.map((_, i) => `/blog/page/${i + 1}`),
-  uniqueTags.map((tag) => `/tags/${tag}`),
+  uniqueTags.map((tag) => `/tags/${tag[0]}`),
   [].concat(...deepTagArray),
 );


### PR DESCRIPTION
* The getUniqueTags function now returns an array of arrays.
* Each tag array contains the tag name as the first element, followed by the tag count as the second element.
* Exmaple: ['family', 62]
* Therefore, when interpolating tags in route strings, we need to use only the first element in each tag array.