### PR TITLE
feat: add Cloudinary URL builder partial

### DIFF
--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -1,0 +1,22 @@
+{{- $src := .src -}}
+{{- $preset := .preset -}}
+
+{{- if not $src -}}
+  {{- return "" -}}
+{{- end -}}
+
+{{- $presets := dict
+  "featured" "c_scale,f_auto,q_auto,w_740"
+  "regular"  "c_scale,f_auto,q_auto,w_610"
+  "article"  "c_scale,f_auto,q_auto:best"
+  "og"       "c_fill,f_auto,h_630,q_auto,w_1200"
+  "rss"      "c_scale,f_auto,q_auto,w_560"
+-}}
+
+{{- $transforms := index $presets $preset -}}
+
+{{- if $transforms -}}
+  {{- return (replace $src "/upload/" (printf "/upload/%s/" $transforms)) -}}
+{{- else -}}
+  {{- return $src -}}
+{{- end -}}


### PR DESCRIPTION
## Summary

- Add `layouts/partials/cloudinary-url.html` — a return-value partial that constructs optimized Cloudinary URLs with context-specific transformations
- Supports five presets: `featured`, `regular`, `article`, `og`, and `rss`
- Handles edge cases: returns empty string for empty input, returns unmodified URL for unknown presets

## Changes

- **feat**: New `layouts/partials/cloudinary-url.html` partial that accepts a dict with `src` (full Cloudinary URL) and `preset` (string), looks up the transformation parameters, and inserts them into the URL path after `/upload/`

## Testing

- [x] `hugo --gc --minify` build passes
- [x] `hugo server -D` runs without errors
- [ ] Functional testing will occur when the article card partial (#18) calls this partial with real Cloudinary URLs

Closes #16