### PR TITLE
feat: add sample blog articles for development

### DIFF
--- a/content/blog/2024-06-15-language-learning-journey.md
+++ b/content/blog/2024-06-15-language-learning-journey.md
@@ -1,0 +1,17 @@
+---
+title: "Language Learning Journey"
+date: 2024-06-15
+author: "Joshua Steele"
+description: >-
+  Reflections on the ongoing journey of learning Ukrainian and the role that
+  language proficiency plays in effective cross-cultural ministry.
+tags:
+  - family
+slug: "2024-06-15-language-learning-journey"
+---
+
+After many years in Ukraine, you might think we have the language fully mastered. The truth is that language learning is a lifelong journey, and there are always new nuances to discover. Ukrainian is a rich and expressive language, and the more we learn, the more deeply we can connect with the people we serve.
+
+This spring, I began working through an advanced grammar textbook that focuses on written Ukrainian. While my conversational skills are solid, there is always room to improve in areas like formal writing and public speaking. Being able to teach and preach clearly in Ukrainian is one of my highest ministry priorities.
+
+Our children have an advantage that we did not — they are growing up immersed in both languages from birth. Watching them switch effortlessly between English and Ukrainian is one of the daily joys of life on the mission field. Language is more than a skill; it is a bridge to people's hearts.

--- a/content/blog/2024-07-01-good-and-evil-book-distribution.md
+++ b/content/blog/2024-07-01-good-and-evil-book-distribution.md
@@ -1,0 +1,19 @@
+---
+title: "Good and Evil Book Distribution"
+date: 2024-07-01
+author: "Joshua Steele"
+description: >-
+  Distributing copies of the Good and Evil book in Ukrainian communities and
+  the impact this illustrated Bible narrative is having on readers.
+tags:
+  - ministry
+  - good-and-evil
+pdf: "OFR-Jul-Aug-2024.pdf"
+slug: "2024-07-01-good-and-evil-book-distribution"
+---
+
+The Good and Evil book continues to be one of our most powerful evangelistic tools. This beautifully illustrated volume presents the Bible's overarching narrative — from creation to the return of Christ — in a format that resonates with readers of all ages.
+
+Over the past month, we distributed over 300 copies of the Ukrainian edition in communities throughout our region. The response has been overwhelmingly positive. Parents tell us their children read it cover to cover. Teenagers who might never pick up a traditional Bible are drawn in by the artwork and gripped by the story.
+
+One family recently told us that reading Good and Evil together sparked the first real spiritual conversations they had ever had in their home. The father, who had been skeptical of religion, began asking questions about the Gospel after reading the section on the crucifixion. We are following up with this family and praying for continued openness.

--- a/content/blog/2024-07-30-july-ministry-report.md
+++ b/content/blog/2024-07-30-july-ministry-report.md
@@ -1,0 +1,20 @@
+---
+title: "July Ministry Report"
+date: 2024-07-30
+author: "Joshua Steele"
+description: >-
+  A summary of ministry activities during July, including CMO preparations,
+  Bible study groups, and partnership development.
+tags:
+  - newsletter
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-07-30-july-ministry-report/summer-bible-study.jpg"
+caption: "Our summer evening Bible study group"
+pdf: "OFR-Jul-Aug-2024.pdf"
+slug: "2024-07-30-july-ministry-report"
+---
+
+July was a whirlwind month for our ministry. With CMO in full swing and regular Bible studies continuing, our team was busier than ever. Despite the pace, we saw God working in remarkable ways.
+
+One of the standout moments was a midweek Bible study where a young man asked pointed questions about the reliability of Scripture. What followed was an hour-long discussion that engaged the entire group. By the end, several people expressed that their confidence in God's Word had been strengthened. Moments like these remind us that faithful teaching bears fruit.
+
+On the logistics side, we spent much of July finalizing plans for the remainder of the CMO summer project. Coordinating housing, transportation, and outreach schedules for a dozen team members is no small task, but our local partners have been invaluable. Thank you for your continued prayers and support.

--- a/content/blog/2024-08-20-summer-in-the-carpathians.md
+++ b/content/blog/2024-08-20-summer-in-the-carpathians.md
@@ -1,0 +1,20 @@
+---
+title: "Summer in the Carpathians"
+date: 2024-08-20
+author: "Joshua Steele"
+description: >-
+  Our family's summer adventures in the Carpathian Mountains, featuring hiking
+  trails, mountain streams, and quality time together in God's creation.
+tags:
+  - family
+  - photos
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-08-20-summer-in-the-carpathians/carpathian-hiking-trail.jpg"
+caption: "Hiking through the Carpathian Mountains with the family"
+slug: "2024-08-20-summer-in-the-carpathians"
+---
+
+Every summer, we try to take some time as a family to explore the beautiful Carpathian Mountains in western Ukraine. This year, we spent a long weekend hiking, swimming in mountain streams, and simply enjoying the beauty of God's creation together.
+
+The Carpathians are one of Ukraine's greatest natural treasures. Rolling green peaks, dense forests, and crystal-clear streams make it an ideal getaway from the busier pace of ministry life. The kids especially loved finding wild blueberries along the trails and building rock dams in the shallow creeks.
+
+These trips are more than just vacations — they are times of refreshment and reconnection. Ministry can be demanding, and intentional rest is something we have learned to prioritize. We come back to our work renewed and ready to serve.

--- a/content/blog/2024-09-15-church-plant-update.md
+++ b/content/blog/2024-09-15-church-plant-update.md
@@ -1,0 +1,20 @@
+---
+title: "Church Plant Update"
+date: 2024-09-15
+author: "Joshua Steele"
+description: >-
+  An update on our church planting efforts, including growth in attendance,
+  new small groups, and the search for a permanent meeting location.
+tags:
+  - ministry
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-09-15-church-plant-update/church-meeting-room.jpg"
+caption: "Our Sunday gathering in the rented meeting hall"
+pdf: "OFR-Sep-Oct-2024.pdf"
+slug: "2024-09-15-church-plant-update"
+---
+
+Our church plant has reached an exciting milestone. For the first time, we are consistently seeing 30 or more people at our Sunday gatherings. This growth has brought new energy and new challenges, both of which we welcome with open arms.
+
+In addition to our Sunday services, we have launched two new small groups that meet during the week. One focuses on studying the book of Ephesians, and the other is a practical discipleship group for new believers. Both groups are being led by Ukrainian brothers who have shown real leadership potential.
+
+The biggest need right now is a permanent meeting space. We have been renting a hall, which works fine for now, but the cost adds up and availability is not always guaranteed. Please pray with us that God would provide the right space at the right time.

--- a/content/blog/2024-10-05-cmo-2024-recap.md
+++ b/content/blog/2024-10-05-cmo-2024-recap.md
@@ -1,0 +1,21 @@
+---
+title: "CMO 2024 Recap"
+date: 2024-10-05
+author: "Joshua Steele"
+description: >-
+  A recap of Carpathian Mountain Outreach 2024, including team highlights,
+  evangelism results, and lessons learned from this summer's project.
+tags:
+  - ministry
+  - newsletter
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-10-05-cmo-2024-recap/cmo-team-mountains.jpg"
+caption: "The CMO 2024 team in the Carpathian Mountains"
+pdf: "OFR-Sep-Oct-2024.pdf"
+slug: "2024-10-05-cmo-2024-recap"
+---
+
+Carpathian Mountain Outreach 2024 was one for the books. This summer, we welcomed a team of 12 young men from the United States who spent six weeks serving alongside our ministry in western Ukraine. Together, we distributed thousands of Gospel tracts, showed evangelistic films, and conducted Bible studies in multiple villages.
+
+The team dynamic this year was outstanding. Several of the guys had prior missions experience, which allowed us to tackle more ambitious outreach plans. One of the most memorable moments was a village film showing where nearly 80 people gathered in a community hall to watch and listen to the Gospel message.
+
+As we debrief and plan for next summer, we are grateful for every life touched during CMO 2024. If you or someone you know is interested in joining the team next year, visit our website for more information. The harvest truly is plentiful.

--- a/content/blog/2024-10-25-homeschooling-adventures.md
+++ b/content/blog/2024-10-25-homeschooling-adventures.md
@@ -1,0 +1,17 @@
+---
+title: "Homeschooling Adventures"
+date: 2024-10-25
+author: "Kelsie Steele"
+description: >-
+  A glimpse into our homeschooling routine on the mission field, including the
+  joys and challenges of educating our children in a bilingual environment.
+tags:
+  - family
+slug: "2024-10-25-homeschooling-adventures"
+---
+
+Homeschooling on the mission field comes with its own unique set of challenges and rewards. Our children are growing up bilingual, which means our school day often switches between English and Ukrainian depending on the subject and the resources we are using.
+
+This fall, we started a new history curriculum that takes a chronological approach to world events. The kids have been fascinated by ancient civilizations, and it has sparked some wonderful conversations about God's sovereignty over nations and history. We have also been incorporating more hands-on science experiments, which is always a hit with the younger ones.
+
+One of the greatest blessings of homeschooling abroad is the flexibility it gives us. When ministry opportunities arise, we can adjust our schedule. When friends visit from the States, we can take a week to show them around. It is not always easy, but we would not trade it for anything.

--- a/content/blog/2024-11-10-bible-first-progress.md
+++ b/content/blog/2024-11-10-bible-first-progress.md
@@ -1,0 +1,19 @@
+---
+title: "Bible First Progress"
+date: 2024-11-10
+author: "Joshua Steele"
+description: >-
+  An update on the Bible First correspondence course ministry, including
+  enrollment numbers, student testimonies, and plans for new lessons.
+tags:
+  - ministry
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-11-10-bible-first-progress/bible-first-lesson-stack.jpg"
+caption: "A stack of Bible First lessons ready for mailing"
+slug: "2024-11-10-bible-first-progress"
+---
+
+The Bible First correspondence course continues to be one of the most effective tools in our ministry. This year, we have seen a steady increase in enrollment, with over 150 active students working through the lessons at any given time.
+
+One student recently wrote to tell us how the course had changed his understanding of God's grace. He had grown up in a religious home but had never understood the Gospel clearly until he worked through the lessons on salvation by faith. Stories like his remind us why this ministry matters.
+
+We are currently developing new lesson materials that will take students deeper into the book of Romans. This is a significant undertaking, but we believe it will strengthen the discipleship component of the course. Please pray for wisdom and clarity as we write.

--- a/content/blog/2024-11-30-fall-outreach-report.md
+++ b/content/blog/2024-11-30-fall-outreach-report.md
@@ -1,0 +1,21 @@
+---
+title: "Fall Outreach Report"
+date: 2024-11-30
+author: "Joshua Steele"
+description: >-
+  Highlights from our fall outreach season, including literature distribution,
+  film showings, and new contacts made in surrounding villages.
+tags:
+  - newsletter
+  - ministry
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-11-30-fall-outreach-report/outreach-team-village.jpg"
+caption: "Our outreach team visiting a nearby village"
+pdf: "OFR-Nov-Dec-2024.pdf"
+slug: "2024-11-30-fall-outreach-report"
+---
+
+This fall has been one of our most active outreach seasons in recent memory. Our team distributed over 2,000 pieces of Christian literature across five villages in the surrounding region. Many people were receptive, and we had numerous conversations about faith and the Bible.
+
+One of the highlights was a series of film showings we organized in a rented hall. We showed a Ukrainian-dubbed film about the life of Christ, followed by a Q&A session. Attendance exceeded our expectations, with over 60 people at the largest showing. Several attendees have since begun attending our weekly Bible study.
+
+We are following up with new contacts and praying for lasting fruit. If you would like to support our literature ministry, please reach out — every piece of literature is an opportunity for someone to encounter the Gospel.

--- a/content/blog/2024-12-20-christmas-in-ukraine.md
+++ b/content/blog/2024-12-20-christmas-in-ukraine.md
@@ -1,0 +1,20 @@
+---
+title: "Christmas in Ukraine"
+date: 2024-12-20
+author: "Joshua Steele"
+description: >-
+  Celebrating Christmas in Ukraine with our family and church community,
+  including caroling, special services, and time-honored traditions.
+tags:
+  - family
+  - photos
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-12-20-christmas-in-ukraine/christmas-church-service.jpg"
+caption: "Our church family gathered for the Christmas service"
+slug: "2024-12-20-christmas-in-ukraine"
+---
+
+Christmas in Ukraine is a unique experience. While many Ukrainians celebrate on January 7th according to the Orthodox calendar, our church holds services on December 25th as well, giving us two opportunities to celebrate the birth of Christ with our community.
+
+This year, our church organized a caroling outreach in the neighborhood surrounding our meeting place. Groups of young people went door to door, singing hymns and sharing small gifts. The response was overwhelmingly positive, and several families expressed interest in attending a service.
+
+Our own family traditions include baking together, reading the Christmas story from Luke chapter 2, and enjoying a special meal. The kids always look forward to this time, and it is one of the moments where life on the mission field feels most like home.

--- a/content/blog/2025-01-02-new-year-reflections.md
+++ b/content/blog/2025-01-02-new-year-reflections.md
@@ -1,0 +1,19 @@
+---
+title: "New Year Reflections"
+date: 2025-01-02
+author: "Kelsie Steele"
+description: >-
+  Reflecting on the past year and looking forward to what God has in store for
+  our family and ministry in the new year.
+tags:
+  - family
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2025-01-02-new-year-reflections/family-new-year.jpg"
+caption: "Our family ringing in the new year together"
+slug: "2025-01-02-new-year-reflections"
+---
+
+As we step into a new year, I find myself grateful for so many things. This past year brought challenges we did not expect, but through it all, God proved Himself faithful again and again. Our children are growing fast, and it is a joy to watch them develop their own relationships with the Lord.
+
+One highlight of last year was watching our oldest daughter help lead a children's Sunday school class. Seeing the next generation step into ministry roles is both humbling and encouraging. It reminds me that the work we do here is bigger than any one family.
+
+We are excited about the year ahead. Joshua has several teaching opportunities planned, and I am looking forward to deepening relationships with the women in our church community. Thank you for praying for us — your support means the world.

--- a/content/blog/2025-01-15-winter-ministry-update.md
+++ b/content/blog/2025-01-15-winter-ministry-update.md
@@ -1,0 +1,21 @@
+---
+title: "Winter Ministry Update"
+date: 2025-01-15
+author: "Joshua Steele"
+description: >-
+  A look at what God has been doing through our ministry during the cold winter
+  months in Ukraine, including Bible studies, outreach events, and church growth.
+tags:
+  - newsletter
+  - ministry
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2025-01-15-winter-ministry-update/winter-town-square.jpg"
+caption: "A quiet winter morning in our town square"
+pdf: "OFR-Jan-Feb-2025.pdf"
+slug: "2025-01-15-winter-ministry-update"
+---
+
+As the snow blankets the streets of our Ukrainian town, our ministry continues to grow. This winter has been especially fruitful, with new families joining our weekly Bible studies and several young people expressing interest in the Gospel for the first time.
+
+We recently hosted a winter outreach event at the local community center. Over 40 people attended, including many who had never visited our church before. The evening included worship, a short message, and hot drinks — a welcome combination on a freezing January night.
+
+Looking ahead, we are preparing for a series of evangelistic meetings in February. Please pray for open hearts and for wisdom as we share the truth of God's Word in this season.


### PR DESCRIPTION
## Summary

- Add 12 sample blog articles in `content/blog/` with realistic frontmatter and body content
- Articles serve as development fixtures for building blog listing, pagination, and article card components
- Variety in dates, tags, authors, cover images, and PDF fields to exercise all template code paths

## Changes

- **12 new files** in `content/blog/` with filenames following `YYYY-MM-DD-slug-title.md` pattern
- Date range: June 2024 – January 2025 (newest-first sort order testing)
- 5 distinct tags: `newsletter`, `ministry`, `family`, `photos`, `good-and-evil`
- 2 authors: Joshua Steele (10), Kelsie Steele (2)
- 9 articles with cover images, 3 without
- 6 articles with PDF field, 6 without
- Each article has 2–3 paragraphs of realistic sample text

## Testing

- [x] `hugo --gc --minify` builds successfully
- [x] 12 articles produce 2 pages of pagination with `pagerSize = 8`
- [ ] Visual verification with blog listing template (Phase 4)

> **Note:** These are development fixtures that will be replaced by real migrated content in Phase 15.

Closes #17