### PR TITLE
feat: add pagination partial

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -35,6 +35,8 @@
             </div>
           {{- end }}
         </div>
+
+        {{ partial "pagination.html" . }}
       </div>
     </div>
   </div>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -26,13 +26,9 @@
       {{- range $paginator.Pagers -}}
         {{- $pageNum := .PageNumber -}}
 
-        {{/* Show first page */}}
+        {{/* Show first page (always non-current — windowStart > 1 requires current >= 4) */}}
         {{- if and (eq $pageNum 1) (gt $windowStart 1) }}
-          {{- if eq $current 1 }}
-            <a href="{{ .URL }}" aria-current="page" class="inline-flex items-center border-t-2 border-blue-500 px-4 pt-4 text-sm font-medium text-blue-600">1</a>
-          {{- else }}
-            <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">1</a>
-          {{- end }}
+          <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">1</a>
           {{- if gt $windowStart 2 }}
             <span class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">&hellip;</span>
           {{- end }}
@@ -52,11 +48,8 @@
           {{- if lt $windowEnd (sub $total 1) }}
             <span class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">&hellip;</span>
           {{- end }}
-          {{- if eq $current $total }}
-            <a href="{{ .URL }}" aria-current="page" class="inline-flex items-center border-t-2 border-blue-500 px-4 pt-4 text-sm font-medium text-blue-600">{{ $total }}</a>
-          {{- else }}
-            <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">{{ $total }}</a>
-          {{- end }}
+          {{/* Always non-current — windowEnd < total requires current < total-2 */}}
+          <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">{{ $total }}</a>
         {{- end }}
       {{- end }}
     </div>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,0 +1,76 @@
+{{- $paginator := .Paginator -}}
+
+{{- if gt $paginator.TotalPages 1 -}}
+  {{- $current := $paginator.PageNumber -}}
+  {{- $total := $paginator.TotalPages -}}
+
+  {{/* Windowed page numbers: current ± 2 */}}
+  {{- $windowStart := math.Max 1 (sub $current 2) -}}
+  {{- $windowEnd := math.Min $total (add $current 2) -}}
+
+  <nav aria-label="Pagination" class="mt-16 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+    {{/* Previous link */}}
+    <div class="-mt-px flex w-0 flex-1">
+      {{- if $paginator.HasPrev }}
+        <a href="{{ $paginator.Prev.URL }}" class="inline-flex items-center border-t-2 border-transparent pt-4 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="mr-3 size-5 text-gray-400">
+            <path d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" fill-rule="evenodd" />
+          </svg>
+          Previous
+        </a>
+      {{- end }}
+    </div>
+
+    {{/* Page numbers (hidden on mobile) */}}
+    <div class="hidden md:-mt-px md:flex">
+      {{- range $paginator.Pagers -}}
+        {{- $pageNum := .PageNumber -}}
+
+        {{/* Show first page */}}
+        {{- if and (eq $pageNum 1) (gt $windowStart 1) }}
+          {{- if eq $current 1 }}
+            <a href="{{ .URL }}" aria-current="page" class="inline-flex items-center border-t-2 border-blue-500 px-4 pt-4 text-sm font-medium text-blue-600">1</a>
+          {{- else }}
+            <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">1</a>
+          {{- end }}
+          {{- if gt $windowStart 2 }}
+            <span class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">&hellip;</span>
+          {{- end }}
+        {{- end }}
+
+        {{/* Show pages within the window */}}
+        {{- if and (ge $pageNum (int $windowStart)) (le $pageNum (int $windowEnd)) }}
+          {{- if eq $pageNum $current }}
+            <a href="{{ .URL }}" aria-current="page" class="inline-flex items-center border-t-2 border-blue-500 px-4 pt-4 text-sm font-medium text-blue-600">{{ $pageNum }}</a>
+          {{- else }}
+            <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">{{ $pageNum }}</a>
+          {{- end }}
+        {{- end }}
+
+        {{/* Show last page */}}
+        {{- if and (eq $pageNum $total) (lt $windowEnd $total) }}
+          {{- if lt $windowEnd (sub $total 1) }}
+            <span class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">&hellip;</span>
+          {{- end }}
+          {{- if eq $current $total }}
+            <a href="{{ .URL }}" aria-current="page" class="inline-flex items-center border-t-2 border-blue-500 px-4 pt-4 text-sm font-medium text-blue-600">{{ $total }}</a>
+          {{- else }}
+            <a href="{{ .URL }}" class="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">{{ $total }}</a>
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    </div>
+
+    {{/* Next link */}}
+    <div class="-mt-px flex w-0 flex-1 justify-end">
+      {{- if $paginator.HasNext }}
+        <a href="{{ $paginator.Next.URL }}" class="inline-flex items-center border-t-2 border-transparent pt-4 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
+          Next
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="ml-3 size-5 text-gray-400">
+            <path d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" fill-rule="evenodd" />
+          </svg>
+        </a>
+      {{- end }}
+    </div>
+  </nav>
+{{- end -}}


### PR DESCRIPTION
## Summary

- Add reusable pagination navigation partial with windowed page numbers
- Integrate pagination into the blog listing template, completing Phase 4

## Changes

- **`layouts/partials/pagination.html`** (new): Pagination nav with Previous/Next arrow links and numbered page links. Uses a current ± 2 window with ellipsis for large page counts. Page numbers hidden on mobile, visible on `md:` screens. Hidden entirely when only one page exists. Styled with Tailwind CSS adapted from Tailwind Plus patterns.
- **`layouts/blog/list.html`** (updated): Add pagination partial call below the article grid.

## Testing

- [x] Hugo production build passes (`hugo --gc --minify`)
- [x] Markdown lint passes (0 errors)
- [x] Page 1 shows [**1**] 2 with Next link, no Previous
- [x] Page 2 shows 1 [**2**] with Previous link, no Next
- [x] Single-page scenario hides pagination entirely
- [x] Windowed logic verified for 28+ page scenarios (current ± 2 with ellipsis)

## Notes

- Completes Phase 4 (Blog Listing with Pagination) — all three issues (#18, #19, #20) are now resolved
- Color uses blue (blue-500/blue-600) to match the site's established palette
- Includes `aria-label="Pagination"` and `aria-current="page"` for accessibility
- Reusable for tag listing pages in Phase 7

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)