### PR TITLE
Fix nested double quotes in article-card date attribute

### DIFF
--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -18,7 +18,8 @@
 
   <div>
     <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-      <time datetime="{{ $page.Date.Format "2006-01-02" }}" class="text-gray-500">
+      {{- $isoDate := $page.Date.Format "2006-01-02" -}}
+      <time datetime="{{ $isoDate }}" class="text-gray-500">
         {{- $page.Date.Format "January 2, 2006" -}}
       </time>
       {{- range $page.Params.tags }}


### PR DESCRIPTION
## Summary

- Extract ISO date into a `$isoDate` variable to avoid nested double quotes inside the `datetime` HTML attribute in `article-card.html`
- Eliminates false positive errors from HTML linters (e.g., Herb LSP)

Closes #25

## Test plan

- [ ] `hugo --gc --minify` builds without errors
- [ ] Blog listing page renders identically (no visual change)
- [ ] Rendered HTML `datetime` attributes contain clean values (e.g., `datetime="2025-01-15"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)