### PR TITLE
Add spacing between cover image and tags in article card

### DIFF
--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -2,7 +2,7 @@
 {{- $featured := default false .featured -}}
 {{- $preset := cond $featured "featured" "regular" -}}
 
-<article class="{{ if $featured }}relative isolate flex flex-col gap-8 lg:flex-row{{ else }}relative isolate flex flex-col{{ end }}">
+<article class="{{ if $featured }}relative isolate flex flex-col gap-8 lg:flex-row{{ else }}relative isolate flex flex-col gap-6{{ end }}">
   {{- with $page.Params.cover }}
     {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" $preset) }}
     <div class="{{ if $featured }}relative aspect-video sm:aspect-2/1 lg:aspect-square lg:w-64 lg:shrink-0{{ else }}relative aspect-video{{ end }}">


### PR DESCRIPTION
## Summary

- Add `gap-6` to non-featured article card flex container to provide spacing between cover image and date/tags row
- Featured card spacing (`gap-8`) remains unchanged

Closes #26

## Test plan

- [ ] `hugo --gc --minify` builds without errors
- [ ] Non-featured article cards show visible gap between cover image and tags
- [ ] Featured card layout and spacing are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)