### PR TITLE
feat: add single article template with cover image and metadata

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @source "hugo_stats.json";
+@plugin "@tailwindcss/typography";
 
 @theme {
   /* Blue palette — matches existing OFReport site */

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,59 @@
+{{ define "main" }}
+  <article class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+
+      {{/* Cover image */}}
+      {{- with .Params.cover }}
+        {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" "article") }}
+        <figure class="mb-10">
+          <img
+            src="{{ $imgURL }}"
+            alt="{{ $.Title }}"
+            class="aspect-video w-full rounded-xl bg-gray-50 object-cover"
+            loading="eager"
+          >
+          {{- with $.Params.caption }}
+            <figcaption class="mt-3 text-sm/6 text-gray-500">{{ . }}</figcaption>
+          {{- end }}
+        </figure>
+      {{- end }}
+
+      {{/* Article title */}}
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+        {{- .Title -}}
+      </h1>
+
+      {{/* Meta line: author, date, reading time */}}
+      <div class="mt-4 flex flex-wrap items-center gap-x-3 text-sm/6 text-gray-500">
+        {{- with .Params.author }}
+          <span>{{ . }}</span>
+          <span aria-hidden="true">&middot;</span>
+        {{- end }}
+        {{- $isoDate := .Date.Format "2006-01-02" -}}
+        <time datetime="{{ $isoDate }}">{{ .Date.Format "January 2, 2006" }}</time>
+        <span aria-hidden="true">&middot;</span>
+        <span>{{ .ReadingTime }} min read</span>
+      </div>
+
+      {{/* Tag badges */}}
+      {{- with .Params.tags }}
+        <div class="mt-4 flex flex-wrap gap-2">
+          {{- range . }}
+            <a
+              href="{{ "/tags/" | relURL }}{{ . | urlize }}/"
+              class="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
+            >
+              {{- . -}}
+            </a>
+          {{- end }}
+        </div>
+      {{- end }}
+
+      {{/* Article content */}}
+      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
+        {{ .Content }}
+      </div>
+
+    </div>
+  </article>
+{{ end }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "ofreport.com-hugo",
       "devDependencies": {
         "@tailwindcss/cli": "^4.0.0",
+        "@tailwindcss/typography": "^0.5.19",
         "alpinejs": "^3.0.0",
         "markdownlint-cli2": "^0.20.0",
         "tailwindcss": "^4.0.0"
@@ -698,6 +699,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -830,6 +844,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/debug": {
@@ -2175,6 +2202,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -2350,6 +2391,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.0.0",
+    "@tailwindcss/typography": "^0.5.19",
     "alpinejs": "^3.0.0",
     "markdownlint-cli2": "^0.20.0",
     "tailwindcss": "^4.0.0"


### PR DESCRIPTION
## Summary

- Add `layouts/blog/single.html` — the core reading experience for individual blog posts
- Install `@tailwindcss/typography` plugin for styled markdown content rendering
- Resolves the `found no layout file for "html" for kind "page"` build warning

## Changes

- **feat**: Install `@tailwindcss/typography` and register `@plugin` in `assets/css/main.css`
- **feat**: Create `layouts/blog/single.html` with:
  - Cover image using Cloudinary `article` preset (`c_scale,f_auto,q_auto:best`)
  - Caption (conditional on `.Params.caption`)
  - Article title as `<h1>` with `font-header`
  - Meta line: author, formatted date, reading time (`.ReadingTime`)
  - Tag badges as `<a>` links to `/tags/{tag}/`
  - Article content in `prose` wrapper for styled markdown

## Testing

- [ ] `hugo server -D` — article pages render with cover image, metadata, and styled content
- [ ] `hugo --gc --minify` — production build passes cleanly (29 pages, no warnings)
- [ ] Navigate from blog listing to an article — link works, page displays correctly

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)