### PR TITLE
feat: add previous/next article navigation

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -54,6 +54,38 @@
         {{ .Content }}
       </div>
 
+      {{/* Previous/next article navigation */}}
+      {{- $older := .NextInSection -}}
+      {{- $newer := .PrevInSection -}}
+      {{- if or $older $newer }}
+        <nav class="mt-16 border-t border-gray-200 pt-8" aria-label="Previous and next articles">
+          <div class="flex flex-col gap-6 sm:flex-row sm:justify-between">
+            {{- if $older }}
+              <a href="{{ $older.RelPermalink }}" class="group flex-1">
+                <span class="flex items-center gap-1 text-sm font-medium text-gray-500 group-hover:text-blue-700 transition-colors">
+                  <span aria-hidden="true">&larr;</span> Previous
+                </span>
+                <span class="mt-1 block text-base font-semibold text-gray-900 group-hover:text-blue-700 transition-colors">
+                  {{- $older.Title -}}
+                </span>
+              </a>
+            {{- else }}
+              <div class="flex-1"></div>
+            {{- end }}
+            {{- if $newer }}
+              <a href="{{ $newer.RelPermalink }}" class="group flex-1 sm:text-right">
+                <span class="flex items-center gap-1 text-sm font-medium text-gray-500 group-hover:text-blue-700 transition-colors sm:justify-end">
+                  Next <span aria-hidden="true">&rarr;</span>
+                </span>
+                <span class="mt-1 block text-base font-semibold text-gray-900 group-hover:text-blue-700 transition-colors">
+                  {{- $newer.Title -}}
+                </span>
+              </a>
+            {{- end }}
+          </div>
+        </nav>
+      {{- end }}
+
     </div>
   </article>
 {{ end }}


### PR DESCRIPTION
## Summary

- Add previous/next article links at the bottom of single blog posts for sequential navigation
- Uses Hugo's `.PrevInSection` / `.NextInSection` with reader-friendly semantics (Previous = older, Next = newer)
- Handles edge cases gracefully — first and last articles omit the missing direction

## Changes

- **`layouts/blog/single.html`**: Added `<nav>` block with prev/next links after article content, styled with Tailwind (responsive two-column layout, hover states, directional arrows)

## Testing

- [ ] `hugo --gc --minify` passes
- [ ] Navigate to a mid-range article — both Previous and Next links appear
- [ ] Navigate to the oldest article — only Next link appears
- [ ] Navigate to the newest article — only Previous link appears
- [ ] Links point to the correct adjacent articles
- [ ] Responsive: stacks vertically on mobile, side-by-side on desktop

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)