### PR TITLE
feat: link tag badges to tag pages on article cards

### DIFF
--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -23,9 +23,12 @@
         {{- $page.Date.Format "January 2, 2006" -}}
       </time>
       {{- range $page.Params.tags }}
-        <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 inset-ring inset-ring-blue-700/10">
+        <a
+          href="{{ "/tags/" | relURL }}{{ . | urlize }}/"
+          class="relative z-10 inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
+        >
           {{- . -}}
-        </span>
+        </a>
       {{- end }}
     </div>
 


### PR DESCRIPTION
## Summary

- Convert tag badges on article cards from plain `<span>` elements to `<a>` links pointing to `/tags/{tag}/` taxonomy pages
- Add `relative z-10` positioning so tag links are clickable above the full-card link overlay
- Add hover state (`hover:bg-blue-100 transition-colors`) consistent with the single article template

## Changes

- **`layouts/partials/article-card.html`**: Changed tag badges from `<span>` to `<a>` with taxonomy URL, z-index stacking, and hover styling

**Note:** `layouts/blog/single.html` already had linked tag badges — no changes needed there.

## Testing

- [ ] `hugo --gc --minify` builds successfully
- [ ] Tag badges on blog listing page render as clickable links
- [ ] Tag links point to correct `/tags/{tag}/` URLs
- [ ] Tag badges remain visually styled as badges with hover state
- [ ] Tags are independently clickable (not intercepted by the full-card link overlay)
- [ ] PDF link on article cards still works correctly

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)