### PR TITLE
feat: add Umami analytics tracking

### DIFF
--- a/config/head.js
+++ b/config/head.js
@@ -71,4 +71,14 @@ export default {
       href: 'https://fonts.googleapis.com/icon?family=Material+Icons&display=swap',
     },
   ],
+  script:
+    process.env.NODE_ENV === 'production'
+      ? [
+          {
+            src: 'https://lens.euroteamoutreach.org/script.js',
+            'data-website-id': '34d2cfa4-e623-418a-936d-670c9d163ead',
+            defer: true,
+          },
+        ]
+      : [],
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,7 +24,7 @@ export default {
     '~/plugins/vuelidate.js',
   ],
 
-  buildModules: ['@nuxtjs/google-analytics', '@nuxtjs/tailwindcss'],
+  buildModules: ['@nuxtjs/tailwindcss'],
 
   modules: [
     '@nuxtjs/axios',
@@ -65,11 +65,6 @@ export default {
     path: '/sitemap.xml',
     hostname: 'https://ofreport.com',
     gzip: true,
-  },
-
-  googleAnalytics: {
-    id: 'UA-22952661-1',
-    dev: false,
   },
 
   build,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/tailwindcss": "4.0.0",
     "babel-eslint": "^10.0.3",
     "eslint": "7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,13 +1910,6 @@
     consola "^2.12.1"
     feed "^4.2.0"
 
-"@nuxtjs/google-analytics@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/google-analytics/-/google-analytics-2.4.0.tgz#3bb9f398a05cc23340d1f423f8d8653dc4114f46"
-  integrity sha512-rDQTwHIjyjVrx8GywHPuWykJ3jRFGaHl5Iqji/y8tQWUc0yGEeHxOoR0yimzxnTS1Ph2/PubQYpgnVeEPEdL/A==
-  dependencies:
-    vue-analytics "^5.22.1"
-
 "@nuxtjs/proxy@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-2.1.0.tgz#fa7715a11d237fa1273503c4e9e137dd1bf5575b"
@@ -10876,11 +10869,6 @@ vm2@^3.10.2, vm2@^3.9.3:
   dependencies:
     acorn "^8.14.1"
     acorn-walk "^8.3.4"
-
-vue-analytics@^5.22.1:
-  version "5.22.1"
-  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.22.1.tgz#9d6b32da56daee1b9dfb23a267b50349a03f710f"
-  integrity sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==
 
 vue-client-only@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

- Adds cookieless Umami analytics script to the site `<head>`, loaded in production only
- Tracking via self-hosted instance at `lens.euroteamoutreach.org`
- Script is <2KB, deferred, and requires no GDPR consent banner

Closes #212

## Test plan

- [x] `yarn generate` builds successfully
- [x] Umami script tag present in generated HTML pages
- [x] After deploy, verify pageviews appear in the Umami dashboard