### PR TITLE
feat: add "25 Years in Ukraine" blog post

### DIFF
--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -124,8 +124,9 @@ completed. 5,000 copies are delivered in January 2009.
 
 ### 2010
 
-CMO 2010 — our fifth project in a row — is held. Our third child, Hosanna, is
-born in November.
+CMO 2010 — our fifth project in a row — is held.
+
+Our third child, Hosanna, is born in November.
 
 ### 2011
 
@@ -213,7 +214,7 @@ updates and spread awareness about what is happening in Ukraine.
 
 New donations come in for the printing of _Good and Evil_, and we print 15,000
 copies in a special full-color edition. Armed with these new books, we launch
-our _Good and Evil_ distributor network, resulting in the broad distribution of
+our Good and Evil Distributor Network, resulting in the broad distribution of
 the _Good and Evil_ book all across Ukraine, even in areas hardest hit by the
 war.
 

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -246,7 +246,7 @@ place in October.
 Funding is provided for our fourth full-color printing of _Good and Evil_,
 enabling us to continue our Good and Evil Distributor Network.
 
-<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_7695_yrdvwy" width="768" caption="Ministering the Gospel in Zhytomry at the conclusion of our 2025 UGO project" />
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_7695_yrdvwy" width="768" caption="Ministering the Gospel in Zhytomyr at the conclusion of our 2025 UGO project" />
 
 ## Conclusion
 

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -50,6 +50,8 @@ Now, in the early morning hours of March 19, 2001, after an overnight train trip
 from Kyiv, I arrived in the city that would be my home for decades to come, the
 city where I still live with my family today: Lviv.
 
+<article-image publicId="OFReport/2024-09-24-of-books-baptisms-and-blessings/dad-joshua-mom_oueihc" width="768" caption="No reflection on my time in Ukraine could be complete without acknowledging the incredible debt of gratitude I owe to my precious parents, Mike and Cathy Steele. Thank you, Mom and Dad, for training me, for believing in me, and for having the courage to let me go to the ends of the earth." />
+
 ## The Early Years (2001–2006)
 
 ### 2001
@@ -71,7 +73,7 @@ serve with us in Lviv today.
 
 After my return from Thailand, Nathan Day, Jessie Beal, and I decide to work
 together as a team, training young men in missions as we share the Gospel with
-Ukrainians. In time, we call adopt the name _Euro Team Outreach_.
+Ukrainians. In time, we adopt the name _Euro Team Outreach_.
 
 On September 18th, Kelsie and I are married in Texas, and after a few weeks of
 preparation, we return to Ukraine together.
@@ -95,7 +97,7 @@ Carpathian Mountain Outreach launches in May and lasts a full four months. What
 we envisioned as a one-off project becomes an annual event spanning 17 years
 that trains over 60 men in hands-on foreign mission work.
 
-The first lessons of our Bible First course are written and distributed to
+The first lessons of our _Bible First_ course are written and distributed to
 people responding to our summer outreach (CMO 2006).
 
 Our nonprofit, Euro Team Outreach, is incorporated in the State of Texas, with
@@ -107,18 +109,18 @@ Jessie, Nathan, and me serving as board members.
 
 During these years, we see our ministry solidify around three primary branches:
 
-1. Our Bible First correspondence course
+1. Our _Bible First_ correspondence course
 2. Our annual CMO projects
-3. The printing and distribution of the Good and Evil book in Ukrainian
+3. The printing and distribution of the _Good and Evil_ book in Ukrainian
 
 ### 2008
 
 Our second child, Rebekah, is born in January.
 
-The translation of the Good and Evil book into the Ukrainian language is
+The translation of the _Good and Evil_ book into the Ukrainian language is
 completed. 5,000 copies are delivered in January 2009.
 
-<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/dsc_4266_qic6hy" width="768" caption="Serhii Chepara helps me unload the shipment of 5,000 Good and Evil books." />
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/dsc_4266_qic6hy" width="768" caption="Serhii Chepara helps me unload the shipment of 5,000 _Good and Evil_ books." />
 
 ### 2010
 
@@ -128,18 +130,18 @@ born in November.
 ### 2011
 
 For the first time in five years, we take a year off from CMO to focus more
-heavily on the development and writing of our Bible First lessons.
+heavily on the development and writing of our _Bible First_ lessons.
 
 ### 2012
 
 My brother Jonathan joins us for CMO — his third trip to Ukraine — and films a
-short promotional video about CMO, which we affectionately call "The CMO Movie."
-[LINK TO WATCH]
+short promotional video about CMO, which we affectionately call
+[The CMO Movie](https://cmoproject.org/movie/).
 
 ### 2013
 
-The final two lessons of our Bible First course are complete, bringing the total
-to twenty. Bible First remains at the core of our ministry today.
+The final two lessons of our _Bible First_ course are complete, bringing the
+total to twenty. _Bible First_ remains at the core of our ministry today.
 
 <article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_1623_g9e0wb_e9hgsz" width="768" caption="Filming Bible teaching videos in Ukrainian" />
 
@@ -152,8 +154,8 @@ Our fourth daughter, Kathryn, is born in December.
 
 ### 2015
 
-Development begins on our web-based Bible First platform, enabling students for
-the first time to progress through our Bible lessons online.
+Development begins on our web-based _Bible First_ platform, enabling students
+for the first time to progress through our Bible lessons online.
 
 Ben Sargent, who would later join our staff team, travels to Ukraine and attends
 CMO for the first time.
@@ -169,15 +171,15 @@ development of Bible First Online.
 
 Our fifth child and first son, David, is born in January.
 
-Once again, we take a break from CMO to focus on the development of our Bible
-First course.
+Once again, we take a break from CMO to focus on the development of our _Bible
+First_ course.
 
 <article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/hackers-for-christ-2000w_ilvvag" width="768" caption="Trevor Brown travels to Ukraine to help us with coding Bible First Online." />
 
 ### 2018
 
 Working with a professional Ukrainian philologist, we complete a thorough
-updated translation of Good and Evil in Ukrainian. New donations come in,
+updated translation of _Good and Evil_ in Ukrainian. New donations come in,
 enabling us to print 5,000 copies — this time in full color.
 
 Ben Sargent joins ETO's Board of Directors.
@@ -209,12 +211,13 @@ Slovakia, where we stay for 16 months. We become heavily involved in ministering
 to Ukrainian refugees. We launch a podcast called Journey to Ukraine to share
 updates and spread awareness about what is happening in Ukraine.
 
-New donations come in for the printing of Good and Evil, and we print 15,000
+New donations come in for the printing of _Good and Evil_, and we print 15,000
 copies in a special full-color edition. Armed with these new books, we launch
-our Good and Evil distributor network, resulting in the broad distribution of
-the Good and Evil book all across Ukraine, even in areas hardest hit by the war.
+our _Good and Evil_ distributor network, resulting in the broad distribution of
+the _Good and Evil_ book all across Ukraine, even in areas hardest hit by the
+war.
 
-<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/ge-print-blend_osqrye_ydn2xf" width="768" caption="Thanks to the generosity of No Greater Joy Ministries and many individual donors, 15,000 copies of a special edition of Good and Evil are printed." />
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/ge-print-blend_osqrye_ydn2xf" width="768" caption="Thanks to the generosity of No Greater Joy Ministries and many individual donors, 15,000 copies of a special edition of _Good and Evil_ are printed." />
 
 ### 2023
 
@@ -240,7 +243,7 @@ Kelsie and I celebrate 20 years of marriage.
 Ukraine Gospel Outreach is formally announced, with our second project taking
 place in October.
 
-Funding is provided for our fourth full-color printing of Good and Evil,
+Funding is provided for our fourth full-color printing of _Good and Evil_,
 enabling us to continue our Good and Evil Distributor Network.
 
 <article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_7695_yrdvwy" width="768" caption="Ministering the Gospel in Zhytomry at the conclusion of our 2025 UGO project" />

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -3,10 +3,15 @@ title: '25 Years in Ukraine'
 date: '2026-03-18'
 author: 'Joshua Steele'
 cover: 'https://res.cloudinary.com/dnkvsijzu/image/upload/v1773822298/OFReport/2026-03-18-25-years-in-ukraine/25-year-anniversary-cover_mmanas.jpg'
-preview: >-
-  TODO
-caption: >-
-  TODO
+preview: >
+  Today marks exactly 25 years since I arrived in Ukraine to serve the Lord as a
+  full-time missionary. I felt I could not let this day pass without expressing
+  my gratefulness to the Lord and to the many friends and family who have walked
+  with me through this journey.
+caption: >
+  Clockwise from the top: open-air preaching in Lviv (2006); a final picture
+  before leaving for the airport (March 17, 2001); the first issue of my
+  newsletter, Ukraine Report.
 tags:
   - ukraine
   - ministry
@@ -17,14 +22,16 @@ full-time missionary. I felt I could not let this day pass without expressing my
 gratefulness to the Lord and to the many friends and family who have walked with
 me through this journey.
 
-There is so much I could share that the constraints of space and time do not
-allow, but in this brief post, I'd like to reflect on a few of the milestones
-God has led me through. I hope that as you read, you will be encouraged to trust
-Him with your life and to follow Him in faith, no matter what happens. Like so
-many that have come before me, I can testify from long experience and deep
-conviction that I have found my Savior to be very, very faithful.
+There is so much I could share, but in this brief post, I'd like to reflect on a
+few of the milestones God has led me through. I hope that as you read, you will
+be encouraged to trust Him with your life and to follow Him in faith, no matter
+what happens. Like so many that have come before me, I can testify from long
+experience and deep conviction that I have found my Savior to be very, very
+faithful.
 
 _“O taste and see that the LORD is good…” (Psalms 34:8)_
+
+<article-callout content="Check out my very first newsletter from Ukraine!" :link="{ name: 'Ukraine Report, March 2001', href: 'https://d21yo20tm8bmc2.cloudfront.net/ofr/ukraine_report_mar_2001.pdf' }" />
 
 ## Arrival
 
@@ -34,10 +41,10 @@ years earlier, I had come as a teenager to take part in a short-term missions
 project organized by my friend and mentor, Jessie Beal. During the five months I
 spent in Kyiv in 1997, I fell in love with this land.
 
-In the intervening years, as I worked, studied, and ministered the Gospel in my
-home state of Texas, it seemed my heart remained in Ukraine. When people asked
-me what I wanted to do in life, who I wanted to be, and what I wanted to
-accomplish, I would tell them that I wanted to serve as a missionary in Ukraine.
+In the years that followed, as I worked, studied, and ministered the Gospel in
+my home state of Texas, my heart remained in Ukraine. When people asked me what
+I wanted to do with my life, I would tell them I wanted to serve as a missionary
+in Ukraine.
 
 Now, in the early morning hours of March 19, 2001, after an overnight train trip
 from Kyiv, I arrived in the city that would be my home for decades to come, the
@@ -47,47 +54,46 @@ city where I still live with my family today: Lviv.
 
 ### 2001
 
-During my first two and a half years in Ukraine, I focused primarily on language
+During my first two and a half years in Ukraine, I focus primarily on language
 study and ministry with a small Ukrainian church that I am still a part of
-today: Greater Grace. I shared an apartment with a Ukrainian national named
-Ruslan — now one of my closest friends — and I immersed myself in the Ukrainian
+today: Greater Grace. I share an apartment with a Ukrainian national named
+Ruslan — now one of my closest friends — and I immerse myself in the Ukrainian
 language.
 
 ### 2003
 
-God surprised me by leading me away from Ukraine for seven months to participate
-in a ministry project in Thailand. During my time there, I met Nathan Day, who
-came back with me to Ukraine in April of 2004. Nathan and his family still serve
-with us in Lviv today.
+God surprises me by leading me away from Ukraine for seven months to participate
+in a ministry project in Thailand. During my time there, I meet Nathan Day, who
+comes back with me to Ukraine in April of 2004. Nathan and his family still
+serve with us in Lviv today.
 
 ### 2004
 
-After my return from Thailand, Nathan Day, Jessie Beal, and I decided to work
-together as a team, training young men in missions as we shared the Gospel with
-Ukrainians. In time, we adopted the name Euro Team Outreach.
+After my return from Thailand, Nathan Day, Jessie Beal, and I decide to work
+together as a team, training young men in missions as we share the Gospel with
+Ukrainians. In time, we call adopt the name _Euro Team Outreach_.
 
-On September 18th, Kelsie and I were married in Texas, and after a few weeks of
-preparation, we returned to Ukraine together.
+On September 18th, Kelsie and I are married in Texas, and after a few weeks of
+preparation, we return to Ukraine together.
 
 ### 2005
 
-Nathan and I made our first scouting trip to the Carpathians to plan a new
+Nathan and I make our first scouting trip to the Carpathians to plan a new
 project: Carpathian Mountain Outreach.
 
-We also organized a Bible camp in the Carpathian Mountains for a small group of
-Ukrainian young men, including Serhii Chepara. Serhii became a close friend and
-a key ministry ally in the years that followed.
+We also organize a Bible camp in the Carpathian Mountains for a small group of
+Ukrainian young men, including Serhii Chepara. Serhii becomes a close friend and
+a key ministry ally in the years that follow.
 
-Kelsie and I welcome our first child, Abigail.
+Our first child, Abigail, is born in September.
 
 ### 2006
 
-Carpathian Mountain Outreach was launched in May of this year and lasted a full
-four months. What was envisioned as a one-off project became an annual event
-spanning 17 years that trained over 60 men in practical, hands-on foreign
-mission work.
+Carpathian Mountain Outreach launches in May and lasts a full four months. What
+we envisioned as a one-off project becomes an annual event spanning 17 years
+that trains over 60 men in hands-on foreign mission work.
 
-The first lessons of our Bible First course were written and distributed to
+The first lessons of our Bible First course are written and distributed to
 people responding to our summer outreach (CMO 2006).
 
 Our nonprofit, Euro Team Outreach, is incorporated in the State of Texas, with
@@ -95,8 +101,7 @@ Jessie, Nathan, and me serving as board members.
 
 ## Expansion: Bible First, CMO, Good and Evil (2007–2019)
 
-During these years, we saw our ministry solidify around three primary branches.
-These were:
+During these years, we see our ministry solidify around three primary branches:
 
 1. Our Bible First correspondence course
 2. Our annual CMO projects
@@ -116,25 +121,26 @@ born in November.
 
 ### 2011
 
-For the first time in five years we decided to take a year off from CMO to focus
-more heavily on the development and writing of our Bible First lessons.
+For the first time in five years, we take a year off from CMO to focus more
+heavily on the development and writing of our Bible First lessons.
 
 ### 2012
 
-My brother Jonathan joined us for CMO — his third trip to Ukraine — and filmed a
-short promotional video about CMO, which we call affectionately “The CMO Movie”
+My brother Jonathan joins us for CMO — his third trip to Ukraine — and films a
+short promotional video about CMO, which we affectionately call "The CMO Movie."
 [LINK TO WATCH]
 
 ### 2013
 
 The final two lessons of our Bible First course are complete, bringing the total
-to twenty. Bible First remains at the core of our ministry today
+to twenty. Bible First remains at the core of our ministry today.
 
 ### 2014
 
 The Maidan revolution begins in Ukraine, followed by Russia's invasion and
 subsequent annexation of Crimea, as well as large portions of the Donbas region.
-Our fourth daughter Kathryn is born in December
+
+Our fourth daughter, Kathryn, is born in December.
 
 ### 2015
 
@@ -146,28 +152,34 @@ CMO for the first time.
 
 ### 2016
 
-Our tenth CMO project is completed. We engage a local software company in Lviv
-to assist us with the continuing development of Bible First Online.
+Our tenth CMO project is completed.
+
+We engage a local software company in Lviv to assist us with the continuing
+development of Bible First Online.
 
 ### 2017
 
-Our fifth child and first son, David, is born in January. Once again, we take a
-break from CMO to focus on the development of our Bible first course.
+Our fifth child and first son, David, is born in January.
+
+Once again, we take a break from CMO to focus on the development of our Bible
+First course.
 
 ### 2018
 
 Working with a professional Ukrainian philologist, we complete a thorough
-updated translation of "Good and Evil" in Ukrainian. New donations come in,
-enabling us to print 5,000 more copies this time in color for the first time.
+updated translation of Good and Evil in Ukrainian. New donations come in,
+enabling us to print 5,000 copies — this time in full color.
 
 Ben Sargent joins ETO's Board of Directors.
 
 ### 2019
 
 After many years of development and field testing, Bible First Online is finally
-ready. We launched the Bible First Pioneers program, inviting people from the
-U.S. to test-try Bible First Online in their own ministries and with
-English-speaking audiences.  Our sixth child, Mia, is born in July.
+ready. We launch the Bible First Pioneers program, inviting people from the U.S.
+to test-drive Bible First Online in their own ministries and with
+English-speaking audiences.
+
+Our sixth child, Mia, is born in July.
 
 ## War and Perseverance (2020–Present)
 
@@ -180,46 +192,50 @@ transportation has been shut down due to quarantine restrictions.
 
 ### 2022
 
-Russia invades Ukraine on February 24. Three days later our family evacuates to
+Russia invades Ukraine on February 24. Three days later, our family evacuates to
 Slovakia, where we stay for 16 months. We become heavily involved in ministering
 to Ukrainian refugees. We launch a podcast called Journey to Ukraine to share
 updates and spread awareness about what is happening in Ukraine.
 
-New donations come in for the printing of Good and Evil and we print 15,000
-copies of a special edition full color. Armed with these new books, we launch
-our Good and Evil distributor network, which results in the broad distribution
-of the good and evil book all across Ukraine, even in the most hard-hit areas by
-the war
+New donations come in for the printing of Good and Evil, and we print 15,000
+copies in a special full-color edition. Armed with these new books, we launch
+our Good and Evil distributor network, resulting in the broad distribution of
+the Good and Evil book all across Ukraine, even in areas hardest hit by the war.
 
 ### 2023
 
 After nearly a year and a half in Slovakia and despite the ongoing war in
-Ukraine, our family returns to Lviv to continue our lives and ministry here. In
-the summer we host our final CMO project.
+Ukraine, our family returns to Lviv to continue our lives and ministry here.
+
+In the summer, we host our final CMO project.
 
 ### 2024
 
 Nathan and I, along with Ben Sargent, join up with Ukrainian missionary
 Oleksandr Ilchenko for our first trip to the southern regions of Ukraine,
-recently liberated from Russian occupation. The things we learn during this
-project lead to the establishment of a new ministry: Ukraine Gospel Outreach
-(UGO).  Kelsie and I celebrate 20 years of marriage.
+ministering in villages recently liberated from Russian occupation. The things
+we learn during this project lead to the establishment of a new ministry:
+Ukraine Gospel Outreach (UGO).
+
+Kelsie and I celebrate 20 years of marriage.
 
 ### 2025
 
 Ukraine Gospel Outreach is formally announced, with our second project taking
-place in October. Funding is provided for our fourth full-color printing of Good
-and Evil, enabling us to continue our Good and Evil distributor network
+place in October.
+
+Funding is provided for our fourth full-color printing of Good and Evil,
+enabling us to continue our Good and Evil Distributor Network.
 
 ## Conclusion
 
-In publishing this article, I think what I want most is to give glory to God for
-His faithfulness, and to urge you, my reader, to trust Him with your own life.
-Let me lend my voice to the many thousands who have gone before me, echoing the
-same conclusion: the God of Elijah is alive today, and He calls you to follow
-Him in faith. He wants to lead you, He wants to bless you in ways you cannot
-imagine, and He wants to use your voice to call the lost out of darkness and
-into His light.
+In publishing this article, what I want most is to give glory to God for His
+faithfulness, and to urge you, my reader, to trust Him with your own life. Let
+me lend my voice to the many thousands who have gone before me, echoing the same
+conclusion: the God of Elijah is alive today, and He calls you to follow Him in
+faith. He wants to lead you, He wants to bless you in ways you cannot imagine,
+and He wants to use your voice to call the lost out of darkness and into His
+light.
 
 Looking back over these 25 years, I realize that I wouldn't trade them for the
 world. There's nowhere else I would rather have been. There's nothing else I

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -147,7 +147,7 @@ total to twenty. _Bible First_ remains at the core of our ministry today.
 
 ### 2014
 
-The Maidan revolution begins in Ukraine, followed by Russia's invasion and
+The Maidan Revolution begins in Ukraine, followed by russia's invasion and
 subsequent annexation of Crimea, as well as large portions of the Donbas region.
 
 Our fourth daughter, Kathryn, is born in December.
@@ -206,7 +206,7 @@ transportation has been shut down due to quarantine restrictions.
 
 ### 2022
 
-Russia invades Ukraine on February 24. Three days later, our family evacuates to
+russia invades Ukraine on February 24. Three days later, our family evacuates to
 Slovakia, where we stay for 16 months. We become heavily involved in ministering
 to Ukrainian refugees. We launch a podcast called Journey to Ukraine to share
 updates and spread awareness about what is happening in Ukraine.
@@ -230,7 +230,7 @@ In the summer, we host our final CMO project.
 
 Nathan and I, along with Ben Sargent, join up with Ukrainian missionary
 Oleksandr Ilchenko for our first trip to the southern regions of Ukraine,
-ministering in villages recently liberated from Russian occupation. The things
+ministering in villages recently liberated from russian occupation. The things
 we learn during this project lead to the establishment of a new ministry:
 Ukraine Gospel Outreach (UGO).
 

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -1,0 +1,240 @@
+---
+title: '25 Years in Ukraine'
+date: '2026-03-18'
+author: 'Joshua Steele'
+cover: 'https://res.cloudinary.com/dnkvsijzu/image/upload/v1773822298/OFReport/2026-03-18-25-years-in-ukraine/25-year-anniversary-cover_mmanas.jpg'
+preview: >-
+  TODO
+caption: >-
+  TODO
+tags:
+  - ukraine
+  - ministry
+---
+
+Today marks exactly 25 years since I arrived in Ukraine to serve the Lord as a
+full-time missionary. I felt I could not let this day pass without expressing my
+gratefulness to the Lord and to the many friends and family who have walked with
+me through this journey.
+
+There is so much I could share that the constraints of space and time do not
+allow, but in this brief post, I'd like to reflect on a few of the milestones
+God has led me through. I hope that as you read, you will be encouraged to trust
+Him with your life and to follow Him in faith, no matter what happens. Like so
+many that have come before me, I can testify from long experience and deep
+conviction that I have found my Savior to be very, very faithful.
+
+_“O taste and see that the LORD is good…” (Psalms 34:8)_
+
+## Arrival
+
+On March 18th, 2001, I stepped off a plane in Kyiv and into a journey that I
+could never have imagined. This was not my first visit to Ukraine. Almost four
+years earlier, I had come as a teenager to take part in a short-term missions
+project organized by my friend and mentor, Jessie Beal. During the five months I
+spent in Kyiv in 1997, I fell in love with this land.
+
+In the intervening years, as I worked, studied, and ministered the Gospel in my
+home state of Texas, it seemed my heart remained in Ukraine. When people asked
+me what I wanted to do in life, who I wanted to be, and what I wanted to
+accomplish, I would tell them that I wanted to serve as a missionary in Ukraine.
+
+Now, in the early morning hours of March 19, 2001, after an overnight train trip
+from Kyiv, I arrived in the city that would be my home for decades to come, the
+city where I still live with my family today: Lviv.
+
+## The Early Years (2001–2006)
+
+### 2001
+
+During my first two and a half years in Ukraine, I focused primarily on language
+study and ministry with a small Ukrainian church that I am still a part of
+today: Greater Grace. I shared an apartment with a Ukrainian national named
+Ruslan — now one of my closest friends — and I immersed myself in the Ukrainian
+language.
+
+### 2003
+
+God surprised me by leading me away from Ukraine for seven months to participate
+in a ministry project in Thailand. During my time there, I met Nathan Day, who
+came back with me to Ukraine in April of 2004. Nathan and his family still serve
+with us in Lviv today.
+
+### 2004
+
+After my return from Thailand, Nathan Day, Jessie Beal, and I decided to work
+together as a team, training young men in missions as we shared the Gospel with
+Ukrainians. In time, we adopted the name Euro Team Outreach.
+
+On September 18th, Kelsie and I were married in Texas, and after a few weeks of
+preparation, we returned to Ukraine together.
+
+### 2005
+
+Nathan and I made our first scouting trip to the Carpathians to plan a new
+project: Carpathian Mountain Outreach.
+
+We also organized a Bible camp in the Carpathian Mountains for a small group of
+Ukrainian young men, including Serhii Chepara. Serhii became a close friend and
+a key ministry ally in the years that followed.
+
+Kelsie and I welcome our first child, Abigail.
+
+### 2006
+
+Carpathian Mountain Outreach was launched in May of this year and lasted a full
+four months. What was envisioned as a one-off project became an annual event
+spanning 17 years that trained over 60 men in practical, hands-on foreign
+mission work.
+
+The first lessons of our Bible First course were written and distributed to
+people responding to our summer outreach (CMO 2006).
+
+Our nonprofit, Euro Team Outreach, is incorporated in the State of Texas, with
+Jessie, Nathan, and me serving as board members.
+
+## Expansion: Bible First, CMO, Good and Evil (2007–2019)
+
+During these years, we saw our ministry solidify around three primary branches.
+These were:
+
+1. Our Bible First correspondence course
+2. Our annual CMO projects
+3. The printing and distribution of the Good and Evil book in Ukrainian
+
+### 2008
+
+Our second child, Rebekah, is born in January.
+
+The translation of the Good and Evil book into the Ukrainian language is
+completed. 5,000 copies are delivered in January 2009.
+
+### 2010
+
+CMO 2010 — our fifth project in a row — is held. Our third child, Hosanna, is
+born in November.
+
+### 2011
+
+For the first time in five years we decided to take a year off from CMO to focus
+more heavily on the development and writing of our Bible First lessons.
+
+### 2012
+
+My brother Jonathan joined us for CMO — his third trip to Ukraine — and filmed a
+short promotional video about CMO, which we call affectionately “The CMO Movie”
+[LINK TO WATCH]
+
+### 2013
+
+The final two lessons of our Bible First course are complete, bringing the total
+to twenty. Bible First remains at the core of our ministry today
+
+### 2014
+
+The Maidan revolution begins in Ukraine, followed by Russia's invasion and
+subsequent annexation of Crimea, as well as large portions of the Donbas region.
+Our fourth daughter Kathryn is born in December
+
+### 2015
+
+Development begins on our web-based Bible First platform, enabling students for
+the first time to progress through our Bible lessons online.
+
+Ben Sargent, who would later join our staff team, travels to Ukraine and attends
+CMO for the first time.
+
+### 2016
+
+Our tenth CMO project is completed. We engage a local software company in Lviv
+to assist us with the continuing development of Bible First Online.
+
+### 2017
+
+Our fifth child and first son, David, is born in January. Once again, we take a
+break from CMO to focus on the development of our Bible first course.
+
+### 2018
+
+Working with a professional Ukrainian philologist, we complete a thorough
+updated translation of "Good and Evil" in Ukrainian. New donations come in,
+enabling us to print 5,000 more copies this time in color for the first time.
+
+Ben Sargent joins ETO's Board of Directors.
+
+### 2019
+
+After many years of development and field testing, Bible First Online is finally
+ready. We launched the Bible First Pioneers program, inviting people from the
+U.S. to test-try Bible First Online in their own ministries and with
+English-speaking audiences.  Our sixth child, Mia, is born in July.
+
+## War and Perseverance (2020–Present)
+
+### 2020
+
+The COVID pandemic begins and our lives change dramatically. I become involved
+in a local initiative called Lviv Angels, where Christian drivers help doctors
+and nurses get to hospitals every day. This is needful because public
+transportation has been shut down due to quarantine restrictions.
+
+### 2022
+
+Russia invades Ukraine on February 24. Three days later our family evacuates to
+Slovakia, where we stay for 16 months. We become heavily involved in ministering
+to Ukrainian refugees. We launch a podcast called Journey to Ukraine to share
+updates and spread awareness about what is happening in Ukraine.
+
+New donations come in for the printing of Good and Evil and we print 15,000
+copies of a special edition full color. Armed with these new books, we launch
+our Good and Evil distributor network, which results in the broad distribution
+of the good and evil book all across Ukraine, even in the most hard-hit areas by
+the war
+
+### 2023
+
+After nearly a year and a half in Slovakia and despite the ongoing war in
+Ukraine, our family returns to Lviv to continue our lives and ministry here. In
+the summer we host our final CMO project.
+
+### 2024
+
+Nathan and I, along with Ben Sargent, join up with Ukrainian missionary
+Oleksandr Ilchenko for our first trip to the southern regions of Ukraine,
+recently liberated from Russian occupation. The things we learn during this
+project lead to the establishment of a new ministry: Ukraine Gospel Outreach
+(UGO).  Kelsie and I celebrate 20 years of marriage.
+
+### 2025
+
+Ukraine Gospel Outreach is formally announced, with our second project taking
+place in October. Funding is provided for our fourth full-color printing of Good
+and Evil, enabling us to continue our Good and Evil distributor network
+
+## Conclusion
+
+In publishing this article, I think what I want most is to give glory to God for
+His faithfulness, and to urge you, my reader, to trust Him with your own life.
+Let me lend my voice to the many thousands who have gone before me, echoing the
+same conclusion: the God of Elijah is alive today, and He calls you to follow
+Him in faith. He wants to lead you, He wants to bless you in ways you cannot
+imagine, and He wants to use your voice to call the lost out of darkness and
+into His light.
+
+Looking back over these 25 years, I realize that I wouldn't trade them for the
+world. There's nowhere else I would rather have been. There's nothing else I
+would rather have done than to raise my family in Ukraine and share Jesus Christ
+with the precious people amongst whom we live.
+
+I can't know how many more years God will give me on this earth, but my purpose
+remains the same. Whether in Ukraine or the United States or wherever God will
+lead me, I am called to preach the Gospel of Jesus Christ to those who have not
+heard.
+
+To all of you, my friends, my family, my mentors, those in America and those
+here in Ukraine: thank you for standing with me, for trusting me, for supporting
+my family and me over all these years. I know I speak for Kelsie and all of our
+children when I say that we consider ourselves greatly blessed to have the
+privilege of living and ministering in the beautiful country of Ukraine. We are
+excited about what the future holds, and we look forward to whatever God has in
+store for our family in the days, months, and years ahead.

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -236,7 +236,7 @@ Ukraine Gospel Outreach (UGO).
 
 Kelsie and I celebrate 20 years of marriage.
 
-<article-image publicId="OFReport/2024-09-24-of-books-baptisms-and-blessings/joshua-kelsie-20-years_yjb8pt" width="768" caption="More in love than ever!" />
+<article-image publicId="OFReport/2024-09-24-of-books-baptisms-and-blessings/joshua-kelsie-20-years_yjb8pt" width="768" caption="More in love than ever! 💞" />
 
 ### 2025
 

--- a/content/articles/2026-03-18-25-years-in-ukraine.md
+++ b/content/articles/2026-03-18-25-years-in-ukraine.md
@@ -76,6 +76,8 @@ Ukrainians. In time, we call adopt the name _Euro Team Outreach_.
 On September 18th, Kelsie and I are married in Texas, and after a few weeks of
 preparation, we return to Ukraine together.
 
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/joshua-kelsie-wedding_ynacqc" width="768" caption="No single person has had a greater impact on my life and ministry in Ukraine than the beautiful bride God brought me, my precious Kelsie. ❤️" />
+
 ### 2005
 
 Nathan and I make our first scouting trip to the Carpathians to plan a new
@@ -99,6 +101,8 @@ people responding to our summer outreach (CMO 2006).
 Our nonprofit, Euro Team Outreach, is incorporated in the State of Texas, with
 Jessie, Nathan, and me serving as board members.
 
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/cmo-2006-team-picture_veueqk" width="768" caption="The original CMO team, 2006" />
+
 ## Expansion: Bible First, CMO, Good and Evil (2007–2019)
 
 During these years, we see our ministry solidify around three primary branches:
@@ -113,6 +117,8 @@ Our second child, Rebekah, is born in January.
 
 The translation of the Good and Evil book into the Ukrainian language is
 completed. 5,000 copies are delivered in January 2009.
+
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/dsc_4266_qic6hy" width="768" caption="Serhii Chepara helps me unload the shipment of 5,000 Good and Evil books." />
 
 ### 2010
 
@@ -134,6 +140,8 @@ short promotional video about CMO, which we affectionately call "The CMO Movie."
 
 The final two lessons of our Bible First course are complete, bringing the total
 to twenty. Bible First remains at the core of our ministry today.
+
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_1623_g9e0wb_e9hgsz" width="768" caption="Filming Bible teaching videos in Ukrainian" />
 
 ### 2014
 
@@ -164,6 +172,8 @@ Our fifth child and first son, David, is born in January.
 Once again, we take a break from CMO to focus on the development of our Bible
 First course.
 
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/hackers-for-christ-2000w_ilvvag" width="768" caption="Trevor Brown travels to Ukraine to help us with coding Bible First Online." />
+
 ### 2018
 
 Working with a professional Ukrainian philologist, we complete a thorough
@@ -190,6 +200,8 @@ in a local initiative called Lviv Angels, where Christian drivers help doctors
 and nurses get to hospitals every day. This is needful because public
 transportation has been shut down due to quarantine restrictions.
 
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/drivers-books_ylteqh_bmaf5z" width="768" caption="Driving doctors and passing out Bible literature as the pandemic rages." />
+
 ### 2022
 
 Russia invades Ukraine on February 24. Three days later, our family evacuates to
@@ -201,6 +213,8 @@ New donations come in for the printing of Good and Evil, and we print 15,000
 copies in a special full-color edition. Armed with these new books, we launch
 our Good and Evil distributor network, resulting in the broad distribution of
 the Good and Evil book all across Ukraine, even in areas hardest hit by the war.
+
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/ge-print-blend_osqrye_ydn2xf" width="768" caption="Thanks to the generosity of No Greater Joy Ministries and many individual donors, 15,000 copies of a special edition of Good and Evil are printed." />
 
 ### 2023
 
@@ -219,6 +233,8 @@ Ukraine Gospel Outreach (UGO).
 
 Kelsie and I celebrate 20 years of marriage.
 
+<article-image publicId="OFReport/2024-09-24-of-books-baptisms-and-blessings/joshua-kelsie-20-years_yjb8pt" width="768" caption="More in love than ever!" />
+
 ### 2025
 
 Ukraine Gospel Outreach is formally announced, with our second project taking
@@ -226,6 +242,8 @@ place in October.
 
 Funding is provided for our fourth full-color printing of Good and Evil,
 enabling us to continue our Good and Evil Distributor Network.
+
+<article-image publicId="OFReport/2026-03-18-25-years-in-ukraine/IMG_7695_yrdvwy" width="768" caption="Ministering the Gospel in Zhytomry at the conclusion of our 2025 UGO project" />
 
 ## Conclusion
 

--- a/data/archives.json
+++ b/data/archives.json
@@ -449,5 +449,12 @@
       "issue": "Sep/Oct 2003",
       "file": "steele_ofr_sep-oct_2003.pdf"
     }
+  ],
+  "2001": [
+    {
+      "title": "The Beginning",
+      "issue": "March 2001",
+      "file": "ukraine_report_mar_2001.pdf"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add new blog post "25 Years in Ukraine" commemorating 25 years of missionary work since March 18, 2001
- Include nine captioned photos throughout the article timeline
- Add March 2001 newsletter archive entry

## Changes

- **feat**: New article `content/articles/2026-03-18-25-years-in-ukraine.md` with full timeline from 2001–2025
- **feat**: Nine Cloudinary-hosted images placed throughout the article with captions
- **feat**: New 2001 entry in `data/archives.json` linking to the first Ukraine Report newsletter

## Testing

- [x] `yarn dev` — verify article renders correctly with images
- [x] Check pagination and tag filtering still work
- [x] Verify the archives page shows the new 2001 entry
- [x] Confirm Cloudinary images load at correct sizes