### PR TITLE
fix: remove MailChimp popup subscribe form

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -23,38 +23,6 @@ export default {
       return `${site.url + this.$route.path}`;
     },
   },
-  mounted() {
-    this.setupMailChimpPopup();
-  },
-  methods: {
-    setupMailChimpPopup() {
-      const mailchimpConfig = {
-        baseUrl: 'mc.us6.list-manage.com',
-        uuid: '1e0c65850b60905f65b151819',
-        lid: '97b9f6a559',
-      };
-
-      const mcPopupLoader = document.createElement('script');
-      mcPopupLoader.src =
-        '//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js';
-      mcPopupLoader.setAttribute(
-        'data-dojo-config',
-        'usePlainJson: true, isDebug: false'
-      );
-
-      const mcPopup = document.createElement('script');
-      mcPopup.appendChild(
-        document.createTextNode(
-          `require(["mojo/signup-forms/Loader"], function (L) { L.start({"baseUrl": "${mailchimpConfig.baseUrl}", "uuid": "${mailchimpConfig.uuid}", "lid": "${mailchimpConfig.lid}"})});`
-        )
-      );
-
-      mcPopupLoader.onload = () => {
-        document.body.appendChild(mcPopup);
-      };
-      document.body.appendChild(mcPopupLoader);
-    },
-  },
   head() {
     return {
       meta: [


### PR DESCRIPTION
## Summary
- Remove the auto-injected MailChimp popup that appears on page load from `layouts/default.vue`
- Inline MailChimp subscribe forms on the subscribe page, homepage, and article footers are **not affected**

## Motivation
The popup can be confusing alongside Kelsie's new Substack, and is generally intrusive. The embedded subscribe forms remain as the primary way for readers to join the mailing list.

## Test plan
- [x] Verify the MailChimp popup no longer appears on page load
- [x] Verify the subscribe form on `/subscribe/` still works
- [x] Verify the "Read the News" section on the homepage still shows the subscribe form
- [x] Verify the subscribe form at the bottom of blog posts still works