### PR TITLE
docs: bring PRD structure up to current workflow standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-OFReport.com is a missionary family blog (Joshua and Kelsie Steele) being rebuilt from Nuxt.js 2 to Hugo. The site has 219 blog articles spanning 2008–2025, 5+ static pages, and 26 tags. Full requirements are in the `docs/prd/` directory (start with `00-overview.md`; see `ROADMAP.md` for build phases).
+OFReport.com is a missionary family blog (Joshua and Kelsie Steele) being rebuilt from Nuxt.js 2 to Hugo. The site has 219 blog articles spanning 2008–2025, 5+ static pages, and 26 tags. Full requirements are in the `docs/prd/` directory (start with `README.md`; see `ROADMAP.md` for build phases).
 
 ## Development Approach
 

--- a/docs/prd/00-overview.md
+++ b/docs/prd/00-overview.md
@@ -91,22 +91,6 @@ committed to the repository.
 
 ## PRD Structure
 
-This PRD is split across multiple files for easier navigation:
-
-| File                                                   | Focus                                           |
-| ------------------------------------------------------ | ----------------------------------------------- |
-| `00-overview.md`                                       | Project goals, development approach (this file) |
-| [`01-architecture.md`](./01-architecture.md)           | Architectural decisions                         |
-| [`02-design.md`](./02-design.md)                       | Design philosophy and visual identity           |
-| [`03-site-structure.md`](./03-site-structure.md)       | Content organization, URLs, Hugo configuration  |
-| [`04-templates.md`](./04-templates.md)                 | Layout and template specifications              |
-| [`05-shortcodes.md`](./05-shortcodes.md)               | Hugo shortcode specifications                   |
-| [`06-content-migration.md`](./06-content-migration.md) | Migration script, legacy articles, checklist    |
-| [`07-deployment.md`](./07-deployment.md)               | Source control, Netlify config, deployment      |
-| [`08-risks-and-future.md`](./08-risks-and-future.md)   | New features, risks, out-of-scope items         |
-| [`ROADMAP.md`](./ROADMAP.md)                           | Build phases and progress tracking              |
-| [`appendix.md`](./appendix.md)                         | Reference links and existing data files         |
-
-The [Hugo Migration Brief](../hugo-migration-brief.md) documents the existing
-Nuxt site and serves as a reference for understanding the current content,
-features, and user experience.
+This PRD is split across multiple files for easier navigation. See
+[`README.md`](./README.md) for the full file index with "consult when..."
+guidance and PRD conventions.

--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -1,0 +1,37 @@
+# OFReport.com Hugo Rebuild — PRD Changelog
+
+This file tracks material deviations from the PRD discovered during implementation. It is the record of the "never silently deviate" rule. See `~/.claude/docs/prd-workflow/spec-driven-development.md` §2–§3 for the deviation threshold and workflow.
+
+## Format
+
+Each entry records one deviation or decision:
+
+```text
+### YYYY-MM-DD — [file changed]
+
+**What changed:** One-sentence description of the change.
+
+**Why:** The rationale — what was wrong, what was discovered, or what prompted the pivot.
+
+**Category:** Correction | Discovery | Pivot
+```
+
+**Categories:**
+
+- **Correction** — The PRD was wrong or inconsistent.
+- **Discovery** — Implementation revealed something the PRD didn't anticipate.
+- **Pivot** — A deliberate decision to change direction.
+
+## Guidelines
+
+- **Newest entries first** — add new entries at the top of the Entries section.
+- Log when the PR is created, not after it's merged.
+- The "why" is required — a change without rationale is not useful.
+- Skip typo fixes and formatting corrections.
+- At natural breakpoints (end of a phase, or 10+ accumulated entries), fold changes back into the PRD files themselves during a sync session.
+
+---
+
+## Entries
+
+*No entries yet.*

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,40 @@
+# OFReport.com Hugo Rebuild — Product Requirements Document
+
+This directory contains the modular PRD for the OFReport.com Hugo rebuild. Each file is a self-contained specification that can be referenced independently during implementation.
+
+The [Hugo Migration Brief](../hugo-migration-brief.md) documents the existing Nuxt site and serves as a reference for understanding the current content, features, and user experience.
+
+## How to Use This PRD
+
+**For Claude Code / AI-assisted implementation:** Reference the specific PRD section relevant to your current task. Start here to find the right file, then consult the referenced section for requirements.
+
+**For human reviewers:** Read `00-overview.md` for context, then dive into the feature spec that matters to you.
+
+## File Index
+
+| File | Contents | Consult When... |
+| --- | --- | --- |
+| `CHANGELOG.md` | Material deviations from the PRD discovered during implementation | Recording or reviewing a "never silently deviate" decision |
+| `ROADMAP.md` | Build phases and progress tracking | Planning a phase, checking what's next, marking work complete |
+| `00-overview.md` | Project goals, non-goals, development approach | Onboarding to the project, understanding scope and the AI-assisted workflow |
+| `01-architecture.md` | Architectural decisions (Tailwind pipeline, Cloudinary, RSS, forms) | Wiring up the asset pipeline, image handling, or an integration |
+| `02-design.md` | Design philosophy and visual identity | Making styling, typography, or layout decisions |
+| `03-site-structure.md` | Content organization, URL structure, Hugo configuration | Adding content types, touching `hugo.toml`, or changing URLs |
+| `04-templates.md` | Layout and template specifications | Building or editing a layout, partial, or list/single template |
+| `05-shortcodes.md` | Hugo shortcode specifications | Implementing or changing a shortcode (figure, callout, button, svg) |
+| `06-content-migration.md` | Migration script, legacy articles, validation checklist | Migrating the 219 Nuxt articles or debugging converted content |
+| `07-deployment.md` | Source control, Netlify config, deployment | Configuring Netlify, redirects, headers, or the production deploy |
+| `08-risks-and-future.md` | New features, risks, out-of-scope items | Scoping a future enhancement or weighing a known risk |
+| `appendix.md` | Reference links and existing data files | Looking up a source reference or data file detail |
+
+## Conventions
+
+- **"MUST", "SHALL", "REQUIRED"** — non-negotiable for MVP launch.
+- **"SHOULD"** — expected for MVP unless a specific technical constraint prevents it.
+- **"MAY"** — nice to have; implement if straightforward, otherwise defer.
+- **"TBD"** — explicitly unresolved; document with context and resolution guidance.
+- **Cross-references** use the format `→ See 04-templates.md §3 "Section Heading"` to point to other PRD sections — always include the filename and quoted heading. (Existing files also use inline Markdown links; new cross-references should follow the `→ See` form.)
+
+### Numbering divergence
+
+This PRD numbers files from `00-` and phases from Phase 1, rather than the current workflow template's `01-` files and Phase 0 foundation. This is an intentional divergence retained from the project's original structure — renumbering would churn every cross-reference and debrief for no functional gain. New files and phases continue the existing sequence.

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -3,6 +3,29 @@
 This document tracks implementation progress across build phases. Each item
 links to the relevant PRD document for full requirements.
 
+**Progress key:** `[ ]` Not started · `[~]` In progress · `[x]` Complete · `[—]` Deferred / descoped
+
+## Phase Overview
+
+| Phase | Name | Dependencies | Status |
+| ----- | ---- | ------------ | ------ |
+| 1 | Project Scaffolding & Configuration | — | Complete |
+| 2 | Tailwind CSS v4 Integration | Phase 1 | Complete |
+| 3 | Base Layout & Navigation | Phase 2 | Complete |
+| 4 | Blog Listing with Pagination | Phase 3 | Complete |
+| 5 | Single Article Template | Phase 3 | Complete |
+| 6 | Shortcodes | Phase 5 | Not started |
+| 7 | Tag Taxonomy | Phase 4 | Not started |
+| 8 | Static Pages | Phase 3 | Not started |
+| 9 | RSS Feed | Phase 5 | Not started |
+| 10 | SEO & Meta Tags | Phase 3 | Not started |
+| 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
+| 12 | Newsletter Integration | Phase 3 | Not started |
+| 13 | Lightbox Integration | Phase 6 | Not started |
+| 14 | Analytics | Phase 3 | Not started |
+| 15 | Content Migration | Phase 6 | Not started |
+| 16 | Deployment | Phase 15 | Not started |
+
 ---
 
 ## Phase 1: Project Scaffolding & Configuration


### PR DESCRIPTION
## Summary

Brings the `docs/prd/` structure up to the current dotfiles PRD-workflow standard (Tier A of the re-entry plan in #36). The PRD's content was already healthy; these are the structural scaffolding files the standard has added since this PRD was written (v1.1, Feb 8).

- **A1 — Deviation log.** Add `docs/prd/CHANGELOG.md` from the template, standing up the "never silently deviate" record before Phase 6 so divergences in the remaining phases are captured forward.
- **A2 — Navigation hub.** Add `docs/prd/README.md` (File Index with "consult when…" guidance + RFC keyword / cross-reference conventions + a note recording the intentional numbering divergence). Relocate the file index out of `00-overview.md` so there is a single hub, and repoint the `CLAUDE.md` entry pointer to the README.
- **A3 — ROADMAP scaffolding.** Add a Phase Overview table (phase · name · dependencies · status) and the progress-key legend to `ROADMAP.md`.

## Verification

- `npm run lint` — clean (43 files, 0 errors)
- `hugo --gc --minify` — builds OK (`docs/` is outside Hugo's content path; no site impact)

## Notes

- The `Dependencies` column in the new Phase Overview table reflects build-order constraints (e.g., shortcodes before lightbox and content migration), not a naive sequential chain — open to correction.
- Tier-C numbering divergences (1-based phases, `00-` filenames) are intentionally retained and documented in the new README rather than renumbered, which would churn every cross-reference and debrief for no functional gain.

Refs #36 — Tier A of the re-entry plan. Does **not** close #36; the housekeeping, reorientation, and Tier-B/C PRD items remain open.
