### PR TITLE
chore: add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # npm dependencies (Tailwind CSS, Alpine.js, markdownlint)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "chore"
+    groups:
+      # Bundle low-risk minor/patch bumps into one PR to reduce noise.
+      # Major bumps stay as individual PRs so they get individual review.
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the CI workflow (checkout, setup-node, actions-hugo)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency update PRs — the one "do" item from the remaining re-entry housekeeping (#36).

- **npm** — monthly updates; minor/patch bumps grouped into a single PR to reduce noise; major bumps stay as individual PRs for review. Labeled `chore`.
- **GitHub Actions** — monthly updates for the CI workflow's actions (`checkout`, `setup-node`, `peaceiris/actions-hugo`), grouped. Labeled `chore`.

## Why

This project sat dormant ~3½ months and silently accumulated a high-severity `picomatch` advisory that only surfaced during the manual `/update-deps` audit. Dependabot provides automated early warning between manual maintenance runs.

## Verification

- `dependabot.yml` validates as well-formed YAML (version 2, both ecosystems present).
- No build/lint impact (config-only).

Part of the #36 re-entry plan (Dependabot housekeeping item). _(Not using a closing keyword — #36 is already closed.)_
