### PR TITLE
feat: add button shortcode for styled CTA links

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -84,7 +84,7 @@ links to the relevant PRD document for full requirements.
 
 - [ ] `figure.html` — image with caption + lightbox (see [`05-shortcodes.md`](./05-shortcodes.md))
 - [ ] `callout.html` — highlighted box with optional CTA
-- [ ] `button.html` — styled CTA link
+- [x] `button.html` — styled CTA link
 - [ ] `svg.html` — inline SVG from assets
 - [ ] All shortcodes tested with sample content
 

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,0 +1,27 @@
+{{- /*
+  button — styled CTA link (filled primary).
+
+  Params:
+    href     (required) destination URL
+    text     (required) visible label
+    external (optional) "true" opens in a new tab with rel="noopener noreferrer"
+
+  Usage:
+    {{< button href="/donate/" text="Support Our Ministry" >}}
+    {{< button href="https://example.com" text="Visit Site" external=true >}}
+*/ -}}
+{{- $href := .Get "href" -}}
+{{- $text := .Get "text" -}}
+{{- if not $href -}}
+  {{- errorf "button shortcode: 'href' param is required (%s)" .Position -}}
+{{- end -}}
+{{- if not $text -}}
+  {{- errorf "button shortcode: 'text' param is required (%s)" .Position -}}
+{{- end -}}
+{{- /* Hugo parses unquoted external=true as a bool; normalize to compare either form. */ -}}
+{{- $external := eq (printf "%v" (.Get "external")) "true" -}}
+<a
+  href="{{ $href }}"
+  class="inline-flex items-center rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition-colors hover:bg-blue-700"
+  {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
+>{{ $text }}</a>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -4,7 +4,8 @@
   Params:
     href     (required) destination URL
     text     (required) visible label
-    external (optional) "true" opens in a new tab with rel="noopener noreferrer"
+    external (optional) "true" opens in a new tab — adds rel="noopener noreferrer",
+                        an external-link icon, and a screen-reader "opens in a new tab" note
 
   Usage:
     {{< button href="/donate/" text="Support Our Ministry" >}}
@@ -22,6 +23,11 @@
 {{- $external := eq (printf "%v" (.Get "external")) "true" -}}
 <a
   href="{{ $href }}"
-  class="inline-flex items-center rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition-colors hover:bg-blue-700"
+  class="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition-colors hover:bg-blue-700"
   {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
->{{ $text }}</a>
+>
+  {{- $text -}}
+  {{- if $external -}}
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg><span class="sr-only">(opens in a new tab)</span>
+  {{- end -}}
+</a>


### PR DESCRIPTION
## Summary

- Adds the `button` shortcode — the first of Phase 6's four shortcodes — rendering a filled-primary CTA link.
- Establishes the shortcode pattern (named `.Get` params, required-param guard via `errorf`, Tailwind styling) that the upcoming `svg`/`callout`/`figure` shortcodes will reuse.

## Changes

- **New `layouts/shortcodes/button.html`**: `href` + `text` params (both required), optional `external`. `external=true` adds `target="_blank" rel="noopener noreferrer"`; internal links render without them.
- Missing `href`/`text` calls `errorf` with `.Position`, failing the build with a `file:line` pointer rather than emitting a broken link.
- Filled-primary styling: `bg-blue-600` → `hover:bg-blue-700`, with `no-underline` so the `.prose` typography plugin doesn't underline the button on article pages.
- **ROADMAP**: marked `button.html` complete (Phase 6).

## Testing

- [x] Production build passes (`hugo --gc --minify`), no warnings
- [x] Manual: built a temporary draft post and inspected the generated HTML —
  - internal variant → no `target`/`rel`
  - external variant → `target="_blank" rel="noopener noreferrer"`
  - missing `href` → build fails with `'href' param is required (…md:8:1)`

## Notes

- Hugo parses an unquoted `external=true` as a **boolean**, not a string. The shortcode normalizes the value with `printf "%v"` before comparing, so both `external=true` and `external="true"` work. (First pass compared against the string `"true"` and silently failed — caught by inspecting rendered output.)
- GLightbox activation (Phase 13) and real content migration (Phase 15) are out of scope here; the remaining three Phase 6 shortcodes are tracked in #42, #43, #44.

Closes #41
