### PR TITLE
feat: add svg shortcode for inline SVG embedding

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -85,7 +85,7 @@ links to the relevant PRD document for full requirements.
 - [ ] `figure.html` — image with caption + lightbox (see [`05-shortcodes.md`](./05-shortcodes.md))
 - [ ] `callout.html` — highlighted box with optional CTA
 - [x] `button.html` — styled CTA link
-- [ ] `svg.html` — inline SVG from assets
+- [x] `svg.html` — inline SVG from assets
 - [ ] All shortcodes tested with sample content
 
 **Key learning:** Custom shortcodes for images, callouts, buttons

--- a/layouts/shortcodes/svg.html
+++ b/layouts/shortcodes/svg.html
@@ -1,0 +1,23 @@
+{{- /*
+  svg — embed an SVG file from assets/img/ inline.
+
+  Inlining the markup (vs. an <img> tag) lets the SVG be styled and animated
+  with CSS — currentColor, hover states, etc. Assets are first-party, so
+  safeHTML is appropriate here.
+
+  Params:
+    name (required) base filename without extension; reads assets/img/{name}.svg
+
+  Usage:
+    {{< svg name="ofr-logo" >}}
+*/ -}}
+{{- $name := .Get "name" -}}
+{{- if not $name -}}
+  {{- errorf "svg shortcode: 'name' param is required (%s)" .Position -}}
+{{- end -}}
+{{- $path := printf "img/%s.svg" $name -}}
+{{- with resources.Get $path -}}
+  {{- .Content | safeHTML -}}
+{{- else -}}
+  {{- warnf "svg shortcode: file not found: assets/%s (%s)" $path .Position -}}
+{{- end -}}


### PR DESCRIPTION
## Summary

- Adds the `svg` shortcode — the second of Phase 6's four shortcodes — which inlines an SVG file from `assets/img/` so it can be styled/animated with CSS.
- Reuses the same `resources.Get` idiom as `header.html`, but outputs `.Content | safeHTML` (inline markup) rather than linking an `<img>`.

## Changes

- **New `layouts/shortcodes/svg.html`**: `name` param → reads `assets/img/{name}.svg` → inlines the markup via `safeHTML`.
- **Distinct failure modes:**
  - Missing `name` param → `errorf` (fails the build) — an author usage error, consistent with the button shortcode's required-param guard.
  - Missing *file* → `warnf` (warns, build continues) — Phase 8 ministry logos don't exist yet, so a reference to one shouldn't break the build.
- **ROADMAP**: marked `svg.html` complete (Phase 6).

## Testing

- [x] Production build passes (`hugo --gc --minify`), no warnings
- [x] Manual: built a temporary draft post and inspected output —
  - `name="ofr-logo"` → real `<svg viewBox="0 0 1000 200">` inlined, unescaped
  - `name="does-not-exist"` → `WARN … file not found`, build still succeeds
  - `{{< svg >}}` (no `name`) → `ERROR … 'name' param is required (…md:8:1)`, build fails

## Notes

- `safeHTML` bypasses Hugo's HTML escaping, which is correct for first-party assets in `assets/img/`. Worth remembering only if SVGs ever come from an untrusted source (not the case in this project).
- Only `ofr-logo.svg` exists in `assets/img/` today; the shortcode is ready for the ministry logos that arrive in Phase 8. Remaining Phase 6 shortcodes: #43 (callout), #44 (figure).

Closes #42
