### PR TITLE
feat: add callout shortcode with optional PDF link

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -83,7 +83,7 @@ links to the relevant PRD document for full requirements.
 ## Phase 6: Shortcodes
 
 - [ ] `figure.html` — image with caption + lightbox (see [`05-shortcodes.md`](./05-shortcodes.md))
-- [ ] `callout.html` — highlighted box with optional CTA
+- [x] `callout.html` — highlighted box with optional CTA
 - [x] `button.html` — styled CTA link
 - [x] `svg.html` — inline SVG from assets
 - [ ] All shortcodes tested with sample content

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,0 +1,37 @@
+{{- /*
+  callout — highlighted box for important info / CTAs, with an optional PDF link.
+
+  Paired shortcode used with angle brackets ({{< callout >}}…{{< /callout >}}),
+  so .Inner is raw and we render it as markdown ourselves. display=block ensures
+  paragraphs/lists wrap properly (RenderString defaults to inline otherwise).
+
+  The [&>:first-child]:mt-0 / [&>:last-child]:mb-0 utilities reset the outer
+  margins of the prose-rendered content so the box padding stays even — the
+  inner <p> isn't a direct child of .prose, so its margins aren't auto-trimmed.
+
+  Params:
+    pdf (optional) newsletter PDF filename; appended to site.Params.pdfBase
+
+  Usage:
+    {{< callout >}}
+    Important information goes here.
+    {{< /callout >}}
+
+    {{< callout pdf="OFR-Jul-Aug-2025.pdf" >}}
+    Get the full newsletter PDF.
+    {{< /callout >}}
+*/ -}}
+<div class="callout my-6 rounded-r-lg border-l-4 border-blue-500 bg-blue-50 px-5 py-4 [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+  {{ .Page.RenderString (dict "display" "block") .Inner }}
+  {{- with .Get "pdf" }}
+  <a
+    href="{{ site.Params.pdfBase }}{{ . }}"
+    class="callout-download inline-flex items-center gap-1.5 font-semibold text-blue-700 no-underline transition-colors hover:text-blue-900"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
+    Download PDF
+  </a>
+  {{- end }}
+</div>


### PR DESCRIPTION
## Summary

- Adds the `callout` shortcode — the third of Phase 6's four shortcodes — a highlighted box for important info / CTAs with an optional PDF download link.
- First **paired** shortcode in the project: renders `.Inner` as block-level markdown via `.Page.RenderString`.

## Changes

- **New `layouts/shortcodes/callout.html`**: paired shortcode (`{{< callout >}}…{{< /callout >}}`).
  - Inner content rendered with `.Page.RenderString (dict "display" "block") .Inner` — block display so multi-paragraph/list content wraps in `<p>` correctly (`RenderString` defaults to inline).
  - Optional `pdf` param appends a `callout-download` link → `site.Params.pdfBase` + filename, with a document-download icon and `target="_blank" rel="noopener noreferrer"` (matching the PDF link in `article-card.html`).
  - Blue accent-bar styling (`border-l-4 border-blue-500 bg-blue-50`), with `[&>:first-child]:mt-0 [&>:last-child]:mb-0` to keep box padding even against prose paragraph margins.
- **ROADMAP**: marked `callout.html` complete (Phase 6).

## Testing

- [x] Production build passes (`hugo --gc --minify`), no warnings
- [x] Manual: built a temporary draft post and inspected output —
  - plain single paragraph → `<p>` inside `.callout`
  - multi-paragraph + inline markdown (link, bold) → two `<p>`, confirming `display=block`
  - `pdf="OFR-Jul-Aug-2025.pdf"` → link to `…cloudfront.net/ofr/OFR-Jul-Aug-2025.pdf`, icon, new-tab
  - verified Tailwind generated the `[&>:first-child]:mt-0` / `[&>:last-child]:mb-0` arbitrary-variant CSS and that it out-specifies prose's paragraph margins
- [x] `/simplify` pass applied (inlined a single-use `.Get "pdf"`); reuse/efficiency/altitude confirmed clean

## Notes

- Chose `.Page.RenderString` over `markdownify` per the issue's technical notes — it respects site render hooks.
- The `callout` / `callout-download` class hooks are intentional (issue #43): they keep the Phase 15 migration output scannable, layered on top of Tailwind utilities rather than a component CSS class (the project has no component CSS layer).
- The PDF download icon + link pattern now appears 2× (here and `article-card.html`); per "no premature abstraction" it stays inline until a 3rd occurrence, at which point a `partials/pdf-link.html` would be the extraction point.
- Remaining Phase 6 shortcode: #44 (figure).

Closes #43
