### PR TITLE
feat: add figure shortcode with lightbox-compatible markup

### DIFF
--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,4 +34,10 @@ Each entry records one deviation or decision:
 
 ## Entries
 
-*No entries yet.*
+### 2026-06-04 — `layouts/shortcodes/figure.html`, `layouts/partials/cloudinary-url.html`
+
+**What changed:** The figure shortcode serves its inline display image from a new width-capped `figure` Cloudinary preset (`w_768`) and its lightbox link from a new larger `lightbox` preset (`w_1600`), instead of the uncapped `article` preset named in the issue #44 technical note (`05-shortcodes.md`).
+
+**Why:** The `article` preset is width-uncapped (it serves the full original), which contradicts the established convention of ~768px inline body images — confirmed by Joshua against the current Nuxt blog — that keeps article bodies from loading huge files. "Display = article + a larger lightbox" was self-contradictory, since `article` is already full-size. A capped display (`w_768`, covering the `max-w-2xl` ≈ 672px article column) plus a larger lightbox (`w_1600`) is the correct click-to-zoom pattern. The cover image (handled separately in `blog/single.html`) is unaffected.
+
+**Category:** Correction

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -14,7 +14,7 @@ links to the relevant PRD document for full requirements.
 | 3 | Base Layout & Navigation | Phase 2 | Complete |
 | 4 | Blog Listing with Pagination | Phase 3 | Complete |
 | 5 | Single Article Template | Phase 3 | Complete |
-| 6 | Shortcodes | Phase 5 | Not started |
+| 6 | Shortcodes | Phase 5 | Complete |
 | 7 | Tag Taxonomy | Phase 4 | Not started |
 | 8 | Static Pages | Phase 3 | Not started |
 | 9 | RSS Feed | Phase 5 | Not started |
@@ -82,11 +82,11 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 6: Shortcodes
 
-- [ ] `figure.html` — image with caption + lightbox (see [`05-shortcodes.md`](./05-shortcodes.md))
+- [x] `figure.html` — image with caption + lightbox (see [`05-shortcodes.md`](./05-shortcodes.md))
 - [x] `callout.html` — highlighted box with optional CTA
 - [x] `button.html` — styled CTA link
 - [x] `svg.html` — inline SVG from assets
-- [ ] All shortcodes tested with sample content
+- [x] All shortcodes tested with sample content
 
 **Key learning:** Custom shortcodes for images, callouts, buttons
 

--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -3,10 +3,17 @@
 {{- $result := "" -}}
 
 {{- if $src -}}
+  {{- /* Accept a bare public ID by expanding it to a full Cloudinary URL. */ -}}
+  {{- if not (hasPrefix $src "http") -}}
+    {{- $src = printf "%s/image/upload/%s" site.Params.cloudinaryBase $src -}}
+  {{- end -}}
+
   {{- $presets := dict
     "featured" "c_scale,f_auto,q_auto,w_740"
     "regular"  "c_scale,f_auto,q_auto,w_610"
+    "figure"   "c_scale,f_auto,q_auto,w_768"
     "article"  "c_scale,f_auto,q_auto:best"
+    "lightbox" "c_scale,f_auto,q_auto,w_1600"
     "og"       "c_fill,f_auto,h_630,q_auto,w_1200"
     "rss"      "c_scale,f_auto,q_auto,w_560"
   -}}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,0 +1,36 @@
+{{- /*
+  figure — inline Cloudinary image, clickable to a larger lightbox view.
+
+  Inline <img> is served at ~768px (the article body width) so pages stay light;
+  the wrapping <a> points at a larger version for the lightbox zoom. GLightbox
+  itself is wired up in Phase 13 — this only emits the compatible markup
+  (class="glightbox", data-gallery, data-description), which is forward-compatible.
+
+  not-prose keeps the typography plugin from styling the figure/img/figcaption,
+  so it matches the cover figure in blog/single.html exactly.
+
+  Params:
+    src     (required) full Cloudinary URL OR a bare public ID
+    caption (optional) shown below the image and as the lightbox description
+    alt     (optional) image alt text; falls back to caption when omitted
+
+  Usage:
+    {{< figure src="OFReport/2025-01/photo" caption="A caption" alt="Alt text" >}}
+*/ -}}
+{{- $src := .Get "src" -}}
+{{- if not $src -}}
+  {{- errorf "figure shortcode: 'src' param is required (%s)" .Position -}}
+{{- end -}}
+{{- $caption := .Get "caption" -}}
+{{- $alt := or (.Get "alt") $caption -}}
+{{- /* src may be a full Cloudinary URL or a bare public ID; cloudinary-url.html handles both. */ -}}
+{{- $display := partial "cloudinary-url.html" (dict "src" $src "preset" "figure") -}}
+{{- $lightbox := partial "cloudinary-url.html" (dict "src" $src "preset" "lightbox") -}}
+<figure class="not-prose my-8">
+  <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $caption }} data-description="{{ . }}"{{ end }}>
+    <img src="{{ $display }}" alt="{{ $alt }}" loading="lazy" class="w-full rounded-xl bg-gray-50">
+  </a>
+  {{- with $caption }}
+  <figcaption class="mt-3 text-center text-sm/6 text-gray-500">{{ . }}</figcaption>
+  {{- end }}
+</figure>


### PR DESCRIPTION
## Summary

- Adds the `figure` shortcode — the **fourth and final** of Phase 6's shortcodes — an inline Cloudinary image that's clickable to a larger lightbox view.
- Completes Phase 6 (Shortcodes): `button`, `svg`, `callout`, `figure` all built and tested.

## Changes

- **New `layouts/shortcodes/figure.html`**: `{{< figure src caption alt >}}`.
  - Inline `<img>` served at `w_768` (article body width) for light pages; wrapping `<a>` links to a larger `w_1600` version for the lightbox zoom.
  - Emits lightbox-compatible markup (`class="glightbox" data-gallery="article" data-description="…"`) — GLightbox itself is wired up in Phase 13; this is forward-compatible.
  - `loading="lazy"`; `not-prose` so it matches the cover figure in `single.html` exactly; centered figcaption.
  - `figcaption`/`data-description` rendered only when `caption` is set; `alt` falls back to `caption`.
- **`layouts/partials/cloudinary-url.html`**:
  - Added `figure` (`w_768`) and `lightbox` (`w_1600`) presets.
  - The partial now expands a **bare public ID** into a full Cloudinary URL (`{cloudinaryBase}/image/upload/{id}`) so `src` accepts both full URLs and public IDs — and the helper owns that contract for all callers. Backward-compatible: full `https://` URLs skip the new branch unchanged.
- **`docs/prd/CHANGELOG.md`**: logged the preset deviation (display uses `w_768`, not the uncapped `article` preset the issue note named).
- **ROADMAP**: marked `figure.html` + "All shortcodes tested" complete; Phase 6 status → Complete.

## Testing

- [x] Production build passes (`hugo --gc --minify`), no warnings
- [x] Manual (temp draft, then removed): full Cloudinary URL **and** bare public ID both produce correct `w_768` display + `w_1600` lightbox URLs; caption present → figcaption + `data-description`; no caption → both omitted, `alt=""`; alt falls back to caption
- [x] Verified the shared-partial change is backward-compatible: existing cover callers (`single.html` `article` preset, `article-card.html` `featured`/`regular`) render identical URLs
- [x] `/simplify` (moved public-ID handling into the partial) and `/code-review medium` (no findings) both run

## Notes

- **Deviation (logged in CHANGELOG):** display uses the new `w_768` `figure` preset, not the uncapped `article` preset. Confirmed with Joshua against the current Nuxt blog: inline body images use ~768px to keep pages light, and the lightbox is the larger/zoom path. The cover image (separate, in `single.html`) is unaffected.
- **GLightbox activation** (CSS/JS + `partials/glightbox.html`) is Phase 13; this PR only emits compatible markup.
- **Detection assumption:** `hasPrefix $src "http"` distinguishes full URL from public ID; all `cover` values and migration output are lowercase `https://`, so protocol-relative/uppercase schemes (which would misclassify) don't occur.

Closes #44
