### PR TITLE
feat: add outline variant and layout defaults to button shortcode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ All images are on Cloudinary — no local image processing. The `partials/cloudi
 |-----------|-------|
 | `figure`  | `{{</* figure src="..." caption="..." alt="..." */>}}` — Cloudinary image with GLightbox |
 | `callout` | `{{</* callout pdf="file.pdf" */>}}Content{{</* /callout */>}}` — highlighted box with optional PDF link |
-| `button`  | `{{</* button href="..." text="..." */>}}` — styled CTA link |
+| `button`  | `{{</* button href="..." text="..." */>}}` — CTA link; `outline=true` for the secondary variant, `external=true` for a new tab, `align="left"` to opt out of centering (centered by default) |
 | `svg`     | `{{</* svg name="logo-name" */>}}` — inline SVG from `assets/img/` |
 
 ## Tailwind Plus Workflow

--- a/docs/prd/05-shortcodes.md
+++ b/docs/prd/05-shortcodes.md
@@ -88,14 +88,31 @@ Get the full newsletter PDF.
 
 ## Button Shortcode
 
-**Purpose:** Styled CTA link.
+**Purpose:** Styled CTA link, in a filled-primary or outline/secondary variant.
 
 **Usage:**
 
 ```text
 {{< button href="/donate/" text="Support Our Ministry" >}}
-{{< button href="https://example.com" text="Visit Site" external=true >}}
+{{< button href="https://example.com" text="Visit Site" outline=true external=true >}}
+{{< button href="/blog/" text="Read more" align="left" >}}
 ```
+
+**Params:**
+
+- `href` (required) — destination URL
+- `text` (required) — visible label
+- `outline` — `true` renders the outline/secondary variant (default is filled primary)
+- `external` — `true` opens in a new tab (adds `rel="noopener noreferrer"`, an external-link icon, and a screen-reader "opens in a new tab" note)
+- `align` — `left` left-aligns the button (centered by default)
+
+**Notes:**
+
+- A layout wrapper `<div>` owns placement — standalone CTAs are centered with
+  vertical spacing (`my-6 md:my-8`) by default; `align="left"` opts out. The
+  button's appearance (variant) lives on the `<a>`. (The legacy `<article-button>`
+  Vue component's per-instance `margin`/`center` props are lifted into these
+  defaults; see `06-content-migration.md`.)
 
 ---
 

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,15 +1,24 @@
 {{- /*
-  button — styled CTA link (filled primary).
+  button — styled CTA link.
+
+  Filled-primary by default, or an outline/secondary variant with outline=true.
+  A layout wrapper <div> owns placement: standalone CTAs almost always want
+  vertical breathing room and centering, so both are defaults — use align="left"
+  to opt out of centering. (The button's appearance lives on the <a>; its
+  placement lives on the wrapper.)
 
   Params:
     href     (required) destination URL
     text     (required) visible label
+    outline  (optional) "true" renders the outline/secondary variant
     external (optional) "true" opens in a new tab — adds rel="noopener noreferrer",
                         an external-link icon, and a screen-reader "opens in a new tab" note
+    align    (optional) "left" left-aligns the button (centered by default)
 
   Usage:
     {{< button href="/donate/" text="Support Our Ministry" >}}
-    {{< button href="https://example.com" text="Visit Site" external=true >}}
+    {{< button href="https://example.com" text="Visit Site" outline=true external=true >}}
+    {{< button href="/blog/" text="Read more" align="left" >}}
 */ -}}
 {{- $href := .Get "href" -}}
 {{- $text := .Get "text" -}}
@@ -19,15 +28,20 @@
 {{- if not $text -}}
   {{- errorf "button shortcode: 'text' param is required (%s)" .Position -}}
 {{- end -}}
-{{- /* Hugo parses unquoted external=true as a bool; normalize to compare either form. */ -}}
+{{- /* Hugo parses an unquoted true as a bool; normalize to compare either form. */ -}}
+{{- $outline := eq (printf "%v" (.Get "outline")) "true" -}}
 {{- $external := eq (printf "%v" (.Get "external")) "true" -}}
-<a
-  href="{{ $href }}"
-  class="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition-colors hover:bg-blue-700"
-  {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
->
-  {{- $text -}}
-  {{- if $external -}}
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg><span class="sr-only">(opens in a new tab)</span>
-  {{- end -}}
-</a>
+{{- $center := ne (.Get "align") "left" -}}
+{{- $variant := cond $outline "text-blue-700 ring-1 ring-inset ring-blue-700/30 hover:bg-blue-50" "bg-blue-600 text-white shadow-sm hover:bg-blue-700" -}}
+<div class="my-6 md:my-8{{ if $center }} text-center{{ end }}">
+  <a
+    href="{{ $href }}"
+    class="inline-flex items-center gap-1.5 rounded-md px-4 py-2.5 text-sm font-semibold no-underline transition-colors {{ $variant }}"
+    {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
+  >
+    {{- $text -}}
+    {{- if $external -}}
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg><span class="sr-only">(opens in a new tab)</span>
+    {{- end -}}
+  </a>
+</div>


### PR DESCRIPTION
## Summary

- Extends the `button` shortcode with an **outline/secondary variant** and **sensible layout defaults**, so it can faithfully replace the legacy `<article-button>` Vue component in the Phase 15 migration.
- A survey of the Nuxt source content found **14 `<article-button>` usages across 10 articles**, and **every one** uses `:outline="true"` + `:external="true"` + a `margin`, with ~10/14 centered — i.e. the original filled-primary-only shortcode would have mis-rendered all of them.

## Changes

- **`layouts/shortcodes/button.html`:**
  - `outline=true` → outline/secondary variant (`text-blue-700 ring-1 ring-inset ring-blue-700/30 hover:bg-blue-50`); filled primary stays the default.
  - A layout wrapper `<div>` owns placement: standalone CTAs are **centered** with vertical spacing (`my-6 md:my-8`) **by default**; `align="left"` opts out. The button's appearance (variant) lives on the `<a>`.
  - The Vue component's per-instance `margin`/`center` props are lifted into these defaults (the `margin` prop is dropped — spacing is automatic).
  - `external` behavior and the required `href`/`text` guards are unchanged.
- **`CLAUDE.md`** and **`docs/prd/05-shortcodes.md`:** documented the variants, default centering/spacing, and `align` opt-out.

## Testing

- [x] Production build passes (`hugo --gc --minify`), no warnings
- [x] Manual (temp draft, then removed): verified all four combinations — filled/outline × centered/`align="left"`, plus internal/external. Wrapper carries `my-6 md:my-8` (+ `text-center` unless `align="left"`); the `<a>` carries the correct variant classes; external adds `target`/`rel` + icon + sr-only note.
- [x] Confirmed Tailwind generated the new outline classes (`ring-inset`, `ring-blue-700/30`, `ring-1`) and layout classes (`my-6`, `md:my-8`, `text-center`).
- [x] `/simplify` pass applied (positive `$center` over a double-negative `$alignLeft`); reuse/efficiency/altitude confirmed clean.

## Notes

- **Design rationale:** layout and appearance are deliberately separated — the wrapper owns *where the button sits*, the `<a>` owns *what it looks like*. This is simpler than the Vue component (which put margin classes on the `<a>` and required every caller to specify `margin`/`center`): the common case (centered, spaced) is now free, and the param surface drops from 5 props to `href`/`text`/`outline`/`external`/`align`.
- **Phase 15 migration mapping** (recorded in #49): `<article-button … :outline :center :external margin>` → `{{< button href text outline=true external=true >}}`; `center`/`margin` collapse into defaults; the 4 originally-left-aligned buttons (`getbiblefirst.com`, `euroteamoutreach.org`, `cmoproject.org`, "Donate Online") get `align="left"` to preserve intent.

Closes #49
