### PR TITLE
feat: add tag term template for single-tag article listing

### DIFF
--- a/docs/prd/03-site-structure.md
+++ b/docs/prd/03-site-structure.md
@@ -59,8 +59,8 @@ ofreport.com/
 │   │   ├── button.html          # Styled CTA link
 │   │   └── svg.html             # Inline SVG from assets
 │   ├── taxonomy/
-│   │   ├── tag.html             # Single tag page (articles with that tag)
-│   │   └── tags.html            # All tags listing page
+│   │   ├── taxonomy.html        # All tags listing page (taxonomy kind)
+│   │   └── term.html            # Single tag page (articles with that tag)
 │   └── 404.html                 # Custom 404 page
 ├── static/
 │   ├── favicon.ico

--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,7 +34,13 @@ Each entry records one deviation or decision:
 
 ## Entries
 
-*No open entries — all deviations through Phase 6 have been folded back into the PRD.*
+### 2026-06-04 — `docs/prd/03-site-structure.md`, `docs/prd/ROADMAP.md`
+
+**What changed:** Renamed the Phase 7 taxonomy templates from `taxonomy/tags.html` / `taxonomy/tag.html` to `taxonomy/taxonomy.html` (all-tags index) and `taxonomy/term.html` (single-tag list).
+
+**Why:** The original names don't match Hugo's template lookup. `tags.html` (plural) is never looked up and would silently fall through to `_default/list.html`; `tag.html` (singular) is ambiguous because it matches both the `taxonomy` and `term` page kinds, so one file can't reliably render both the index and the per-tag pages. `taxonomy.html` (taxonomy kind) and `term.html` (term kind) are the correct, unambiguous Hugo names.
+
+**Category:** Correction
 
 <!--
   Folded into the PRD on 2026-06-04 (end of Phase 6):

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -92,10 +92,10 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 7: Tag Taxonomy
 
-- [ ] `taxonomy/tags.html` — all tags listing with article counts
-- [ ] `taxonomy/tag.html` — articles filtered by tag with pagination
-- [ ] Tag badges link to tag pages
-- [ ] Tag URLs: `/tags/`, `/tags/{tag}/`, `/tags/{tag}/page/2/`
+- [ ] `taxonomy/taxonomy.html` — all tags listing with article counts
+- [x] `taxonomy/term.html` — articles filtered by tag with pagination
+- [x] Tag badges link to tag pages
+- [x] Tag URLs: `/tags/`, `/tags/{tag}/`, `/tags/{tag}/page/2/`
 
 **Key learning:** Hugo taxonomies, taxonomy list/term templates
 

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -1,0 +1,28 @@
+{{ define "main" }}
+  <div class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+      <div class="mx-auto max-w-2xl lg:max-w-4xl">
+        {{- $count := len .Pages -}}
+        <p class="text-base/7 font-semibold text-blue-600">Tag</p>
+        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-header">
+          {{ .Title }}
+        </h1>
+        <p class="mt-2 text-lg/8 text-gray-600">
+          {{ $count }} {{ cond (eq $count 1) "article" "articles" }} tagged &ldquo;{{ .Data.Term }}&rdquo;.
+        </p>
+
+        {{- $paginator := .Paginate .Pages -}}
+
+        <div class="mt-16 lg:mt-20">
+          <div class="grid grid-cols-1 gap-x-8 gap-y-20 md:grid-cols-2">
+            {{- range $paginator.Pages }}
+              {{ partial "article-card.html" (dict "page" . "featured" false) }}
+            {{- end }}
+          </div>
+        </div>
+
+        {{ partial "pagination.html" . }}
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds `layouts/taxonomy/term.html` so single-tag pages (`/tags/{tag}/`) render with the site's real design instead of the bare `_default/list.html` fallback.
- Reuses the existing `article-card.html` grid and `pagination.html`, mirroring the blog listing minus the featured-first treatment.
- Corrects a PRD naming error: the Phase 7 templates are `taxonomy/taxonomy.html` (all-tags index) and `taxonomy/term.html` (single-tag list), matching Hugo's template lookup.

## Changes

**feat**

- New `layouts/taxonomy/term.html`: "Tag" eyebrow, capitalized tag-name `<h1>` (`.Title`), an article-count line with correct singular/plural wording, the shared 2-column `article-card` grid, and pagination.

**docs**

- `docs/prd/03-site-structure.md` + `docs/prd/ROADMAP.md`: renamed `taxonomy/tags.html` → `taxonomy/taxonomy.html` and `taxonomy/tag.html` → `taxonomy/term.html`. The old names don't match Hugo's lookup (the plural is never resolved; the singular is ambiguous across the `taxonomy` and `term` page kinds).
- `docs/prd/CHANGELOG.md`: logged the rename as a **Correction**.
- `docs/prd/ROADMAP.md`: marked the term template, tag-badge links, and tag URLs complete for Phase 7. The all-tags index template remains open (tracked in #52).

## Testing

- [x] `hugo --gc --minify` builds clean — no errors or warnings (29 pages).
- [x] All five term pages render with the new grid and correct counts (family 5, good-and-evil 1, ministry 6, newsletter 4, photos 2).
- [x] Singular/plural wording verified ("1 article" vs "6 articles"); hyphenated term title-cases to "Good-and-Evil".
- [x] No regressions in the blog list, single article, or the `/tags/` index (still on the fallback until #52).

## Notes

- Pagination uses the same `.Paginate .Pages` + `pagination.html` mechanism proven on the blog list in Phase 4. It couldn't be exercised end-to-end here because no tag exceeds `pagerSize = 8` (max is 6), so `/tags/{tag}/page/2/` isn't demonstrable with current test content — structurally sound, just not visually shown.
- The `/tags/` index is currently only reachable by URL ("Tags" isn't in the main nav, per the PRD). Flagged for a later decision, out of scope here.

Closes #51
