### PR TITLE
feat: add all-tags index template

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -15,7 +15,7 @@ links to the relevant PRD document for full requirements.
 | 4 | Blog Listing with Pagination | Phase 3 | Complete |
 | 5 | Single Article Template | Phase 3 | Complete |
 | 6 | Shortcodes | Phase 5 | Complete |
-| 7 | Tag Taxonomy | Phase 4 | Not started |
+| 7 | Tag Taxonomy | Phase 4 | Complete |
 | 8 | Static Pages | Phase 3 | Not started |
 | 9 | RSS Feed | Phase 5 | Not started |
 | 10 | SEO & Meta Tags | Phase 3 | Not started |
@@ -92,7 +92,7 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 7: Tag Taxonomy
 
-- [ ] `taxonomy/taxonomy.html` — all tags listing with article counts
+- [x] `taxonomy/taxonomy.html` — all tags listing with article counts
 - [x] `taxonomy/term.html` — articles filtered by tag with pagination
 - [x] Tag badges link to tag pages
 - [x] Tag URLs: `/tags/`, `/tags/{tag}/`, `/tags/{tag}/page/2/`

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+  <div class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+      <div class="mx-auto max-w-2xl lg:max-w-4xl">
+        {{- $tagCount := len .Data.Terms -}}
+        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-header">
+          {{ .Title }}
+        </h1>
+        <p class="mt-2 text-lg/8 text-gray-600">
+          {{ $tagCount }} {{ cond (eq $tagCount 1) "tag" "tags" }} across the blog.
+        </p>
+
+        <div class="mt-10 flex flex-wrap gap-3">
+          {{- range .Data.Terms.Alphabetical }}
+            <a
+              href="{{ .Page.RelPermalink }}"
+              class="inline-flex items-center gap-x-2 rounded-full bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
+            >
+              {{ .Term }}
+              <span class="text-xs text-blue-700/60">{{ .Count }}</span>
+            </a>
+          {{- end }}
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds `layouts/taxonomy/taxonomy.html` so `/tags/` renders a browsable tag index instead of the bare `_default/list.html` fallback.
- Lists every tag alphabetically as a flex-wrap of badges, each linking to its term page and showing its article count.
- Completes Phase 7 (Tag Taxonomy) — both the term template (#51) and this index are now in place.

## Changes

**feat**

- New `layouts/taxonomy/taxonomy.html`: an `<h1>` "Tags" heading, a total-count subtitle with correct singular/plural wording, and an alphabetical badge grid built from `.Data.Terms.Alphabetical` (each badge → `.Page.RelPermalink` with `.Term` + `.Count`). Reuses the blue-badge styling and page container established by the term template.

**docs**

- `docs/prd/ROADMAP.md`: checked off the all-tags index item and marked Phase 7 `Complete` in the phase overview table.

## Testing

- [x] `hugo --gc --minify` builds clean — no errors or warnings.
- [x] Index renders 5 alphabetical badges (family, good-and-evil, ministry, newsletter, photos) with counts matching the known distribution (5, 1, 6, 4, 2).
- [x] Each badge links to the correct `/tags/{tag}/` term page; labels and counts render.
- [x] No regressions in term pages, the blog list, or single articles.

## Notes

- Tags are ordered alphabetically (`.Data.Terms.Alphabetical`) — the conventional ordering for a tag index. `ByCount` is the easy alternative if a popularity-first ordering is ever preferred.
- The `/tags/` index is reachable by URL but not yet linked from the main nav (per the PRD nav list). Left as a future decision, consistent with #51.

Closes #52
