### PR TITLE
feat: add default single-page template and Family page

### DIFF
--- a/content/family.md
+++ b/content/family.md
@@ -1,0 +1,26 @@
+---
+title: "Family"
+description: >-
+  Joshua and Kelsie are missionaries enjoying life as best friends, serving
+  their Savior, and raising up their children to honor Him.
+---
+
+Joshua and Kelsie are missionaries enjoying life as best friends, serving their Savior, and raising up their children to honor Him.
+
+Joshua has been ministering in Ukraine since 2001, and has also served in Mexico, Hong Kong, Thailand and the United States. Kelsie took part in mission trips to Taiwan, Mexico, and Romania prior to her calling as a wife and mother. She and Joshua were married on September 18, 2004, after which they returned to Ukraine as a couple.
+
+Joshua and Kelsie are founding members of [Euro Team Outreach](https://euroteamoutreach.org/) and coauthors of [Bible First](https://getbiblefirst.com/). During the summer months, Joshua leads ETO’s [Carpathian Mountain Outreach](https://cmoproject.org/), preaching the Gospel in the Ukrainian language in mountain villages. He also preaches regularly at various local churches in L’viv.
+
+Kelsie oversees the training and schooling for their six children: Abigail, Rebekah, Hosanna, Kathryn, David, and Mia. Additionally, she enjoys writing on [Substack](https://kelsiesteele.substack.com/).
+
+The Steeles currently reside in L’viv, Ukraine. Both Joshua and Kelsie speak the Ukrainian language fluently and are actively involved in the lives of the Ukrainian people.
+
+---
+
+**Sending Church**
+
+Fairpark Baptist Church  
+6000 Crowley Road  
+Fort Worth, TX 76134  
+
+[www.FairparkBaptist.org](http://www.fairparkbaptist.org/)

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -16,7 +16,7 @@ links to the relevant PRD document for full requirements.
 | 5 | Single Article Template | Phase 3 | Complete |
 | 6 | Shortcodes | Phase 5 | Complete |
 | 7 | Tag Taxonomy | Phase 4 | Complete |
-| 8 | Static Pages | Phase 3 | Not started |
+| 8 | Static Pages | Phase 3 | In progress |
 | 9 | RSS Feed | Phase 5 | Not started |
 | 10 | SEO & Meta Tags | Phase 3 | Not started |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
@@ -101,7 +101,7 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 8: Static Pages
 
-- [ ] Family page (`/family/`)
+- [x] Family page (`/family/`)
 - [ ] Ministry page (`/ministry/`) with SVG logos
 - [ ] Podcast page (`/podcast/`) with Buzzsprout embed
 - [ ] Archives page (`/archives/`) using `data/archives.json`

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+  <div class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+
+      {{/* Page title */}}
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+        {{- .Title -}}
+      </h1>
+
+      {{/* Page content */}}
+      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
+        {{ .Content }}
+      </div>
+
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds `layouts/_default/single.html`, the foundational template that renders Hugo "regular pages" (static pages) — establishing the title + prose pattern reused across Phase 8.
- Adds the Family page (`/family/`), the first static page, ported from the old Nuxt site — fixing the live 404 the header/footer nav pointed at.
- Kicks off Phase 8 (Static Pages) and unblocks the Donate, Ministry, and Podcast pages, which all render through this template.

## Changes

**feat**

- `layouts/_default/single.html`: new default single-page template. Reuses `blog/single.html`'s reading column (`max-w-3xl`), title styling (`font-header`, `text-4xl`/`sm:text-5xl`), and prose classes; omits the cover/meta/tags/nav. Wrapped in a plain `<div>` (not `<article>`) since these are static pages and `<main>` is already the landmark.
- `content/family.md`: new Family page — `title` + `description` (meta ported from the old page) + body ported verbatim from the Nuxt source (external links, `---` divider, and the bolded "Sending Church" address block with hard line breaks).

**docs**

- `docs/prd/ROADMAP.md`: checked off the Family page item and set Phase 8 to "In progress".

## Testing

- [x] `hugo --gc --minify` builds clean — 30 pages, no errors or warnings
- [x] `/family/` renders at the correct URL (no 404) with a styled `<h1>Family</h1>` and prose content
- [x] `---` divider renders as `<hr>`; the "Sending Church" address renders with `<br>` hard breaks
- [x] All four content links (ETO, Bible First, CMO, Substack) plus the Fairpark church link render and open correctly
- [x] Curly apostrophe in "L’viv" preserved

## Notes

- `<div>` vs `<article>`: a blog post is a self-contained composition (`<article>`), but a static bio page is just page content inside the `<main>` landmark, so a plain `<div>` is the more accurate semantics.
- `description` frontmatter is included now (ported from the old page's meta) so the Phase 10 SEO partial will have it to consume — no SEO behavior is wired up in this PR.

Closes #55
