### PR TITLE
feat: add Donate page

### DIFF
--- a/content/donate.md
+++ b/content/donate.md
@@ -1,0 +1,23 @@
+---
+title: "Donate"
+description: >-
+  If you would like to make a financial contribution, please choose from one
+  of the options below. We are grateful for your kindness and generosity!
+---
+
+If you would like to make a financial contribution, please choose from one of the options below. We are grateful for your kindness and generosity!
+
+## Option 1 - Donate online
+
+Click the button below to make a donation online via PayPal.
+
+{{< button text="Donate Online" href="https://www.paypal.me/joshukraine" outline=true external=true >}}
+
+## Option 2 - Donate by mail
+
+Send a check, payable to **Fairpark Baptist Church**, to the following address:
+
+> **Fairpark Baptist Church  
+> ATTN: Steele Family Missions  
+> 6000 Crowley Rd.  
+> Fort Worth, TX 76134**

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -105,7 +105,7 @@ links to the relevant PRD document for full requirements.
 - [ ] Ministry page (`/ministry/`) with SVG logos
 - [ ] Podcast page (`/podcast/`) with Buzzsprout embed
 - [ ] Archives page (`/archives/`) using `data/archives.json`
-- [ ] Donate page (`/donate/`)
+- [x] Donate page (`/donate/`)
 - [ ] Subscribe page (`/subscribe/`) with Mailchimp form
 
 **Key learning:** Content sections, page-specific templates


### PR DESCRIPTION
## Summary

- Adds the Donate page (`/donate/`), the second Phase 8 static page, ported from the old Nuxt site — fixing the live 404 the nav already pointed at.
- Pure markdown rendered through the `_default/single.html` template from #55; reuses the existing `button` shortcode for the PayPal CTA.

## Changes

**feat**

- `content/donate.md`: new Donate page — `title` + `description` (ported meta) and two giving options. Option 1 is an online PayPal CTA via `{{< button … outline=true external=true >}}` (the old `<article-button … path=…>` converted to the `href` param); Option 2 is a mail option with the bolded church address as a multi-line blockquote.

**docs**

- `docs/prd/ROADMAP.md`: checked off the Donate page item under Phase 8.

## Testing

- [x] `hugo --gc --minify` builds clean — no errors or warnings
- [x] `/donate/` renders at the correct URL (no 404) with a styled `<h1>Donate</h1>`
- [x] Both `<h2>` option headings render
- [x] PayPal button renders with the outline variant and `target=_blank rel="noopener noreferrer"` (opens in a new tab)
- [x] Address renders as a blockquote with `<strong>` spanning all four lines via `<br>` hard breaks
- [x] `markdownlint-cli2` passes — 0 errors

## Notes

- Dropped the old button's `margin="t"` prop — the `button` shortcode already owns its vertical spacing (`my-6 md:my-8`) and centers standalone CTAs by default, which is the intended pattern for this page.

Closes #56
