### PR TITLE
feat: add Podcast page

### DIFF
--- a/content/podcast.md
+++ b/content/podcast.md
@@ -1,0 +1,18 @@
+---
+title: "Podcast"
+description: >-
+  Journey to Ukraine is a podcast by Joshua and Kelsie Steele, sharing stories
+  of serving God and ministering to Ukrainians affected by the war.
+---
+
+{{< image src="OFReport/assets/logo_horiz_centered_jp0r8k.png" alt="Journey to Ukraine" class="mx-auto block h-auto w-[480px] max-w-full" >}}
+
+{{< callout >}}
+A podcast by Joshua and Kelsie Steele
+{{< /callout >}}
+
+In March of 2022, our family was forced to evacuate from Ukraine. We have served as missionaries in L’viv for over 20 years, and now, like so many others, we find ourselves suddenly displaced from our home, our church, and our precious Ukrainian friends. But despite the shock of evacuation, God is opening doors and leading us step by step down this new path. Our purpose is to bless and minister to Ukrainians affected by the war. Come with us as we share our stories: striving to serve God, bless people, and praying that someday soon this journey will lead us back to our beloved Ukraine.
+
+{{< button text="Subscribe now!" href="https://journeytoukraine.buzzsprout.com/" outline=true external=true >}}
+
+<div id='buzzsprout-large-player'></div><script type='text/javascript' charset='utf-8' src='https://www.buzzsprout.com/1953515.js?container_id=buzzsprout-large-player&player=large'></script>

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -103,7 +103,7 @@ links to the relevant PRD document for full requirements.
 
 - [x] Family page (`/family/`)
 - [x] Ministry page (`/ministry/`) with SVG logos
-- [ ] Podcast page (`/podcast/`) with Buzzsprout embed
+- [x] Podcast page (`/podcast/`) with Buzzsprout embed
 - [ ] Archives page (`/archives/`) using `data/archives.json`
 - [x] Donate page (`/donate/`)
 - [ ] Subscribe page (`/subscribe/`) with Mailchimp form

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,0 +1,25 @@
+{{- /*
+  image — plain Cloudinary <img>, with no lightbox or caption.
+
+  For logos and images that shouldn't be click-to-zoom — that's what the figure
+  shortcode is for. The URL is built through cloudinary-url.html so the transform
+  stays centralized and no hardcoded Cloudinary URLs leak into content.
+
+  Sizing/placement is left to the caller via class (prose supplies the vertical
+  margins), the same way ministry.md sizes its inline SVGs.
+
+  Params:
+    src   (required) full Cloudinary URL OR a bare public ID
+    alt   (optional) alt text; defaults to ""
+    class (optional) utility classes on the <img>
+
+  Usage:
+    {{< image src="OFReport/assets/logo.png" alt="Logo" class="mx-auto block w-[480px] max-w-full" >}}
+*/ -}}
+{{- $src := .Get "src" -}}
+{{- if not $src -}}
+  {{- errorf "image shortcode: 'src' param is required (%s)" .Position -}}
+{{- end -}}
+{{- $alt := .Get "alt" | default "" -}}
+{{- $url := partial "cloudinary-url.html" (dict "src" $src "preset" "figure") -}}
+<img src="{{ $url }}" alt="{{ $alt }}" loading="lazy"{{ with .Get "class" }} class="{{ . }}"{{ end }}>


### PR DESCRIPTION
## Summary

- Adds the Podcast page at `/podcast/`, resolving the existing 404 (Phase 8, Static Pages).
- Ports the page from the Nuxt source: "Journey to Ukraine" logo, intro copy, a `callout`, a subscribe `button`, and the raw Buzzsprout large-player embed.
- Introduces a small, reusable `image` shortcode for plain Cloudinary images (logos) so Cloudinary URLs stay out of content.

## Changes

- **`layouts/shortcodes/image.html`** (new) — emits a plain `<img>` through the existing `cloudinary-url` partial. No lightbox or caption (that's what `figure` is for); sizing/placement is left to a `class` passthrough, mirroring how `ministry.md` sizes its inline SVGs.
- **`content/podcast.md`** (new) — logo (via the new `image` shortcode) → `callout` → intro paragraph → outline/external `button` → verbatim Buzzsprout `<div>`+`<script>` embed. The Nuxt `<article-spacer>` elements were dropped (shortcodes carry their own margins).
- **`docs/prd/ROADMAP.md`** — marked the Phase 8 "Podcast page" item complete.

## Implementation notes

- **Logo rendering:** content markdown can't call the `cloudinary-url` partial directly, so it needs a shortcode. Rather than reuse `figure` (which wraps images in a GLightbox zoom link with `rounded-xl bg-gray-50` — photo semantics that are wrong for a logo), this adds a dedicated plain-image shortcode.
- **Buzzsprout embed:** ported verbatim. Verified the `<script>` survives Goldmark (`unsafe = true`) and the `&` in the script `src` stays literal/unescaped (zero `&amp;`), so the player loads. The HTML minifier strips the no-op `charset='utf-8'` attribute, which browsers ignore on an external script — no functional impact.

## Testing

- [x] Production build passes (`hugo --gc --minify`) — 33 pages, no errors
- [x] `public/podcast/index.html` exists (no 404)
- [x] Logo, callout, and outline+external subscribe button render correctly
- [x] Buzzsprout embed survives rendering with an unescaped `&`

Closes #58
