### PR TITLE
feat: add Archives page

### DIFF
--- a/content/archives.md
+++ b/content/archives.md
@@ -1,0 +1,13 @@
+---
+title: "Archives"
+layout: archives
+description: >-
+  Since 2003 we have published Overseas Field Report, a newsletter chronicling
+  the history of our ministry overseas. Browse and download every issue here.
+---
+
+Since 2003, we have published a newsletter called *Overseas Field Report*. If you're interested in reading the history of our ministry overseas, you've come to the right place!
+
+God has been — and remains today — our faithful Shepherd: guiding our steps, providing for our needs, and demonstrating His power in ways that continue to astonish and bless us. We hope that our story will encourage you to place your complete trust in Him. He is faithful!
+
+*"O taste and see that the LORD is good: blessed is the man that trusteth in him." (Psalms 34:8)*

--- a/content/archives.md
+++ b/content/archives.md
@@ -1,5 +1,6 @@
 ---
 title: "Archives"
+heading: "Through the Years"
 layout: archives
 description: >-
   Since 2003 we have published Overseas Field Report, a newsletter chronicling

--- a/data/archives.json
+++ b/data/archives.json
@@ -1,0 +1,467 @@
+{
+  "2026": [
+    {
+      "title": "Teaching, Serving, Standing",
+      "issue": "Apr/May 2026",
+      "file": "OFR-Apr-May-2026.pdf"
+    }
+  ],
+  "2025": [
+    {
+      "title": "Announcing Ukraine Gospel Outreach",
+      "issue": "Jul/Aug 2025",
+      "file": "OFR-Jul-Aug-2025.pdf"
+    }
+  ],
+  "2024": [
+    {
+      "title": "The November Project",
+      "issue": "Nov/Dec 2024",
+      "file": "OFR-Nov-Dec-2024.pdf"
+    },
+    {
+      "title": "Of Books, Baptisms, and Blessings",
+      "issue": "Sep/Oct 2024",
+      "file": "OFR-Sep-Oct-2024.pdf"
+    }
+  ],
+  "2023": [
+    {
+      "title": "Ministry and Family in Time of War",
+      "issue": "Nov/Dec 2023",
+      "file": "OFR-Nov-Dec-2023.pdf"
+    }
+  ],
+  "2022": [
+    {
+      "title": "The Body of Christ",
+      "issue": "Nov/Dec 2022",
+      "file": "OFR-Nov-Dec-2022.pdf"
+    },
+    {
+      "title": "Yellow Blue Bus",
+      "issue": "May/Jun 2022",
+      "file": "OFR-May-Jun-2022.pdf"
+    }
+  ],
+  "2021": [
+    {
+      "title": "Shindigs and Such",
+      "issue": "Sep–Dec 2021",
+      "file": "OFR-Sep-Dec-2021.pdf"
+    },
+    {
+      "title": "Return to the Mountains",
+      "issue": "Jul/Aug 2021",
+      "file": "OFR-Jul-Aug-2021.pdf"
+    },
+    {
+      "title": "Bible First Pioneers",
+      "issue": "Apr-Jun 2021",
+      "file": "OFR-Apr-Jun-2021.pdf"
+    }
+  ],
+  "2020": [
+    {
+      "title": "A Time to Write",
+      "issue": "Aug-Dec 2020",
+      "file": "OFR-Aug-Dec-2020.pdf"
+    },
+    {
+      "title": "Standing in the Gap",
+      "issue": "Apr-Jul 2020",
+      "file": "OFR-Apr-Jul-2020.pdf"
+    },
+    {
+      "title": "L’viv Angels",
+      "issue": "Jan–Mar 2020",
+      "file": "OFR-Jan-Mar-2020.pdf"
+    }
+  ],
+  "2019": [
+    {
+      "title": "Kade to Ukraine",
+      "issue": "Nov/Dec 2019",
+      "file": "OFR-Nov-Dec-2019.pdf"
+    },
+    {
+      "title": "Meet Mia",
+      "issue": "Jul-Sep 2019",
+      "file": "OFR-Jul-Sep-2019.pdf"
+    },
+    {
+      "title": "Calm Before the Storm",
+      "issue": "Apr-Jun 2019",
+      "file": "OFR-Apr-Jun-2019.pdf"
+    },
+    {
+      "title": "Operation Library",
+      "issue": "Jan-Mar 2019",
+      "file": "OFR-Jan-Mar-2019.pdf"
+    }
+  ],
+  "2018": [
+    {
+      "title": "A Chapter of Blessing",
+      "issue": "Oct–Dec 2018",
+      "file": "OFR-Oct-Dec-2018.pdf"
+    },
+    {
+      "title": "Vision to Reality",
+      "issue": "Aug/Sep 2018",
+      "file": "OFR-Aug-Sep-2018.pdf"
+    },
+    {
+      "title": "Sharpening Arrows",
+      "issue": "May/Jun 2018",
+      "file": "OFR-May-Jun-2018.pdf"
+    },
+    {
+      "title": "Two Robes",
+      "issue": "Jan/Feb 2018",
+      "file": "OFR-Jan-Feb-2018.pdf"
+    }
+  ],
+  "2017": [
+    {
+      "title": "Grab Bag Report",
+      "issue": "Oct–Dec 2017",
+      "file": "OFR-Oct-Dec-2017.pdf"
+    },
+    {
+      "title": "A Chance to Give Back",
+      "issue": "Jul/Aug 2017",
+      "file": "OFR-Jul-Aug-2017.pdf"
+    },
+    {
+      "title": "Bible First Kids",
+      "issue": "May/Jun 2017",
+      "file": "OFR-May-Jun-2017.pdf"
+    },
+    {
+      "title": "Meet David Noble",
+      "issue": "Mar/Apr 2017",
+      "file": "OFR-Mar-Apr-2017.pdf"
+    }
+  ],
+  "2016": [
+    {
+      "title": "Translators, Inc.",
+      "issue": "Nov/Dec 2016",
+      "file": "OFR-Nov-Dec-2016.pdf"
+    },
+    {
+      "title": "Platform Rising",
+      "issue": "Sep/Oct 2016",
+      "file": "OFR-Sep-Oct-2016.pdf"
+    },
+    {
+      "title": "Parenting Seminar",
+      "issue": "Jan-Mar, 2016",
+      "file": "OFR-Jan-Mar-2016.pdf"
+    }
+  ],
+  "2015": [
+    {
+      "title": "Meet Oleg",
+      "issue": "Nov/Dec 2015",
+      "file": "OFR-Nov-Dec-2015.pdf"
+    },
+    {
+      "title": "Gaining New Ground",
+      "issue": "Sep/Oct 2015",
+      "file": "OFR-Sep-Oct-2015.pdf"
+    },
+    {
+      "title": "When God Provides",
+      "issue": "Mar/Apr 2015",
+      "file": "OFR-Mar-Apr-2015.pdf"
+    },
+    {
+      "title": "Welcome, Kathryn Grace!",
+      "issue": "Jan/Feb 2015",
+      "file": "OFR-Jan-Feb-2015.pdf"
+    }
+  ],
+  "2014": [
+    {
+      "title": "Smoky Mountain Shindig",
+      "issue": "Sep/Oct 2014",
+      "file": "OFR-Sep-Oct-2014.pdf"
+    },
+    {
+      "title": "Overcome Evil with Good",
+      "issue": "Jun-Aug 2014",
+      "file": "OFR-Jun-Aug-2014.pdf"
+    },
+    {
+      "title": "Gearing Up for CMO",
+      "issue": "Apr/May 2014",
+      "file": "OFR-Apr-May-2014.pdf"
+    },
+    {
+      "title": "News from the Front",
+      "issue": "Jan-Mar 2014",
+      "file": "OFR-Jan-Mar-2014.pdf"
+    }
+  ],
+  "2013": [
+    {
+      "title": "Gathering Fruit",
+      "issue": "Oct-Dec 2013",
+      "file": "OFR-Oct-Dec-2013.pdf"
+    },
+    {
+      "title": "CMO 2013: A Summary",
+      "issue": "Jul-Sep 2013",
+      "file": "OFR-Jul-Sep-2013.pdf"
+    },
+    {
+      "title": "230K",
+      "issue": "May/Jun 2013",
+      "file": "OFR-May-Jun-2013.pdf"
+    },
+    {
+      "title": "Bible First: The Final Lessons",
+      "issue": "Mar/Apr 2013",
+      "file": "OFR-Mar-Apr-2013.pdf"
+    },
+    {
+      "title": "Announcing CMO 2013",
+      "issue": "Feb 2013",
+      "file": "OFR-Feb-2013.pdf"
+    },
+    {
+      "title": "Bible First Is Here!",
+      "issue": "Jan 2013",
+      "file": "OFR-Jan-2013.pdf"
+    }
+  ],
+  "2012": [
+    {
+      "title": "Our Love Story",
+      "issue": "Nov/Dec 2012",
+      "file": "OFR-Nov-Dec-2012.pdf"
+    },
+    {
+      "title": "A New Chapter",
+      "issue": "Oct 2012",
+      "file": "OFR-Oct-2012.pdf"
+    },
+    {
+      "title": "A Project of Firsts",
+      "issue": "Sep 2012",
+      "file": "OFR-September-2012.pdf"
+    },
+    {
+      "title": "Faithful Men",
+      "issue": "Aug 2012",
+      "file": "OFR-August-2012.pdf"
+    },
+    {
+      "title": "Little One",
+      "issue": "Jul 2012",
+      "file": "OFR-July-2012.pdf"
+    },
+    {
+      "title": "CMO Returns",
+      "issue": "Jun 2012",
+      "file": "OFR-June-2012.pdf"
+    },
+    {
+      "title": "Registered!",
+      "issue": "May 2012",
+      "file": "OFR-May-2012.pdf"
+    },
+    {
+      "title": "Visas and Beyond",
+      "issue": "Apr 2012",
+      "file": "OFR-Apr-2012.pdf"
+    },
+    {
+      "title": "\"What Saith the Scripture?\"",
+      "issue": "Mar 2012",
+      "file": "OFR-Mar-2012.pdf"
+    },
+    {
+      "title": "Pray for Open Doors",
+      "issue": "Feb 2012",
+      "file": "OFR-Feb-2012.pdf"
+    },
+    {
+      "title": "Every Perfect Gift",
+      "issue": "Jan 2012",
+      "file": "OFR-Jan-2012.pdf"
+    }
+  ],
+  "2011": [
+    {
+      "title": "A Big Year Ahead",
+      "issue": "Apr 2011",
+      "file": "OFR-April-2011.pdf"
+    }
+  ],
+  "2010": [
+    {
+      "title": "Looking Forward to 2012",
+      "issue": "Oct 2010",
+      "file": "OFR-October-2010.pdf"
+    },
+    {
+      "title": "All Over the Map",
+      "issue": "May/Jun 2010",
+      "file": "OFR-May-June-2010.pdf"
+    },
+    {
+      "title": "Looking Ahead to CMO 2010",
+      "issue": "Jan/Feb 2010",
+      "file": "OFR-Jan-Feb-2010.pdf"
+    }
+  ],
+  "2009": [
+    {
+      "title": "I Met the \"Martin Luther\" of the Carpathians",
+      "issue": "Oct-Dec 2009",
+      "file": "OFR_Oct-Dec_2009.pdf"
+    },
+    {
+      "title": "Proving that ALL are Under Sin",
+      "issue": "May 2009",
+      "file": "OFR_May_2009.pdf"
+    }
+  ],
+  "2008": [
+    {
+      "title": "ABS Restarted",
+      "issue": "Dec 2008",
+      "file": "ofr_dec_2008.pdf"
+    },
+    {
+      "title": "CMO 2008: A Summary",
+      "issue": "Oct 2008",
+      "file": "steele_ofr_oct08.pdf"
+    },
+    {
+      "title": "Headed for the Harvest",
+      "issue": "Nov 2007-Jan 2008",
+      "file": "steele_ofr_nov07-jan08.pdf"
+    }
+  ],
+  "2007": [
+    {
+      "title": "From Distance Learning to Direct Contact",
+      "issue": "Sep/Oct 2007",
+      "file": "steele_ofr_sep-oct_2007.pdf"
+    },
+    {
+      "title": "Carpathian Mountain Outreach 2007",
+      "issue": "May-Aug 2007",
+      "file": "steele_ofr_may-aug_2007.pdf"
+    },
+    {
+      "title": "Doors of Utterance",
+      "issue": "Feb-Apr 2007",
+      "file": "steele_ofr_feb-apr_2007.pdf"
+    },
+    {
+      "title": "The Bible at Work",
+      "issue": "Nov 2006-Jan 2007",
+      "file": "steele_ofr_nov06-jan07.pdf"
+    }
+  ],
+  "2006": [
+    {
+      "title": "Teaching All Nations",
+      "issue": "Sep/Oct 2006",
+      "file": "steele_ofr_sep-oct_2006.pdf"
+    },
+    {
+      "title": "Carpathian Mountain Outreach",
+      "issue": "May-Aug 2006",
+      "file": "steele_ofr_may-aug_2006.pdf"
+    },
+    {
+      "title": "By the Word of Truth, by the Power of God",
+      "issue": "Mar/Apr 2006",
+      "file": "steele_ofr_mar-apr_2006.pdf"
+    },
+    {
+      "title": "Disciples Making Disciples",
+      "issue": "Jan/Feb 2006",
+      "file": "steele_ofr_jan-feb_2006.pdf"
+    }
+  ],
+  "2005": [
+    {
+      "title": "The Word of God is quick and powerful",
+      "issue": "Nov/Dec 2005",
+      "file": "steele_ofr_nov-dec_2005.pdf"
+    },
+    {
+      "title": "Bible Camp 2005",
+      "issue": "Aug-Oct 2005",
+      "file": "steele_ofr_aug-oct_2005.pdf"
+    },
+    {
+      "title": "To whom He was not spoke of",
+      "issue": "May-Jul 2005",
+      "file": "steele_ofr_may-july_2005.pdf"
+    },
+    {
+      "title": "Under the Law or under Grace?",
+      "issue": "Mar/Apr 2005",
+      "file": "steele_ofr_mar-apr_2005.pdf"
+    },
+    {
+      "title": "Compel them to come in that My house may be filled.",
+      "issue": "Jan/Feb 2005",
+      "file": "steele_ofr_jan-feb_2005.pdf"
+    }
+  ],
+  "2004": [
+    {
+      "title": "Making Students of God's Word",
+      "issue": "Oct-Dec 2004",
+      "file": "steele_ofr_oct-dec_2004.pdf"
+    },
+    {
+      "title": "The Passion for Winning Souls",
+      "issue": "Jul-Sep 2004",
+      "file": "steele_ofr_jul-sep_2004.pdf"
+    },
+    {
+      "title": "Engaged!",
+      "issue": "May/Jun 2004",
+      "file": "steele_ofr_engagement_2004.pdf"
+    },
+    {
+      "title": "Train Up Faithful Men",
+      "issue": "Mar/Apr 2004",
+      "file": "steele_ofr_mar-apr_2004.pdf"
+    },
+    {
+      "title": "Teach All Nations",
+      "issue": "Jan/Feb 2004",
+      "file": "steele_ofr_jan-feb_2004.pdf"
+    }
+  ],
+  "2003": [
+    {
+      "title": "Pressing Toward the Mark",
+      "issue": "Nov/Dec 2003",
+      "file": "steele_ofr_nov-dec_2003.pdf"
+    },
+    {
+      "title": "Answering the Call",
+      "issue": "Sep/Oct 2003",
+      "file": "steele_ofr_sep-oct_2003.pdf"
+    }
+  ],
+  "2001": [
+    {
+      "title": "The Beginning",
+      "issue": "March 2001",
+      "file": "ukraine_report_mar_2001.pdf"
+    }
+  ]
+}

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -104,7 +104,7 @@ links to the relevant PRD document for full requirements.
 - [x] Family page (`/family/`)
 - [x] Ministry page (`/ministry/`) with SVG logos
 - [x] Podcast page (`/podcast/`) with Buzzsprout embed
-- [ ] Archives page (`/archives/`) using `data/archives.json`
+- [x] Archives page (`/archives/`) using `data/archives.json`
 - [x] Donate page (`/donate/`)
 - [ ] Subscribe page (`/subscribe/`) with Mailchimp form
 

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,0 +1,42 @@
+{{ define "main" }}
+  <div class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+
+      {{/* Page title — mirrors single.html so the chrome matches the other static pages. */}}
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+        {{- .Title -}}
+      </h1>
+
+      {{/* Intro prose lives in .Content; the year loop below lives in this template
+           because markdown can't iterate a data file. */}}
+      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
+        {{ .Content }}
+
+        {{/* data/archives.json → hugo.Data.archives is a map keyed by year string.
+             Hugo ranges map keys ascending, so collect the keys and sort them
+             descending to list newest issues first (replaces the old site's
+             Object.keys(archives).reverse()). */}}
+        {{ $archives := hugo.Data.archives }}
+        {{ $years := slice }}
+        {{ range $year, $_ := $archives }}
+          {{ $years = $years | append $year }}
+        {{ end }}
+
+        {{ range sort $years "value" "desc" }}
+          {{ $issues := index $archives . }}
+          <h2>{{ . }}</h2>
+          <ul>
+            {{ range $issues }}
+              <li>
+                <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer">
+                  {{ .title }} ({{ .issue }})
+                </a>
+              </li>
+            {{ end }}
+          </ul>
+        {{ end }}
+      </div>
+
+    </div>
+  </div>
+{{ end }}

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,38 +2,46 @@
   <div class="bg-white py-24 sm:py-32">
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
-      {{/* Page title — mirrors single.html so the chrome matches the other static pages. */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
-        {{- .Title -}}
+      {{/* Display heading "Through the Years" comes from the `heading` frontmatter
+           (matches the original PageHeader); .Title ("Archives") stays the SEO/tab
+           title. Centered to match the original design. */}}
+      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 
-      {{/* Intro prose lives in .Content; the year loop below lives in this template
-           because markdown can't iterate a data file. */}}
+      {{/* Intro prose (left-aligned), authored in archives.md. */}}
       <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
         {{ .Content }}
+      </div>
 
-        {{/* data/archives.json → hugo.Data.archives is a map keyed by year string.
-             Hugo ranges map keys ascending, so collect the keys and sort them
-             descending to list newest issues first (replaces the old site's
-             Object.keys(archives).reverse()). */}}
-        {{ $archives := hugo.Data.archives }}
-        {{ $years := slice }}
-        {{ range $year, $_ := $archives }}
-          {{ $years = $years | append $year }}
-        {{ end }}
+      {{/* Newsletter issues grouped by year. data/archives.json → hugo.Data.archives
+           is a map keyed by year string; Hugo ranges map keys ascending, so collect
+           the keys and sort them descending to list newest first (replaces the old
+           site's Object.keys(archives).reverse()).
 
+           Each year is a two-column row: the year label on the left, its issues on
+           the right, with a divider between years (none after the last). */}}
+      {{ $archives := hugo.Data.archives }}
+      {{ $years := slice }}
+      {{ range $year, $_ := $archives }}
+        {{ $years = $years | append $year }}
+      {{ end }}
+
+      <div class="mt-10 max-w-2xl">
         {{ range sort $years "value" "desc" }}
-          {{ $issues := index $archives . }}
-          <h2>{{ . }}</h2>
-          <ul>
-            {{ range $issues }}
-              <li>
-                <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer">
-                  {{ .title }} ({{ .issue }})
-                </a>
-              </li>
-            {{ end }}
-          </ul>
+          <div class="flex border-b border-gray-200 pb-6 mb-6 last:mb-0 last:border-b-0 last:pb-0 sm:pb-8 sm:mb-8">
+            <h2 class="shrink-0 pr-4 font-header text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
+            <ul class="space-y-2 md:space-y-4">
+              {{ range (index $archives .) }}
+                <li class="flex items-start gap-2">
+                  <svg viewBox="0 0 640 512" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path d="M537.6 226.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 64.2 315.3 32 256 32c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 219.8 0 273.2 0 336c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 420.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 315.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V176c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z"/></svg>
+                  <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="font-header text-blue-700 hover:text-blue-900">
+                    {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
+                  </a>
+                </li>
+              {{ end }}
+            </ul>
+          </div>
         {{ end }}
       </div>
 


### PR DESCRIPTION
## Summary

- Adds the Archives page at `/archives/`, resolving the existing 404 (Phase 8, Static Pages).
- Migrates `data/archives.json` (25 years, 83 newsletter issues) and builds a data-driven layout that lists issues grouped by year, newest-first, each linking to its PDF on CloudFront.
- Introduces the project's first Hugo **data template** (`hugo.Data`).

## Changes

- **`data/archives.json`** (new) — newsletter index copied verbatim from the Nuxt source: `year → [{title, issue, file}]`. Removed the redundant `data/.keep` placeholder.
- **`content/archives.md`** (new) — `title: "Archives"`, `layout: archives`, a `description`, and the intro prose (newsletter history + Psalm 34:8 quote). Prose stays in `.Content`.
- **`layouts/_default/archives.html`** (new) — mirrors `single.html` page chrome, renders `.Content`, then collects the year keys and `sort … "value" "desc"` for newest-first ordering, emitting each year as an `<h2>` with a `<ul>` of PDF links.
- **`docs/prd/ROADMAP.md`** — marked the Phase 8 "Archives page" item complete.

## Approach

- **Dedicated layout, not a shortcode** (`layout: archives` → `layouts/_default/archives.html`). This keeps the intro prose in `.Content` and the data-iteration logic in the template — the approach recommended in the issue.
- **Newest-first ordering** replicates the old site's `Object.keys(archives).reverse()`: Hugo ranges map keys ascending, so the template collects keys into a slice and sorts descending. (Verified there's no `keys()` helper and that `sort $map "key"` returns values, not keys — so the collect-then-sort pattern is the correct Hugo idiom.)

## Notes

- **`hugo.Data` vs `site.Data`:** the issue's acceptance text references `site.Data.archives`, but that call is deprecated as of Hugo v0.156.0. The template uses the current `hugo.Data.archives` API so the build stays warning-free. Behavior (iterate the data file newest-first) is unchanged.
- Ran `/simplify` (4-angle review): reuse / simplification / efficiency / altitude all came back clean. Deferred a `page-shell` partial extraction — only 2 templates share that wrapper, below the project's "extract after 3" threshold.
- The Phase 15 ROADMAP line "Data files migrated (`authors.json`, `archives.json`)" was intentionally left unchecked — `authors.json` is not migrated yet.

## Testing

- [x] Production build passes (`hugo --gc --minify`) — 34 pages, no warnings or errors
- [x] `/archives/` renders (no 404); H1, intro prose, and Psalm quote present
- [x] Years render newest-first (2026 → 2001)
- [x] All 83 issues link to `pdfBase` + filename with `target="_blank" rel="noopener noreferrer"` and text `Title (Issue)`

Closes #59
