### PR TITLE
fix: default to sans-serif, opt long-form copy into serif

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -17,8 +17,9 @@
   --color-blue-dark: #024775;
   --color-blue-footer: #8bccf8;
 
-  /* Font families */
-  --font-header: "Lato", sans-serif;
+  /* Font families — sans (Lato) is the default for UI, headings, and body;
+     serif (Noto Serif) is opt-in for long-form copy; fancy (Mate SC) is decorative. */
+  --font-sans: "Lato", sans-serif;
   --font-serif: "Noto Serif", ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-fancy: "Mate SC", serif;
 }

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -5,12 +5,12 @@
       {{/* Display heading "Through the Years" comes from the `heading` frontmatter
            (matches the original PageHeader); .Title ("Archives") stays the SEO/tab
            title. Centered to match the original design. */}}
-      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl">
         {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 
       {{/* Intro prose (left-aligned), authored in archives.md. */}}
-      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
         {{ .Content }}
       </div>
 
@@ -30,12 +30,12 @@
       <div class="mt-10 max-w-2xl">
         {{ range sort $years "value" "desc" }}
           <div class="flex border-b border-gray-200 pb-6 mb-6 last:mb-0 last:border-b-0 last:pb-0 sm:pb-8 sm:mb-8">
-            <h2 class="shrink-0 pr-4 font-header text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
+            <h2 class="shrink-0 pr-4 font-sans text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
             <ul class="space-y-2 md:space-y-4">
               {{ range (index $archives .) }}
                 <li class="flex items-start gap-2">
                   <svg viewBox="0 0 640 512" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path d="M537.6 226.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 64.2 315.3 32 256 32c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 219.8 0 273.2 0 336c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 420.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 315.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V176c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z"/></svg>
-                  <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="font-header text-blue-700 hover:text-blue-900">
+                  <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">
                     {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
                   </a>
                 </li>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     {{ partial "css.html" . }}
   {{ end }}
 </head>
-<body class="min-h-screen bg-gray-100 font-serif text-gray-900">
+<body class="min-h-screen bg-gray-100 font-sans text-gray-900">
   {{ partial "header.html" . }}
   <main class="pt-16">
     {{ block "main" . }}{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
   <div class="mx-auto max-w-4xl px-4 py-8">
-    <h1 class="font-header text-4xl font-bold text-gray-900">{{ .Title }}</h1>
+    <h1 class="font-sans text-4xl font-bold text-gray-900">{{ .Title }}</h1>
     {{- with .Content }}
-      <div class="prose mt-4 max-w-none">{{ . }}</div>
+      <div class="prose mt-4 max-w-none font-serif prose-headings:font-sans">{{ . }}</div>
     {{- end }}
     {{- if .Pages }}
       <ul class="mt-8 space-y-4">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,12 +5,12 @@
       {{/* Page title — an optional "heading" frontmatter field overrides .Title
            (and may contain inline HTML such as <br>); "centered: true" centers
            the header and body to match pages like Ministry. */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl{{ if .Params.centered }} text-center{{ end }}">
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl{{ if .Params.centered }} text-center{{ end }}">
         {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 
       {{/* Page content */}}
-      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
+      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
         {{ .Content }}
       </div>
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,7 @@
   <div class="bg-white py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-header">
+        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         {{- with .Content }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -19,7 +19,7 @@
       {{- end }}
 
       {{/* Article title */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-header sm:text-5xl">
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl">
         {{- .Title -}}
       </h1>
 
@@ -50,7 +50,7 @@
       {{- end }}
 
       {{/* Article content */}}
-      <div class="mt-10 max-w-2xl prose prose-gray prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
         {{ .Content }}
       </div>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,10 +9,10 @@
 </title>
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}">
 
-{{/* Google Fonts: Lato (headings), Noto Serif (body), Mate SC (decorative) */}}
+{{/* Google Fonts: Lato (sans — default UI, headings, body), Noto Serif (long-form copy), Mate SC (decorative) */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Lato:wght@700&family=Mate+SC&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Mate+SC&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
 {{/* Favicons */}}
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
       {{ $currentPage := . }}
       {{ range site.Menus.main }}
         <a href="{{ .URL }}"
-           class="font-header text-sm font-bold uppercase tracking-wide transition-colors duration-150
+           class="font-sans text-sm font-bold uppercase tracking-wide transition-colors duration-150
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     text-blue-900
                   {{ else }}
@@ -56,7 +56,7 @@
       {{ $currentPage := . }}
       {{ range site.Menus.main }}
         <a href="{{ .URL }}"
-           class="block rounded-md px-3 py-2 font-header text-base font-bold uppercase tracking-wide transition-colors duration-150
+           class="block rounded-md px-3 py-2 font-sans text-base font-bold uppercase tracking-wide transition-colors duration-150
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     bg-blue-50 text-blue-900
                   {{ else }}

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -36,7 +36,7 @@
 <div class="my-6 md:my-8{{ if $center }} text-center{{ end }}">
   <a
     href="{{ $href }}"
-    class="inline-flex items-center gap-1.5 rounded-full px-4 py-2.5 text-sm font-semibold no-underline transition-colors {{ $variant }}"
+    class="inline-flex items-center gap-1.5 rounded-full px-4 py-2.5 font-sans text-sm font-semibold no-underline transition-colors {{ $variant }}"
     {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
   >
     {{- $text -}}

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -26,7 +26,7 @@
   {{- with .Get "pdf" }}
   <a
     href="{{ site.Params.pdfBase }}{{ . }}"
-    class="callout-download inline-flex items-center gap-1.5 font-semibold text-blue-700 no-underline transition-colors hover:text-blue-900"
+    class="callout-download inline-flex items-center gap-1.5 font-sans font-semibold text-blue-700 no-underline transition-colors hover:text-blue-900"
     target="_blank"
     rel="noopener noreferrer"
   >

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -3,7 +3,7 @@
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $tagCount := len .Data.Terms -}}
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-header">
+        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -4,7 +4,7 @@
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $count := len .Pages -}}
         <p class="text-base/7 font-semibold text-blue-600">Tag</p>
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-header">
+        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">


### PR DESCRIPTION
## Summary

- Restores the original site's typography convention: **sans-serif (Lato) as the default**, with **serif (Noto Serif) opt-in for long-form copy**. The rebuild had inverted this (body defaulted to serif), so button labels, footer text, and standalone links were rendering serif.
- Unifies the sans token to a correctly-named `--font-sans` and fixes a latent font-loading gap (only Lato 700 was loaded).

## Changes

- **Token:** renamed `--font-header` → `--font-sans` (still Lato) and use it for all sans text — body, headings, nav, buttons (`assets/css/main.css` + the ~9 usages across layouts).
- **Default flip:** `<body>` `font-serif` → `font-sans` (`baseof.html`).
- **Long-form opt-in:** added `font-serif` with `prose-headings:font-sans` to the prose containers — blog post bodies (`blog/single.html`), static-page copy (`_default/single.html`, `_default/list.html`), and the Archives intro (`_default/archives.html`). Reading copy is serif; `##` sub-headings stay sans.
- **UI labels:** `button` and `callout`-download links set to sans explicitly, since they render inside serif prose.
- **Font loading:** `head.html` now loads Lato `400/700` + italics (was `700` only), so body copy renders in real Lato instead of a system fallback.
- **Cleanup:** dropped the now-redundant explicit sans on the Archives newsletter links (they default to sans now).

## Approach notes

- **Why a default flip instead of per-element patches:** the original applied serif to individual elements; the rebuild set the whole body serif. Flipping the default and opting prose into serif fixes the whole site at the root rather than chasing individual offenders. Inline links inside a paragraph correctly stay serif; standalone links/buttons are sans.
- **Token decision:** unified to a single `--font-sans` (vs. keeping `--font-header` alongside a new alias) so there's one unambiguous sans token. Purely mechanical rename, zero visual change to headings.

## Testing

- [x] Production build passes (`hugo --gc --minify`) — clean, no warnings
- [x] Archives: nav / heading / download links sans; intro + Psalm quote serif
- [x] Blog post: title / meta / tag / prev-next sans; body copy serif; footer verse (Mate SC) preserved
- [x] Donate: heading + `##` sub-headings + button label + footer links sans; intro / body / blockquote serif

Closes #71
