### PR TITLE
chore: use slate-gray for page headings

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -17,6 +17,9 @@
   --color-blue-dark: #024775;
   --color-blue-footer: #8bccf8;
 
+  /* Ink — the slate used for page headings, matching the original site (Tailwind v1 gray-800). */
+  --color-ink: #2d3748;
+
   /* Font families — sans (Lato) is the default for UI, headings, and body;
      serif (Noto Serif) is opt-in for long-form copy; fancy (Mate SC) is decorative. */
   --font-sans: "Lato", sans-serif;

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -5,7 +5,7 @@
       {{/* Display heading "Through the Years" comes from the `heading` frontmatter
            (matches the original PageHeader); .Title ("Archives") stays the SEO/tab
            title. Centered to match the original design. */}}
-      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl">
+      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
         {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <div class="mx-auto max-w-4xl px-4 py-8">
-    <h1 class="font-sans text-4xl font-bold text-gray-900">{{ .Title }}</h1>
+    <h1 class="font-sans text-4xl font-bold text-ink">{{ .Title }}</h1>
     {{- with .Content }}
       <div class="prose mt-4 max-w-none font-serif prose-headings:font-sans">{{ . }}</div>
     {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
       {{/* Page title — an optional "heading" frontmatter field overrides .Title
            (and may contain inline HTML such as <br>); "centered: true" centers
            the header and body to match pages like Ministry. */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl{{ if .Params.centered }} text-center{{ end }}">
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl{{ if .Params.centered }} text-center{{ end }}">
         {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,7 @@
   <div class="bg-white py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
+        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         {{- with .Content }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -19,7 +19,7 @@
       {{- end }}
 
       {{/* Article title */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 font-sans sm:text-5xl">
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
         {{- .Title -}}
       </h1>
 

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -3,7 +3,7 @@
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $tagCount := len .Data.Terms -}}
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
+        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -4,7 +4,7 @@
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $count := len .Pages -}}
         <p class="text-base/7 font-semibold text-blue-600">Tag</p>
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl font-sans">
+        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">


### PR DESCRIPTION
## Summary

- Page headings rendered in near-black (`text-gray-900`); the original site used a softer slate. This switches all page-title headings to that slate via a new theme token.
- The exact value was sampled from the live old site's rendered heading color: `rgb(45, 55, 72)` = `#2d3748` (Tailwind v1 `gray-800`).

## Changes

- **`assets/css/main.css`** — added the `--color-ink: #2d3748` theme token (semantic name; `slate` would collide with Tailwind's slate scale).
- **7 page-title `<h1>`s** — swapped `text-gray-900` → `text-ink`: `_default/single.html`, `_default/archives.html`, `_default/list.html`, `blog/list.html`, `blog/single.html`, `taxonomy/taxonomy.html`, `taxonomy/term.html`.

## Decisions

- **Blog titles included.** The original article titles inherited the same `gray-800`, so applying the slate uniformly matches it (resolves the open question in the issue).
- **Scope = page-title headings only.** Secondary `text-gray-900` uses are intentionally left as-is: the `<body>` default, prev/next nav labels, article-card titles, and the header hover state — none are page headings.

## Testing

- [x] Production build passes (`hugo --gc --minify`) — clean
- [x] Generated CSS: `.text-ink{color:var(--color-ink)}`, `--color-ink:#2d3748`
- [x] Browser-verified: the new heading computes to `rgb(45, 55, 72)`, an exact match to the live old site

Closes #70
