### PR TITLE
feat: align Donate page header with existing design

### DIFF
--- a/content/donate.md
+++ b/content/donate.md
@@ -1,5 +1,6 @@
 ---
 title: "Donate"
+heading: "How to Donate"
 description: >-
   If you would like to make a financial contribution, please choose from one
   of the options below. We are grateful for your kindness and generosity!

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,14 +2,15 @@
   <div class="bg-white py-24 sm:py-32">
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
-      {{/* Page title — an optional "heading" frontmatter field overrides .Title
-           (and may contain inline HTML such as <br>); "centered: true" centers
-           the header and body to match pages like Ministry. */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl{{ if .Params.centered }} text-center{{ end }}">
+      {{/* Page title — always centered, matching the old design's PageHeader.
+           An optional "heading" frontmatter field overrides .Title (and may
+           contain inline HTML such as <br>). */}}
+      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans text-center sm:text-5xl">
         {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
       </h1>
 
-      {{/* Page content */}}
+      {{/* Page content — "centered: true" centers the body (e.g. Ministry);
+           otherwise it stays left-aligned. */}}
       <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
         {{ .Content }}
       </div>


### PR DESCRIPTION
## Summary

- Give the Donate page a centered **"How to Donate"** header (matching the live site) while keeping its body left-aligned.
- Settle the header/body centering pattern in `single.html`: the page header is now **always centered** and the `centered` frontmatter flag controls **only** the body.

## Changes

- **`layouts/_default/single.html`** — Decoupled header and body centering. The `<h1>` is always `text-center`, matching the old design's always-centered `PageHeader`. The `centered: true` flag now applies `mx-auto text-center` to the body only.
- **`content/donate.md`** — Added `heading: "How to Donate"`.

## Pattern decision

The old design's `PageHeader` was *always* centered; only body alignment varied per page. Rather than add a second flag, we removed the header/body coupling so the header is always centered. This is the simplest model and brings the previously left-aligned **Family** and **Podcast** headers back in line with the old design as an intended side effect.

| Page | Header | Body |
|------|--------|------|
| Donate | centered (new) | left |
| Ministry | centered | centered (`centered: true`) |
| Family | centered (was left) | left |
| Podcast | centered (was left) | left |

## Testing

- [x] Production build passes (`hugo --gc --minify`, 34 pages)
- [x] `/donate/` renders a centered "How to Donate" `<h1>` with a left-aligned body
- [x] `/ministry/` regression check — header and body both remain centered
- [x] `/family/` and `/podcast/` headers now centered (intended)

Closes #64
