### PR TITLE
feat: add Subscribe page with Mailchimp signup form

### DIFF
--- a/content/subscribe.md
+++ b/content/subscribe.md
@@ -1,0 +1,9 @@
+---
+title: "Subscribe"
+layout: subscribe
+description: >-
+  Overseas Field Report is our bi-monthly newsletter with updates on our family
+  and ministry in Ukraine. Subscribe to follow along and pray for us.
+---
+
+*Overseas Field Report* is our bi-monthly newsletter containing updates on our family and ministry here in Ukraine. We&rsquo;d be tickled if you&rsquo;d subscribe and pray for us!

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -16,7 +16,7 @@ links to the relevant PRD document for full requirements.
 | 5 | Single Article Template | Phase 3 | Complete |
 | 6 | Shortcodes | Phase 5 | Complete |
 | 7 | Tag Taxonomy | Phase 4 | Complete |
-| 8 | Static Pages | Phase 3 | In progress |
+| 8 | Static Pages | Phase 3 | Complete |
 | 9 | RSS Feed | Phase 5 | Not started |
 | 10 | SEO & Meta Tags | Phase 3 | Not started |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
@@ -106,7 +106,7 @@ links to the relevant PRD document for full requirements.
 - [x] Podcast page (`/podcast/`) with Buzzsprout embed
 - [x] Archives page (`/archives/`) using `data/archives.json`
 - [x] Donate page (`/donate/`)
-- [ ] Subscribe page (`/subscribe/`) with Mailchimp form
+- [x] Subscribe page (`/subscribe/`) with Mailchimp form
 
 **Key learning:** Content sections, page-specific templates
 

--- a/layouts/_default/subscribe.html
+++ b/layouts/_default/subscribe.html
@@ -1,0 +1,52 @@
+{{ define "main" }}
+  <div class="bg-white py-24 sm:py-32">
+    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+
+      {{/* "Subscribe" page header — always centered, matching the other static
+           pages. .Title doubles as the SEO/tab title. */}}
+      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
+        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
+      </h1>
+
+      {{/* Two-column row: the Overseas Field Report cover beside the intro copy,
+           signup form, and links. The large cover shows from sm up; on mobile it
+           hides and a smaller cover sits inline above the form with the intro. */}}
+      {{ $cover := partial "cloudinary-url.html" (dict "src" "OFReport/assets/OFR-Aug-Dec-2020_dxpdvm.jpg" "preset" "cover") }}
+
+      <div class="mt-10 max-w-2xl sm:flex sm:items-start sm:gap-8 md:gap-10">
+        <figure class="hidden shrink-0 sm:block">
+          <img src="{{ $cover }}" width="200" alt="Overseas Field Report newsletter cover" class="w-[150px] rounded shadow-lg md:w-[200px]" />
+        </figure>
+
+        <div class="flex-1">
+          <div class="flex items-start gap-4">
+            <figure class="shrink-0 sm:hidden">
+              <img src="{{ $cover }}" width="100" alt="Overseas Field Report newsletter cover" class="w-[100px] rounded shadow-md" />
+            </figure>
+
+            {{/* Intro copy authored in content/subscribe.md */}}
+            <div class="prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+              {{ .Content }}
+            </div>
+          </div>
+
+          <div class="mt-6">
+            {{ partial "mailchimp-form.html" . }}
+          </div>
+
+          <p class="mt-6 font-serif">
+            You can also access previous issues in our <a href="/archives/" class="text-blue-700 hover:text-blue-900">Archives</a>.
+          </p>
+
+          <hr class="my-8 border-gray-200" />
+
+          <p class="font-serif text-gray-700">Don&rsquo;t want to receive emails from us anymore?</p>
+          <p class="mt-2 font-serif">
+            <a href="https://OFReport.us6.list-manage.com/unsubscribe?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">Unsubscribe</a>
+          </p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -13,6 +13,7 @@
     "regular"  "c_scale,f_auto,q_auto,w_610"
     "figure"   "c_scale,f_auto,q_auto,w_768"
     "article"  "c_scale,f_auto,q_auto:best"
+    "cover"    "c_scale,f_auto,q_auto:best,w_200"
     "lightbox" "c_scale,f_auto,q_auto,w_1600"
     "og"       "c_fill,f_auto,h_630,q_auto,w_1200"
     "rss"      "c_scale,f_auto,q_auto,w_560"

--- a/layouts/partials/mailchimp-form.html
+++ b/layouts/partials/mailchimp-form.html
@@ -1,0 +1,49 @@
+{{- /*
+  mailchimp-form.html — inline Mailchimp newsletter signup form.
+
+  Ported from the old McSubscribeForm.vue component. Posts directly to the
+  Mailchimp list endpoint (no Mailchimp JavaScript), opening the confirmation
+  in a new tab. Styled with Tailwind to match the site's button: the email
+  input and Subscribe button stack on mobile and join into a pill from sm up.
+
+  The hidden honeypot field named b_<u>_<id> MUST stay — Mailchimp uses it to
+  trap bots, and removing it invites spam signups.
+*/ -}}
+<div id="mc_embed_signup" class="not-prose">
+  <form
+    id="mc-embedded-subscribe-form"
+    action="https://OFReport.us6.list-manage.com/subscribe/post?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559"
+    method="post"
+    name="mc-embedded-subscribe-form"
+    target="_blank"
+    novalidate
+    class="flex flex-col gap-3 sm:flex-row sm:gap-0"
+  >
+    <label for="mce-EMAIL" class="sr-only">Email address</label>
+    <input
+      id="mce-EMAIL"
+      type="email"
+      name="EMAIL"
+      value=""
+      placeholder="you@example.com"
+      autocomplete="email"
+      required
+      class="w-full rounded-full border border-gray-400 px-4 py-2.5 font-sans text-sm placeholder:text-gray-500 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:rounded-r-none sm:border-r-0"
+    />
+
+    {{- /* Honeypot — real visitors never see or fill this; bots that do get
+           dropped by Mailchimp. Off-screen and hidden from a11y tools. Do not
+           remove. */ -}}
+    <div class="absolute -left-[5000px]" aria-hidden="true">
+      <input type="text" name="b_1e0c65850b60905f65b151819_97b9f6a559" tabindex="-1" value="" />
+    </div>
+
+    <input
+      id="mc-embedded-subscribe"
+      type="submit"
+      name="subscribe"
+      value="Subscribe"
+      class="cursor-pointer rounded-full bg-blue-600 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:rounded-l-none"
+    />
+  </form>
+</div>


### PR DESCRIPTION
## Summary

- Add the `/subscribe/` page (resolving its 404), with a working Mailchimp newsletter signup form.
- Port the old `McSubscribeForm` component into a reusable `partials/mailchimp-form.html`, front-running the Phase 12 form partial as planned in #60.
- Complete **Phase 8 (Static Pages)** — Subscribe was the last remaining item.

## Changes

- **`layouts/partials/mailchimp-form.html`** *(new)* — inline Mailchimp embedded form. Posts to the existing list endpoint (`method="post"`, `target="_blank"`, no Mailchimp JS), preserves the anti-bot honeypot field (`b_…`, off-screen + `aria-hidden`), and is restyled for Tailwind v4 to match the site's button. Includes an `sr-only` label and visible focus rings for accessibility.
- **`layouts/_default/subscribe.html`** *(new)* — dedicated layout (selected via `layout: subscribe`), mirroring the `archives` page pattern. Centered "Subscribe" header, responsive two-column cover + form, intro from `.Content`, with Archives and Unsubscribe links.
- **`content/subscribe.md`** *(new)* — `title: "Subscribe"`, `layout: subscribe`, description, and the intro copy.
- **`layouts/partials/cloudinary-url.html`** — added a `cover` preset (`w_200`, matching the old transform) for the *Overseas Field Report* cover image.
- **`docs/prd/ROADMAP.md`** — marked the Subscribe item and Phase 8 complete.

## Implementation notes

- **Layout choice (flagged per #60):** used a dedicated layout rather than markdown + a form shortcode. The two-column cover/form design doesn't fit the default `prose` container cleanly, and this matches the existing Archives precedent. Intro copy stays editable in `content/subscribe.md`; the Archives/Unsubscribe links live in the template (as the old page had them).
- **Header duplication:** the page-header `<h1>` block now repeats across `single.html`, `archives.html`, and `subscribe.html` (rule-of-three). A future `partials/page-header.html` would consolidate it — left out here to keep this PR scoped.

## Testing

- [x] Production build passes (`hugo --gc --minify`, 35 pages)
- [x] `/subscribe/` renders with no 404; form action, `method=post`, honeypot field, email input, and submit button all present in output
- [x] Email input has an `sr-only` label and focus rings (keyboard/focus accessible)
- [x] Visual check at desktop (1280px) and mobile (390px): two-column layout on desktop, stacked cover + full-width form on mobile

Closes #60
