### PR TITLE
feat: add custom RSS feed template

### DIFF
--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,6 +34,14 @@ Each entry records one deviation or decision:
 
 ## Entries
 
+### 2026-06-06 — `docs/prd/01-architecture.md` §"RSS Feed", `docs/prd/ROADMAP.md` Phase 9
+
+**What changed:** The custom RSS feed sends a curated excerpt (`<description>`) plus a single cover-image `<enclosure>` per item, rather than the full HTML-rendered article the PRD called for ("include HTML-rendered description/content").
+
+**Why:** The existing Nuxt feed already runs successfully on an excerpt-only model, and excerpts are the better fit here on three counts: they drive readers back to the site (where the donate/subscribe CTAs, podcast, and lightbox galleries live), they keep emails under Gmail's ~102KB clipping threshold, and they avoid the broken-image problem of image-heavy posts in email (email clients can't lazy-load, so a 20-image post would either block or eager-load every image). The "Read more" link is added in the Mailchimp campaign via the `RSSITEM:URL` merge tag, keeping the feed itself clean.
+
+**Category:** Pivot
+
 ### 2026-06-04 — `docs/prd/03-site-structure.md`, `docs/prd/ROADMAP.md`
 
 **What changed:** Renamed the Phase 7 taxonomy templates from `taxonomy/tags.html` / `taxonomy/tag.html` to `taxonomy/taxonomy.html` (all-tags index) and `taxonomy/term.html` (single-tag list).

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -17,7 +17,7 @@ links to the relevant PRD document for full requirements.
 | 6 | Shortcodes | Phase 5 | Complete |
 | 7 | Tag Taxonomy | Phase 4 | Complete |
 | 8 | Static Pages | Phase 3 | Complete |
-| 9 | RSS Feed | Phase 5 | Not started |
+| 9 | RSS Feed | Phase 5 | Complete |
 | 10 | SEO & Meta Tags | Phase 3 | Not started |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
 | 12 | Newsletter Integration | Phase 3 | Not started |
@@ -112,10 +112,10 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 9: RSS Feed
 
-- [ ] Custom RSS template at `/feed.xml` (see [`01-architecture.md`](./01-architecture.md))
-- [ ] Cover images with Cloudinary transformations
-- [ ] HTML-rendered content in feed items
-- [ ] Mailchimp compatibility verified
+- [x] Custom RSS template at `/feed.xml` (see [`01-architecture.md`](./01-architecture.md))
+- [x] Cover images with Cloudinary transformations (cover `<enclosure>`, `w_560` rss preset)
+- [x] Curated excerpt in feed items (excerpt model, not full HTML — see [`CHANGELOG.md`](./CHANGELOG.md), 2026-06-06)
+- [—] Mailchimp compatibility verified (deferred — needs a live, publicly-pollable feed; verify during Phase 16 deploy)
 
 **Key learning:** Custom RSS template, Hugo output formats
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,7 @@
 baseURL = "https://ofreport.com/"
 locale = "en-US"
 title = "OFReport.com"
+copyright = "© 2026 Joshua and Kelsie Steele"
 
 # Pagination
 [pagination]

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,58 @@
+{{- /*
+  Custom RSS 2.0 feed for the blog, tuned for Mailchimp RSS-to-email.
+
+  Design (see docs/prd/CHANGELOG.md, 2026-06-06):
+    - Excerpt model: <description> carries the curated frontmatter summary,
+      not the full article. This drives readers to the site (where the
+      lightbox galleries, donate/subscribe CTAs, and podcast live) and keeps
+      emails small enough to dodge Gmail's ~102KB clipping. The "Read more"
+      button is added in the Mailchimp campaign via the RSSITEM:URL merge tag.
+    - One cover image per item via <enclosure> (Cloudinary rss preset, w_560)
+      as the email's visual hook. Email clients can't lazy-load, so a post's
+      full set of images never belongs in the feed.
+    - Restricted to the blog section, so static pages never leak into the feed.
+    - <dc:creator> for the author name (RSS <author> expects an email).
+*/ -}}
+{{- $pages := where site.RegularPages "Section" "blog" -}}
+{{- $limit := site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+  {{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ site.Title | transform.XMLEscape | safeHTML }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ site.Params.description | transform.XMLEscape | safeHTML }}</description>
+    <generator>Hugo</generator>
+    {{- with site.Language.Locale }}
+    <language>{{ . }}</language>
+    {{- end }}
+    {{- with site.Copyright }}
+    <copyright>{{ . | transform.XMLEscape | safeHTML }}</copyright>
+    {{- end }}
+    {{- with (index $pages 0) }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "rss" }}
+    <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title | transform.XMLEscape | safeHTML }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with .Params.author }}
+      <dc:creator>{{ . | transform.XMLEscape | safeHTML }}</dc:creator>
+      {{- end }}
+      <guid>{{ .Permalink }}</guid>
+      {{- with .Description }}
+      <description>{{ . | transform.XMLEscape | safeHTML }}</description>
+      {{- end }}
+      {{- with .Params.cover }}
+      <enclosure url="{{ partial "cloudinary-url.html" (dict "src" . "preset" "rss") }}" length="0" type="image/jpeg" />
+      {{- end }}
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- Replaces Hugo's built-in RSS template with a custom one served at `/feed.xml`, tuned for Mailchimp RSS-to-email.
- Uses an **excerpt model** — a curated `<description>` summary plus one cover-image `<enclosure>` per item — matching the existing Nuxt feed and email best practice. This drives readers to the site (donate/subscribe CTAs, podcast, lightbox galleries) and keeps emails under Gmail's ~102KB clip limit.
- Restricted to the blog section so static pages can't leak into the feed; `<dc:creator>` for the author; all text run through `transform.XMLEscape`.

## Changes

- **feat:** `layouts/_default/rss.xml` — new custom RSS 2.0 template (excerpt + cover enclosure, blog-only, `dc:creator`).
- **feat:** `hugo.toml` — add top-level `copyright` for the channel `<copyright>` element, matching the existing feed.
- **docs:** `docs/prd/CHANGELOG.md` — log the excerpt-vs-full-content pivot (the PRD originally called for full HTML content).
- **docs:** `docs/prd/ROADMAP.md` — mark Phase 9 complete; Mailchimp end-to-end verification deferred to the Phase 16 deploy.

## Testing

- [x] `hugo --gc --minify` builds clean — zero warnings, errors, or deprecations
- [x] `/feed.xml` is well-formed (`xmllint --noout`)
- [x] Exactly 10 items, respecting `[services.rss] limit`
- [x] Each item carries title, link, `pubDate`, `<dc:creator>`, `guid`, `<description>` (curated excerpt), and `<enclosure>` cover (`w_560` rss preset)
- [x] Cover-less post degrades gracefully (no empty `<enclosure>`)
- [x] Static pages excluded (blog-section filter)
- [ ] Mailchimp RSS campaign verified end-to-end — **deferred to Phase 16** (requires a live, publicly-pollable feed)

## Notes

- **Excerpt over full content** is a deliberate deviation from PRD `01-architecture.md` (logged in `CHANGELOG.md`). Full HTML would hit Gmail's clip limit, and email clients can't lazy-load — a 20-image post would block or eager-load every image. The "Read more" link is added in the Mailchimp campaign via the `RSSITEM:URL` merge tag, keeping the feed clean.
- **Template path:** Hugo v0.162 honors the old-style `layouts/_default/rss.xml` override (verified empirically), consistent with the project's other `_default/` templates — the newer `home.rss.xml` lookup wasn't needed.
- The `<enclosure>` declares `type="image/jpeg"` though Cloudinary `f_auto` may serve WebP/AVIF; the type is advisory only (Mailchimp reads the URL). Same harmless quirk as the current production feed.

Closes #76
