### PR TITLE
feat: add SEO partial with Open Graph, Twitter Cards, canonical, and robots

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -18,7 +18,7 @@ links to the relevant PRD document for full requirements.
 | 7 | Tag Taxonomy | Phase 4 | Complete |
 | 8 | Static Pages | Phase 3 | Complete |
 | 9 | RSS Feed | Phase 5 | Complete |
-| 10 | SEO & Meta Tags | Phase 3 | Not started |
+| 10 | SEO & Meta Tags | Phase 3 | In progress |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
 | 12 | Newsletter Integration | Phase 3 | Not started |
 | 13 | Lightbox Integration | Phase 6 | Not started |
@@ -121,10 +121,10 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 10: SEO & Meta Tags
 
-- [ ] `partials/seo.html` — Open Graph, Twitter Cards (see [`04-templates.md`](./04-templates.md))
-- [ ] Title template with suffix
-- [ ] Canonical URLs
-- [ ] Robots meta (production vs. non-production)
+- [x] `partials/seo.html` — Open Graph, Twitter Cards (see [`04-templates.md`](./04-templates.md))
+- [x] Title template with suffix
+- [x] Canonical URLs
+- [x] Robots meta (production vs. non-production) — template logic done; per-context env wiring for deploy previews tracked in #80
 - [ ] Sitemap at `/sitemap.xml`
 - [ ] Favicons (apple-touch-icon, Android Chrome, Safari pinned tab)
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -28,6 +28,9 @@ copyright = "© 2026 Joshua and Kelsie Steele"
   titleSuffix = "Joshua and Kelsie Steele — Missionaries serving Christ in Ukraine"
   cloudinaryBase = "https://res.cloudinary.com/dnkvsijzu"
   pdfBase = "https://d21yo20tm8bmc2.cloudfront.net/ofr/"
+  # Default social/OG image (front-page hero) for pages without a cover.
+  # Stored untransformed; the cloudinary-url "og" preset is applied at render.
+  ogImage = "https://res.cloudinary.com/dnkvsijzu/image/upload/v1574408895/OFReport/assets/ofr-home-page-12-6_dk4tai.jpg"
 
   [params.social]
     facebook = "https://www.facebook.com/joshukraine"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,13 +1,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>
-  {{- if .IsHome -}}
-    {{ site.Params.titleSuffix }}
-  {{- else -}}
-    {{ .Title }} | {{ site.Params.titleSuffix }}
-  {{- end -}}
-</title>
-<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}">
+
+{{/* SEO + social metadata: title, description, canonical, robots, Open Graph, Twitter */}}
+{{ partial "seo.html" . }}
 
 {{/* Google Fonts: Lato (sans — default UI, headings, body), Noto Serif (long-form copy), Mate SC (decorative) */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,0 +1,44 @@
+{{- /*
+  Centralized SEO + social metadata: title, description, canonical, robots,
+  Open Graph, and Twitter Cards. This partial is the single source of truth
+  for these tags — head.html includes it and defines nothing of its own here.
+
+  OG image: a page's own `cover` if present, otherwise the site-wide fallback
+  (params.ogImage, the front-page hero). Both run through the cloudinary-url
+  "og" preset (c_fill,f_auto,h_630,q_auto,w_1200).
+*/ -}}
+{{- $title := cond .IsHome site.Params.titleSuffix (printf "%s | %s" .Title site.Params.titleSuffix) -}}
+{{- $description := or .Description site.Params.description -}}
+{{- $socialTitle := cond .IsHome site.Title .Title -}}
+{{- $ogType := cond (and .IsPage (eq .Section "blog")) "article" "website" -}}
+{{- $imageSrc := or .Params.cover site.Params.ogImage -}}
+{{- $ogImage := partial "cloudinary-url.html" (dict "src" $imageSrc "preset" "og") -}}
+
+<title>{{ $title }}</title>
+<meta name="description" content="{{ $description }}">
+<link rel="canonical" href="{{ .Permalink }}">
+{{- if hugo.IsProduction }}
+<meta name="robots" content="index,follow">
+{{- else }}
+<meta name="robots" content="noindex,nofollow">
+{{- end }}
+
+{{/* Open Graph */}}
+<meta property="og:type" content="{{ $ogType }}">
+<meta property="og:title" content="{{ $socialTitle }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:site_name" content="{{ site.Title }}">
+{{- with $ogImage }}
+<meta property="og:image" content="{{ . }}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+{{- end }}
+
+{{/* Twitter Card */}}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $socialTitle }}">
+<meta name="twitter:description" content="{{ $description }}">
+{{- with $ogImage }}
+<meta name="twitter:image" content="{{ . }}">
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds `layouts/partials/seo.html` as the single source of truth for page metadata — Open Graph, Twitter Cards, canonical URL, environment-aware robots — and consolidates the title/description into it (moved out of `head.html` to avoid duplication).
- OG image resolution mirrors the existing Nuxt site: a page's own `cover` if present, otherwise the front-page hero as a site-wide fallback (`params.ogImage`), both run through the `cloudinary-url` `og` preset (`c_fill,f_auto,h_630,q_auto,w_1200`).
- `og:type` is `article` for blog posts and `website` everywhere else.

## Changes

- **feat:** `layouts/partials/seo.html` — new partial: title, description, canonical, robots, Open Graph (type/title/description/url/site_name/image + 1200×630 dims), Twitter `summary_large_image`.
- **feat:** `layouts/partials/head.html` — replaced the inline `<title>` / `<meta description>` with `{{ partial "seo.html" . }}`.
- **feat:** `hugo.toml` — added `ogImage` param (front-page hero, stored untransformed so the `og` preset applies without stacking transforms).
- **docs:** `docs/prd/ROADMAP.md` — Phase 10 marked in progress; seo.html / title / canonical / robots ticked (sitemap + favicons remain for #78).

## Testing

- [x] `hugo --gc --minify` builds clean — zero warnings, errors, or deprecations
- [x] **Home** → `og:type=website`, fallback hero OG image, single title/description
- [x] **Blog post** → `og:type=article`, uses its **own** cover image, title carries the suffix
- [x] **Static page** (`/family/`) → `og:type=website`, fallback hero
- [x] Robots: `index,follow` under the production environment, `noindex,nofollow` under `--environment development`
- [x] No duplicate `<title>` or `<meta name="description">` after centralizing
- [x] OG fallback image URL resolves (HTTP 200, `image/jpeg`)

## Notes

- **OG fallback** matches the current Nuxt behavior (`site.image` in `data/site.json`) — the `ofr-home-page-12-6` front-page hero.
- **Known follow-up (#80):** `hugo.IsProduction` is `true` for every `hugo` build by default, so Netlify deploy previews / branch deploys would currently render `index,follow`. The partial responds to the environment correctly; the per-context `HUGO_ENVIRONMENT` wiring belongs to the Phase 16 `netlify.toml` work and is tracked in #80. Not in scope here.

Closes #77
