### PR TITLE
chore: verify sitemap output and finalize Phase 10

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -18,7 +18,7 @@ links to the relevant PRD document for full requirements.
 | 7 | Tag Taxonomy | Phase 4 | Complete |
 | 8 | Static Pages | Phase 3 | Complete |
 | 9 | RSS Feed | Phase 5 | Complete |
-| 10 | SEO & Meta Tags | Phase 3 | In progress |
+| 10 | SEO & Meta Tags | Phase 3 | Complete |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Not started |
 | 12 | Newsletter Integration | Phase 3 | Not started |
 | 13 | Lightbox Integration | Phase 6 | Not started |
@@ -125,8 +125,8 @@ links to the relevant PRD document for full requirements.
 - [x] Title template with suffix
 - [x] Canonical URLs
 - [x] Robots meta (production vs. non-production) — template logic done; per-context env wiring for deploy previews tracked in #80
-- [ ] Sitemap at `/sitemap.xml`
-- [ ] Favicons (apple-touch-icon, Android Chrome, Safari pinned tab)
+- [x] Sitemap at `/sitemap.xml` — verified Hugo's default output; no custom template needed
+- [x] Favicons (apple-touch-icon, Android Chrome, Safari pinned tab)
 
 **Key learning:** Head partial, Open Graph, Twitter Cards, sitemap
 


### PR DESCRIPTION
## Summary

Closes #78.

Verifies and finalizes Hugo's sitemap output, closing out **Phase 10 (SEO & Meta Tags)**. This is a verification issue — Hugo's default sitemap proved fully adequate, so no custom template was added. The only change is documentation (ROADMAP).

## Verification results

`hugo --gc --minify` produces `public/sitemap.xml` with **25 URLs**, all expected:

- Home `/`
- 6 static pages (archives, donate, family, ministry, podcast, subscribe)
- `/blog/` section + 13 blog posts
- `/tags/` list + 5 tag pages

Other checks:

- **No improper inclusions** — no `/thank-you/` page exists yet; Hugo auto-excludes 404.
- **`lastmod`** present and correct (matches post dates).
- **`changefreq`/`priority`** omitted by Hugo 0.163's modern sitemap format and ignored by Google — defaults consciously accepted.
- **No custom `layouts/sitemap.xml` needed.**

## Changes

- `docs/prd/ROADMAP.md` — ticked the remaining Phase 10 boxes (sitemap verified; favicons already implemented) and set Phase 10 status to **Complete**.

## Follow-up (not in this PR)

There is no generated `robots.txt` advertising the sitemap via a `Sitemap:` directive. Tracked in a separate issue rather than expanding this one's scope.

## Test plan

- [x] `hugo --gc --minify` exits 0
- [x] `markdownlint` reports 0 errors
- [x] Manually inspected `public/sitemap.xml` URL list
