### PR TITLE
chore: generate robots.txt with sitemap directive

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,7 @@ baseURL = "https://ofreport.com/"
 locale = "en-US"
 title = "OFReport.com"
 copyright = "© 2026 Joshua and Kelsie Steele"
+enableRobotsTXT = true
 
 # Pagination
 [pagination]

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,14 @@
+{{- /*
+  robots.txt — crawl rules mirror the robots meta logic in partials/seo.html:
+  production allows crawling and advertises the sitemap; any non-production
+  build (hugo server, or a Netlify preview/branch deploy once HUGO_ENVIRONMENT
+  is set per #80) disallows everything. The sitemap URL is built with absURL so
+  it follows baseURL rather than hardcoding the domain.
+*/ -}}
+User-agent: *
+{{ if hugo.IsProduction -}}
+Allow: /
+Sitemap: {{ "sitemap.xml" | absURL }}
+{{- else -}}
+Disallow: /
+{{- end }}


### PR DESCRIPTION
## Summary

- Enables Hugo's `robots.txt` output and adds a custom `layouts/robots.txt` template so the site advertises its sitemap and expresses crawl rules.
- Crawl rules mirror the robots **meta** logic already in `partials/seo.html` (`hugo.IsProduction`), keeping the two consistent and avoiding conflicting indexing signals.
- The sitemap URL is built with `absURL`, so it follows `baseURL` rather than hardcoding the domain.

## Changes

- `hugo.toml` — add `enableRobotsTXT = true`.
- `layouts/robots.txt` — new template:
  - **Production** → `User-agent: *` / `Allow: /` / `Sitemap: https://ofreport.com/sitemap.xml`
  - **Non-production** → `User-agent: *` / `Disallow: /` (no sitemap line)

## Testing

- [x] `hugo --gc --minify` exits 0; `public/robots.txt` renders the production variant with the absolute sitemap URL.
- [x] `hugo --gc --minify -e development` renders the non-production variant (`Disallow: /`).
- [x] Output inspected for clean formatting (no stray blank lines).
- [ ] End-to-end serve at `/robots.txt` confirmed on the Netlify deploy preview.

## Notes

- **Consistency with #80:** like the robots meta tag, Netlify deploy previews and branch deploys currently build as `production` and will emit `Allow: /` until #80 wires `HUGO_ENVIRONMENT` for those contexts. This template needs no further change when #80 lands — it switches those contexts to `Disallow: /` automatically.
- Chose `hugo.IsProduction` over a hardcoded rule specifically so the meta tag and `robots.txt` can never drift apart.

Closes #83
