### PR TITLE
chore: noindex Netlify deploy previews and branch deploys

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -124,7 +124,7 @@ links to the relevant PRD document for full requirements.
 - [x] `partials/seo.html` — Open Graph, Twitter Cards (see [`04-templates.md`](./04-templates.md))
 - [x] Title template with suffix
 - [x] Canonical URLs
-- [x] Robots meta (production vs. non-production) — template logic done; per-context env wiring for deploy previews tracked in #80
+- [x] Robots meta (production vs. non-production) — `seo.html` logic + Netlify per-context env wiring (preview/branch deploys render noindex)
 - [x] Sitemap at `/sitemap.xml` — verified Hugo's default output; no custom template needed
 - [x] Favicons (apple-touch-icon, Android Chrome, Safari pinned tab)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,20 +4,25 @@
 
 [build.environment]
   HUGO_VERSION = "0.162.1"
-  HUGO_ENV = "production"
+  HUGO_ENVIRONMENT = "production"
   NODE_VERSION = "22"
 
 [context.deploy-preview]
   command = "npm ci && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
+# "preview" makes hugo.IsProduction false, so seo.html emits noindex,nofollow
+# on preview/branch URLs. We avoid "development" so hugo.IsDevelopment stays
+# false and the CSS pipeline keeps minifying/fingerprinting like production.
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.162.1"
+  HUGO_ENVIRONMENT = "preview"
 
 [context.branch-deploy]
   command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
   HUGO_VERSION = "0.162.1"
+  HUGO_ENVIRONMENT = "preview"
 
 # Redirects for SEO continuity
 [[redirects]]


### PR DESCRIPTION
## Summary

- Stops Netlify deploy previews and branch deploys from being indexable by search engines.
- `seo.html` already emits `noindex,nofollow` when `hugo.IsProduction` is false — but `hugo --gc --minify` defaults to the production environment, so previews were rendering `index,follow`. This sets a non-production Hugo environment for those contexts.
- Uses a dedicated `preview` environment (not `development`) so the production-like CSS pipeline (minify + fingerprint) is preserved.

## Changes

- `netlify.toml`:
  - `[context.deploy-preview.environment]` and `[context.branch-deploy.environment]` — add `HUGO_ENVIRONMENT = "preview"`.
  - `[build.environment]` — replace the legacy `HUGO_ENV = "production"` with the canonical `HUGO_ENVIRONMENT = "production"`. Netlify merges base + context env, so using one variable name guarantees the context override wins instead of relying on undocumented `HUGO_ENV`/`HUGO_ENVIRONMENT` precedence.
- `docs/prd/ROADMAP.md` — update the Phase 10 robots note now that the deploy-preview env wiring is done (no longer deferred to #80).

## Testing

Verified locally by reproducing each environment:

- [x] `hugo --gc --minify -e preview` → `<meta name=robots content="noindex,nofollow">` and `robots.txt` → `Disallow: /`.
- [x] `hugo --gc --minify` (production) → `index,follow` and `robots.txt` → `Allow: /`.
- [x] Fingerprinted CSS asset (`main.<hash>.css`) is identical between the two builds — confirms `preview` keeps the production-like minify/fingerprint pipeline.
- [x] `seo.html` unchanged.
- [ ] **Live check (only this PR's deploy can confirm):** view-source on the Netlify deploy-preview URL shows `noindex,nofollow`.

## Notes

- This completes the robots story started in #77 (meta logic) and #83 (`robots.txt`): both now switch to non-indexable on previews via the same `hugo.IsProduction` signal.
- `preview` over `development` is deliberate — `css.html` branches on `hugo.IsDevelopment` for minify/fingerprint, and `development` would have shipped unminified, un-fingerprinted CSS on previews.

Closes #80
