### PR TITLE
chore: align Netlify Hugo version pin with local (0.163.0)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "npm ci && hugo --gc --minify"
 
 [build.environment]
-  HUGO_VERSION = "0.162.1"
+  HUGO_VERSION = "0.163.0"
   HUGO_ENVIRONMENT = "production"
   NODE_VERSION = "22"
 
@@ -14,14 +14,14 @@
 # on preview/branch URLs. We avoid "development" so hugo.IsDevelopment stays
 # false and the CSS pipeline keeps minifying/fingerprinting like production.
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.162.1"
+  HUGO_VERSION = "0.163.0"
   HUGO_ENVIRONMENT = "preview"
 
 [context.branch-deploy]
   command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.162.1"
+  HUGO_VERSION = "0.163.0"
   HUGO_ENVIRONMENT = "preview"
 
 # Redirects for SEO continuity


### PR DESCRIPTION
## Summary

- Aligns the `netlify.toml` Hugo version pin with the current local version so Netlify staging builds match local builds.
- Bumps all three `HUGO_VERSION` pins (`[build.environment]`, deploy-preview, branch-deploy) from `0.162.1` → `0.163.0`.

## Changes

- `netlify.toml` — `HUGO_VERSION` `0.162.1` → `0.163.0` (3 occurrences).

## Why

Local builds use Hugo `0.163.0` (Homebrew). Pinning Netlify to the same version avoids "works locally, breaks on deploy" surprises once the staging site is connected (#35). This is the version-alignment prerequisite for standing up Netlify staging.

## Testing

- [x] `hugo --gc --minify` passes locally on `0.163.0` (exit 0).

Part of #35.
