### PR TITLE
feat: add faded full-bleed backgrounds to static pages

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,8 +34,13 @@
 
 /* Faded full-bleed page background for static pages (see #69). The per-page
    Cloudinary URL is injected via the --page-bg-image custom property on a
-   .page-bg element; applied from the sm breakpoint up (640px) so mobile stays
-   plain. The *-bg-fade assets fade into white, blending into the wrapper. */
+   .page-bg element. The background color is the exact light gray the photos'
+   gradient fades to (#f7fafc — the old site's Tailwind v1 gray-100 body color),
+   so the fade is seamless instead of meeting a hard edge against white. The
+   image applies from the sm breakpoint up (640px); mobile shows the flat color. */
+.page-bg {
+  background-color: #f7fafc;
+}
 @media (min-width: 640px) {
   .page-bg {
     background-image: var(--page-bg-image);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -31,3 +31,15 @@
 [x-cloak] {
   display: none !important;
 }
+
+/* Faded full-bleed page background for static pages (see #69). The per-page
+   Cloudinary URL is injected via the --page-bg-image custom property on a
+   .page-bg element; applied from the sm breakpoint up (640px) so mobile stays
+   plain. The *-bg-fade assets fade into white, blending into the wrapper. */
+@media (min-width: 640px) {
+  .page-bg {
+    background-image: var(--page-bg-image);
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+  }
+}

--- a/content/archives.md
+++ b/content/archives.md
@@ -2,6 +2,7 @@
 title: "Archives"
 heading: "Through the Years"
 layout: archives
+bgImage: "OFReport/assets/selfie-family-bg-fade_qkqb9u"
 description: >-
   Since 2003 we have published Overseas Field Report, a newsletter chronicling
   the history of our ministry overseas. Browse and download every issue here.

--- a/content/donate.md
+++ b/content/donate.md
@@ -1,6 +1,7 @@
 ---
 title: "Donate"
 heading: "How to Donate"
+bgImage: "OFReport/assets/full-family-bg-fade_b2lc3m"
 description: >-
   If you would like to make a financial contribution, please choose from one
   of the options below. We are grateful for your kindness and generosity!

--- a/content/ministry.md
+++ b/content/ministry.md
@@ -2,6 +2,7 @@
 title: "Ministry"
 heading: "We live to serve<br>Jesus Christ."
 centered: true
+bgImage: "OFReport/assets/abby-beka-ministry-bg-fade_lwhwyj"
 description: >-
   Our highest purpose in life is to follow our Savior, the Lord Jesus Christ.
   We are raising our family in Ukraine, and striving to share the Gospel with

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,5 +1,10 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  {{/* Optional faded full-bleed background — Cloudinary public ID in the
+       `bgImage` frontmatter. The image paints onto the white wrapper from the
+       sm breakpoint up and fades into white below; mobile stays plain. */}}
+  {{ $bg := "" }}
+  {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
+  <div class="bg-white py-24 sm:py-32{{ with $bg }} page-bg{{ end }}"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Display heading "Through the Years" comes from the `heading` frontmatter

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,10 +1,12 @@
 {{ define "main" }}
   {{/* Optional faded full-bleed background — Cloudinary public ID in the
-       `bgImage` frontmatter. The image paints onto the white wrapper from the
-       sm breakpoint up and fades into white below; mobile stays plain. */}}
+       `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
+       (its background color is the exact gray the photos fade to) and paints
+       the image from the sm breakpoint up; mobile shows the flat color. Without
+       it, the wrapper keeps its plain white background. */}}
   {{ $bg := "" }}
   {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="bg-white py-24 sm:py-32{{ with $bg }} page-bg{{ end }}"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
+  <div class="{{ if $bg }}page-bg{{ else }}bg-white{{ end }} py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Display heading "Through the Years" comes from the `heading` frontmatter

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,10 +1,12 @@
 {{ define "main" }}
   {{/* Optional faded full-bleed background — Cloudinary public ID in the
-       `bgImage` frontmatter. The image paints onto the white wrapper from the
-       sm breakpoint up and fades into white below; mobile stays plain. */}}
+       `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
+       (its background color is the exact gray the photos fade to) and paints
+       the image from the sm breakpoint up; mobile shows the flat color. Without
+       it, the wrapper keeps its plain white background. */}}
   {{ $bg := "" }}
   {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="bg-white py-24 sm:py-32{{ with $bg }} page-bg{{ end }}"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
+  <div class="{{ if $bg }}page-bg{{ else }}bg-white{{ end }} py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Page title — always centered, matching the old design's PageHeader.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,10 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  {{/* Optional faded full-bleed background — Cloudinary public ID in the
+       `bgImage` frontmatter. The image paints onto the white wrapper from the
+       sm breakpoint up and fades into white below; mobile stays plain. */}}
+  {{ $bg := "" }}
+  {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
+  <div class="bg-white py-24 sm:py-32{{ with $bg }} page-bg{{ end }}"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Page title — always centered, matching the old design's PageHeader.

--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -17,6 +17,7 @@
     "lightbox" "c_scale,f_auto,q_auto,w_1600"
     "og"       "c_fill,f_auto,h_630,q_auto,w_1200"
     "rss"      "c_scale,f_auto,q_auto,w_560"
+    "bg"       "c_scale,f_auto,q_auto,w_2000"
   -}}
 
   {{- $transforms := index $presets $preset -}}


### PR DESCRIPTION
## Summary

- Restores the original site's faded full-bleed background photos on the static pages, via a shared, opt-in mechanism.
- A page sets a Cloudinary public ID in a `bgImage` frontmatter field; the static-page wrapper paints that image onto its existing full-width white background, fading into it. Applied from the `sm` breakpoint up so mobile stays plain.
- Scope is **Ministry, Donate, Archives** — the three pages that had a faded `*-bg-fade` background on the original site.

## Changes

**Mechanism** (`4b02dad`)
- `layouts/partials/cloudinary-url.html` — new `bg` preset (`c_scale,f_auto,q_auto,w_2000`, matching the old rule's `w_2000`).
- `assets/css/main.css` — `.page-bg` rule (`background-image: var(--page-bg-image)`, `no-repeat`, `100% auto`), scoped to `@media (min-width: 640px)`.
- `layouts/_default/single.html` + `archives.html` — when `bgImage` is set, the full-width wrapper gets the `page-bg` class plus an inline `--page-bg-image` custom property.

**Content** (`53c796f`)
- `bgImage` frontmatter on `ministry.md`, `donate.md`, `archives.md` (each with its pre-faded asset).

## Testing

- [x] `hugo --gc --minify` exits 0; `markdownlint` 0 errors
- [x] Build output: each in-scope page renders `page-bg` + the correct `w_2000` Cloudinary URL
- [x] `.page-bg` rule present and wrapped in the `sm` media query (mobile stays plain)
- [x] Regression: Podcast (no `bgImage`) renders unchanged plain `bg-white`
- [ ] **Visual A/B on the deploy preview** — Ministry/Donate/Archives match the live site, and content stays legible over the faded image

## Notes

- **Design decision (resolved via a live-vs-staging comparison):** the old static pages have a full-bleed faded photo behind content with **no white card**; our wrapper is already full-width white and the `*-bg-fade` assets fade into white, so the fix is **additive** — paint the image onto the existing wrapper, no teardown.
- **Family excluded:** the live Family page uses a *sharp* full-bleed hero (not a faded page-bg) — that's handled separately in #65. This keeps #69 and #65 from both touching the Family page.
- **Contact deferred:** its background lands with the contact page in Phase 11.
- **Absorbs #63** (Ministry-only background), which was closed as superseded.
- This PR's deploy preview also serves as the live verification for #80 (preview builds should render `noindex,nofollow`).

Closes #69
