### PR TITLE
fix: use the site-wide light-gray body background (#f7fafc) consistently

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -20,6 +20,12 @@
   /* Ink — the slate used for page headings, matching the original site (Tailwind v1 gray-800). */
   --color-ink: #2d3748;
 
+  /* Page background — the light gray applied to <body> site-wide, matching the
+     original site (Tailwind v1 gray-100). Tailwind v4's bg-gray-100 is #f3f4f6,
+     a different value, so we name this explicitly instead. Generates the bg-page
+     utility and is also referenced as var(--color-page) by the .page-bg rule. */
+  --color-page: #f7fafc;
+
   /* Font families — sans (Lato) is the default for UI, headings, and body;
      serif (Noto Serif) is opt-in for long-form copy; fancy (Mate SC) is decorative. */
   --font-sans: "Lato", sans-serif;
@@ -34,12 +40,12 @@
 
 /* Faded full-bleed page background for static pages (see #69). The per-page
    Cloudinary URL is injected via the --page-bg-image custom property on a
-   .page-bg element. The background color is the exact light gray the photos'
-   gradient fades to (#f7fafc — the old site's Tailwind v1 gray-100 body color),
-   so the fade is seamless instead of meeting a hard edge against white. The
-   image applies from the sm breakpoint up (640px); mobile shows the flat color. */
+   .page-bg element. The background color is the site-wide page gray (the exact
+   light gray the photos' gradient fades to), so the fade is seamless instead of
+   meeting a hard edge against white. The image applies from the sm breakpoint up
+   (640px); mobile shows the flat color. */
 .page-bg {
-  background-color: #f7fafc;
+  background-color: var(--color-page);
 }
 @media (min-width: 640px) {
   .page-bg {

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -3,10 +3,10 @@
        `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
        (its background color is the exact gray the photos fade to) and paints
        the image from the sm breakpoint up; mobile shows the flat color. Without
-       it, the wrapper keeps its plain white background. */}}
+       it, the wrapper is transparent and the body's page gray shows through. */}}
   {{ $bg := "" }}
   {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="{{ if $bg }}page-bg{{ else }}bg-white{{ end }} py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
+  <div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Display heading "Through the Years" comes from the `heading` frontmatter

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     {{ partial "css.html" . }}
   {{ end }}
 </head>
-<body class="min-h-screen bg-gray-100 font-sans text-gray-900">
+<body class="min-h-screen bg-page font-sans text-gray-900">
   {{ partial "header.html" . }}
   <main class="pt-16">
     {{ block "main" . }}{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,10 +3,10 @@
        `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
        (its background color is the exact gray the photos fade to) and paints
        the image from the sm breakpoint up; mobile shows the flat color. Without
-       it, the wrapper keeps its plain white background. */}}
+       it, the wrapper is transparent and the body's page gray shows through. */}}
   {{ $bg := "" }}
   {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="{{ if $bg }}page-bg{{ else }}bg-white{{ end }} py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
+  <div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Page title — always centered, matching the old design's PageHeader.

--- a/layouts/_default/subscribe.html
+++ b/layouts/_default/subscribe.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* "Subscribe" page header — always centered, matching the other static

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <article class="bg-white py-24 sm:py-32">
+  <article class="py-24 sm:py-32">
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
 
       {{/* Cover image */}}

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $tagCount := len .Data.Terms -}}

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <div class="bg-white py-24 sm:py-32">
+  <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $count := len .Pages -}}


### PR DESCRIPTION
## Summary

- Restores the site-wide light-gray body background (`#f7fafc`) the original site uses, fixing the inconsistent gray/white look across the Hugo rebuild and bringing back the subtle nav-vs-body contrast.
- Fixes the two root causes from the issue: the body shade had silently drifted to Tailwind v4's `#f3f4f6`, and full-width `bg-white` wrappers were covering the gray body on most pages.

## Changes

- **Named token** — added `--color-page: #f7fafc` as a Tailwind v4 `@theme` color (generates the `bg-page` utility and exposes `var(--color-page)`), so the value lives in one place instead of being implied by `bg-gray-100`.
- **Body** — `layouts/_default/baseof.html`: `bg-gray-100` → `bg-page`.
- **`.page-bg` cleanup** — pointed the rule added in #69 at `var(--color-page)`, removing the duplicated `#f7fafc` literal.
- **Removed full-width white wrappers** so the gray shows on `blog/list.html`, `blog/single.html`, `taxonomy/term.html`, `taxonomy/taxonomy.html`, and `subscribe.html`.
- **Static-page layouts** (`_default/single.html`, `_default/archives.html`) — dropped the `bg-white` fallback: no `bgImage` → body gray shows; with a `bgImage` the `page-bg` wrapper (which fades into the same gray) is unchanged. Stale comments updated to match.

## Design decisions (per-page treatment)

The original Nuxt site was **gray body + white preview cards**, with post / static / subscribe content sitting directly on the gray. This PR matches the gray body everywhere.

For the one genuine white surface — the listing-page preview cards — I kept the rebuild's existing **borderless** card design rather than adding white card surfaces. The gray now shows through the page margins and card gutters. This is the single intentional divergence from the original's literal "white card" look, chosen to avoid a card redesign (out of scope) and confirmed during planning.

## Testing

- [x] `hugo --gc --minify` passes (36 pages)
- [x] Clean rebuild confirms exactly one `.page-bg{background-color:var(--color-page)}` rule and the generated `.bg-page{background-color:var(--color-page)}` utility (no duplicated literal)
- [x] Live-vs-preview A/B — gray-body + white-nav contrast confirmed on the blog index, a blog post, and the subscribe page, matching the original site's `#f7fafc`

Closes #88
