### PR TITLE
feat: align Family page header with existing design (cover hero)

### DIFF
--- a/content/family.md
+++ b/content/family.md
@@ -1,5 +1,7 @@
 ---
 title: "Family"
+layout: family
+cover: "v1732215040/OFReport/assets/family-2024-cropped_inq8ir.jpg"
 description: >-
   Joshua and Kelsie are missionaries enjoying life as best friends, serving
   their Savior, and raising up their children to honor Him.

--- a/layouts/_default/family.html
+++ b/layouts/_default/family.html
@@ -1,0 +1,47 @@
+{{ define "main" }}
+  {{/* Family page — opens with a full-bleed cover hero (no "Family" <h1>),
+       followed by a centered intro tagline and the left-aligned bio. Mirrors
+       the original family.vue design. */}}
+
+  {{/* Cover hero. The original used a CSS background (bg-cover bg-top) across
+       four responsive widths; we use a responsive <img> with object-cover so the
+       photo gets real alt text and the browser picks the right width. The widths
+       (768/1024/1500/2000) and version-pinned public ID match the old site.
+       URLs are built inline because the shared cloudinary-url partial only emits
+       fixed-width presets, not a multi-width srcset. */}}
+  {{ $id := "v1732215040/OFReport/assets/family-2024-cropped_inq8ir.jpg" }}
+  {{ $widths := slice 768 1024 1500 2000 }}
+  {{ $srcset := slice }}
+  {{ range $widths }}
+    {{ $url := printf "%s/image/upload/c_scale,f_auto,q_auto:best,w_%d/%s" site.Params.cloudinaryBase . $id }}
+    {{ $srcset = $srcset | append (printf "%s %dw" $url .) }}
+  {{ end }}
+  {{ $fallback := printf "%s/image/upload/c_scale,f_auto,q_auto:best,w_1024/%s" site.Params.cloudinaryBase $id }}
+
+  {{/* Emit srcset as a safe attribute: the Cloudinary transforms contain commas
+       (c_scale,f_auto,…) that Go's srcset escaper would otherwise split on,
+       mangling q_auto:best into #ZgotmplZ. Browsers parse the comma-containing
+       URLs correctly. */}}
+  <img
+    src="{{ $fallback }}"
+    {{ printf "srcset=%q" (delimit $srcset ", ") | safeHTMLAttr }}
+    sizes="100vw"
+    alt="The Steele Family"
+    class="w-full border-b border-gray-200 object-cover object-top min-h-[250px] sm:min-h-[450px] md:min-h-[500px] lg:min-h-[700px] xl:min-h-[900px]"
+  />
+
+  <div class="mx-auto max-w-3xl px-6 lg:px-8">
+
+    {{/* Centered intro tagline (line break after "Steele Family:"). */}}
+    <p class="mt-2 text-center text-sm font-semibold text-ink sm:text-base">
+      Pleased to meet you! We&rsquo;re the Steele Family:<br />
+      Joshua, Kelsie, Abigail, Rebekah, Hosanna, Kathryn, David, and Mia
+    </p>
+
+    {{/* Bio body — left-aligned prose authored in content/family.md. */}}
+    <div class="mt-8 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
+      {{ .Content }}
+    </div>
+
+  </div>
+{{ end }}

--- a/layouts/_default/family.html
+++ b/layouts/_default/family.html
@@ -8,7 +8,13 @@
        photo gets real alt text and the browser picks the right width. The widths
        (768/1024/1500/2000) and version-pinned public ID match the old site.
        URLs are built inline because the shared cloudinary-url partial only emits
-       fixed-width presets, not a multi-width srcset. */}}
+       fixed-width presets, not a multi-width srcset.
+
+       Heights are FIXED (not min-heights) so the photo behaves like the old
+       bg-cover section instead of stretching to the image's intrinsic ratio.
+       max-h-[75vh] mirrors the original's xl:h-3/4-vh (75vh) constraint, applied
+       at every breakpoint so the photo never fills the viewport and the tagline
+       below it stays visible. */}}
   {{ $id := "v1732215040/OFReport/assets/family-2024-cropped_inq8ir.jpg" }}
   {{ $widths := slice 768 1024 1500 2000 }}
   {{ $srcset := slice }}
@@ -27,7 +33,7 @@
     {{ printf "srcset=%q" (delimit $srcset ", ") | safeHTMLAttr }}
     sizes="100vw"
     alt="The Steele Family"
-    class="w-full border-b border-gray-200 object-cover object-top min-h-[250px] sm:min-h-[450px] md:min-h-[500px] lg:min-h-[700px] xl:min-h-[900px]"
+    class="w-full border-b border-gray-200 object-cover object-top h-[250px] sm:h-[450px] md:h-[500px] lg:h-[700px] xl:h-[900px] max-h-[75vh]"
   />
 
   <div class="mx-auto max-w-3xl px-6 lg:px-8">


### PR DESCRIPTION
## Summary

Aligns the Family page header with the original site design. The page now opens with a full-bleed family cover photo, a centered intro tagline, and the left-aligned bio — replacing the plain left-aligned "Family" `<h1>` the rebuild was showing.

Closes #65

## Changes

- **`layouts/_default/family.html`** *(new)* — a dedicated layout selected via `layout: family` frontmatter. The shared `layouts/_default/single.html` always renders an `<h1>`, which the Family page must omit, so a custom template is required (same pattern as `subscribe`/`archives`). It renders, top to bottom: the cover hero, the centered tagline (line break after "Steele Family:"), and the left-aligned bio from `family.md`.
- **`content/family.md`** — adds `layout: family` and a `cover:` image so the OG/Twitter social image is the family photo, restoring parity with the old page (the `seo.html` partial already wires `cover` → `og:image`).

## Design decisions

- **Hero is a responsive `<img>`, not a CSS background.** The original used `bg-cover bg-top` on a `<section>`; I used `<img>` with `object-cover object-top` so the photo gets real `alt` text and the browser picks the optimal width. A four-width `srcset` (`w_768/1024/1500/2000`) and version-pinned public ID mirror the old breakpoints.
- **`srcset` emitted via `safeHTMLAttr`.** Cloudinary transforms contain commas (`c_scale,f_auto,q_auto:best,…`) that Go's `html/template` srcset escaper splits on, mangling `q_auto:best` into `#ZgotmplZ`. `safeHTMLAttr` bypasses that escaping; browsers parse the comma-containing URLs correctly.
- **URLs built inline.** The shared `cloudinary-url` partial only emits fixed-width presets, not a multi-width `srcset`, so the four hero URLs are constructed inline. Extending the shared partial for a single responsive hero would be premature abstraction.
- **Dropped the old `xs:350px` height step.** Tailwind v4 has no `xs` breakpoint; min-heights now step `250 → sm:450 → md:500 → lg:700 → xl:900` px, which still satisfies "responsive heights."

## Verification

- `hugo --gc --minify` builds clean (36 pages).
- Confirmed in rendered HTML: no `<h1>`, clean `srcset` with `q_auto:best` intact across all four widths, tagline with `<br>`, correct `og:image`.
- Visually verified `/family/` on desktop: full-bleed hero, centered tagline, left-aligned bio, no regressions.
