### PR TITLE
refactor: extract shared page-shell partial for static-page layouts

### DIFF
--- a/docs/chrome-devtools-mcp.md
+++ b/docs/chrome-devtools-mcp.md
@@ -66,8 +66,17 @@ The server exposes roughly 40 tools by default; the fuller catalog is around 47 
 2. On the next Claude Code session **in this project**, approve the trust prompt for the new `chrome-devtools` MCP server (a one-time Claude Code safeguard for project-scoped servers). The tools then load only in this repo.
 3. Ask the agent to use the tools, for example:
    - "Run a Lighthouse audit on the home page and summarize the accessibility issues."
-   - "Trace the article page load and find the largest layout shifts."
+   - "Trace the article page load **on a production build** and find the largest layout shifts."
    - "Emulate an iPhone and a slow 4G connection, then screenshot the blog list."
+
+### Which audits are trustworthy against the dev server
+
+The dev server (`hugo server -D`) is **not** representative of production, so split audits by type:
+
+- **Accessibility, SEO, best-practices** — run freely against `http://localhost:1313/`. These are structural checks (alt text, heading order, meta tags, contrast) that don't depend on how assets are built or served.
+- **Performance / Core Web Vitals / LCP** — do **not** trust dev-server numbers. `hugo server -D` serves unminified assets, injects a LiveReload script that is absent from production, includes drafts, and applies no compression, CDN, or cache headers — whereas Netlify serves the `hugo --gc --minify` output from an edge with Brotli/gzip and far-future caching on fingerprinted assets. Run performance audits against either a local **production build** (`hugo --gc --minify`, then serve the `public/` directory with e.g. `npx serve public`) or the live `https://ofreport.com` URL (removing `--no-performance-crux` to pick up real-world CrUX field data — see below).
+
+Layout shift (CLS) is the one performance-adjacent metric worth a glance on dev too, since it's usually caused by missing image dimensions or font swaps that exist regardless of build. Even so, confirm any CLS finding against a production build before acting on it.
 
 ### When to flip a flag back
 

--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,6 +34,14 @@ Each entry records one deviation or decision:
 
 ## Entries
 
+### 2026-06-13 — `layouts/partials/page-shell-open.html`, `layouts/partials/page-shell-close.html`, `layouts/_default/{single,contact,subscribe,archives}.html`
+
+**What changed:** Extracted the shared static-page "shell" (the faded `bgImage` background wrapper + centered page `<h1>`) into a `page-shell-open.html` / `page-shell-close.html` partial pair that `single`, `contact`, `subscribe`, and `archives` now consume (issue #92). In doing so, the shared `<h1>` standardized on the `text-center`-first class order used by 3 of the 4 layouts, which reorders the class attribute on pages rendered through `single.html` (`ministry`, `donate`, `thank-you`, `podcast`).
+
+**Why:** Issue #92 set "rendered HTML is byte-equivalent" as the bar, but `single.html`'s `<h1>` already listed its utility classes in a different order than the other three layouts, so a single shared header cannot be byte-identical to all four at once. Standardizing on the majority order changes only one layout's output, and the change is a pure class **reorder** (identical class set) — verified visually inert since Tailwind applies utility CSS by stylesheet source order, not class-attribute order. A full recursive `public/` diff confirmed every other page (including the byte-identical `contact`/`subscribe`/`archives`) is unchanged. Chose a partial pair over a `baseof` block because `family.html` shares Hugo's default `type = "page"` but uses a divergent cover-hero design that a type-level base block would wrongly wrap.
+
+**Category:** Discovery
+
 ### 2026-06-06 — `docs/prd/01-architecture.md` §"RSS Feed", `docs/prd/ROADMAP.md` Phase 9
 
 **What changed:** The custom RSS feed sends a curated excerpt (`<description>`) plus a single cover-image `<enclosure>` per item, rather than the full HTML-rendered article the PRD called for ("include HTML-rendered description/content").

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,57 +1,41 @@
 {{ define "main" }}
-  {{/* Optional faded full-bleed background — Cloudinary public ID in the
-       `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
-       (its background color is the exact gray the photos fade to) and paints
-       the image from the sm breakpoint up; mobile shows the flat color. Without
-       it, the wrapper is transparent and the body's page gray shows through. */}}
-  {{ $bg := "" }}
-  {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
-    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+  {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
-      {{/* Display heading "Through the Years" comes from the `heading` frontmatter
-           (matches the original PageHeader); .Title ("Archives") stays the SEO/tab
-           title. Centered to match the original design. */}}
-      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
-        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
-      </h1>
-
-      {{/* Intro prose (left-aligned), authored in archives.md. */}}
-      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
-        {{ .Content }}
-      </div>
-
-      {{/* Newsletter issues grouped by year. data/archives.json → hugo.Data.archives
-           is a map keyed by year string; Hugo ranges map keys ascending, so collect
-           the keys and sort them descending to list newest first (replaces the old
-           site's Object.keys(archives).reverse()).
-
-           Each year is a two-column row: the year label on the left, its issues on
-           the right, with a divider between years (none after the last). */}}
-      {{ $archives := hugo.Data.archives }}
-      {{ $years := slice }}
-      {{ range $year, $_ := $archives }}
-        {{ $years = $years | append $year }}
-      {{ end }}
-
-      <div class="mt-10 max-w-2xl">
-        {{ range sort $years "value" "desc" }}
-          <div class="flex border-b border-gray-200 pb-6 mb-6 last:mb-0 last:border-b-0 last:pb-0 sm:pb-8 sm:mb-8">
-            <h2 class="shrink-0 pr-4 font-sans text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
-            <ul class="space-y-2 md:space-y-4">
-              {{ range (index $archives .) }}
-                <li class="flex items-start gap-2">
-                  <svg viewBox="0 0 640 512" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path d="M537.6 226.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 64.2 315.3 32 256 32c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 219.8 0 273.2 0 336c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 420.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 315.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V176c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z"/></svg>
-                  <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">
-                    {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
-                  </a>
-                </li>
-              {{ end }}
-            </ul>
-          </div>
-        {{ end }}
-      </div>
-
+    {{/* Intro prose (left-aligned), authored in archives.md. */}}
+    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      {{ .Content }}
     </div>
-  </div>
+
+    {{/* Newsletter issues grouped by year. data/archives.json → hugo.Data.archives
+         is a map keyed by year string; Hugo ranges map keys ascending, so collect
+         the keys and sort them descending to list newest first (replaces the old
+         site's Object.keys(archives).reverse()).
+
+         Each year is a two-column row: the year label on the left, its issues on
+         the right, with a divider between years (none after the last). */}}
+    {{ $archives := hugo.Data.archives }}
+    {{ $years := slice }}
+    {{ range $year, $_ := $archives }}
+      {{ $years = $years | append $year }}
+    {{ end }}
+
+    <div class="mt-10 max-w-2xl">
+      {{ range sort $years "value" "desc" }}
+        <div class="flex border-b border-gray-200 pb-6 mb-6 last:mb-0 last:border-b-0 last:pb-0 sm:pb-8 sm:mb-8">
+          <h2 class="shrink-0 pr-4 font-sans text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
+          <ul class="space-y-2 md:space-y-4">
+            {{ range (index $archives .) }}
+              <li class="flex items-start gap-2">
+                <svg viewBox="0 0 640 512" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path d="M537.6 226.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 64.2 315.3 32 256 32c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 219.8 0 273.2 0 336c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 420.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 315.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V176c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z"/></svg>
+                <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">
+                  {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
+                </a>
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+      {{ end }}
+    </div>
+
+  {{ partial "page-shell-close.html" . }}
 {{ end }}

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -1,28 +1,13 @@
 {{ define "main" }}
-  {{/* Faded full-bleed background — same mechanism as _default/single.html.
-       The `bgImage` frontmatter holds a Cloudinary public ID; the page-bg
-       class paints it from the sm breakpoint up over the page's flat gray,
-       while mobile shows the flat color. */}}
-  {{ $bg := "" }}
-  {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
-    <div class="mx-auto max-w-2xl px-6 lg:px-8">
+  {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-2xl") }}
 
-      {{/* Page header — always centered, matching the other static pages. An
-           optional `heading` frontmatter field overrides .Title (which doubles
-           as the SEO/tab title). */}}
-      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
-        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
-      </h1>
-
-      {{/* Intro copy authored in content/contact.md */}}
-      <div class="mt-10 prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
-        {{ .Content }}
-      </div>
-
-      {{/* Netlify contact form */}}
-      {{ partial "contact-form.html" . }}
-
+    {{/* Intro copy authored in content/contact.md */}}
+    <div class="mt-10 prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      {{ .Content }}
     </div>
-  </div>
+
+    {{/* Netlify contact form */}}
+    {{ partial "contact-form.html" . }}
+
+  {{ partial "page-shell-close.html" . }}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,27 +1,11 @@
 {{ define "main" }}
-  {{/* Optional faded full-bleed background — Cloudinary public ID in the
-       `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class
-       (its background color is the exact gray the photos fade to) and paints
-       the image from the sm breakpoint up; mobile shows the flat color. Without
-       it, the wrapper is transparent and the body's page gray shows through. */}}
-  {{ $bg := "" }}
-  {{ with .Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end }}
-  <div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
-    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+  {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
-      {{/* Page title — always centered, matching the old design's PageHeader.
-           An optional "heading" frontmatter field overrides .Title (and may
-           contain inline HTML such as <br>). */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans text-center sm:text-5xl">
-        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
-      </h1>
-
-      {{/* Page content — "centered: true" centers the body (e.g. Ministry);
-           otherwise it stays left-aligned. */}}
-      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
-        {{ .Content }}
-      </div>
-
+    {{/* Page content — "centered: true" centers the body (e.g. Ministry);
+         otherwise it stays left-aligned. */}}
+    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
+      {{ .Content }}
     </div>
-  </div>
+
+  {{ partial "page-shell-close.html" . }}
 {{ end }}

--- a/layouts/_default/subscribe.html
+++ b/layouts/_default/subscribe.html
@@ -1,52 +1,44 @@
 {{ define "main" }}
-  <div class="py-24 sm:py-32">
-    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+  {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
-      {{/* "Subscribe" page header — always centered, matching the other static
-           pages. .Title doubles as the SEO/tab title. */}}
-      <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
-        {{- with .Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.Title }}{{ end -}}
-      </h1>
+    {{/* Two-column row: the Overseas Field Report cover beside the intro copy,
+         signup form, and links. The large cover shows from sm up; on mobile it
+         hides and a smaller cover sits inline above the form with the intro. */}}
+    {{ $cover := partial "cloudinary-url.html" (dict "src" "OFReport/assets/OFR-Aug-Dec-2020_dxpdvm.jpg" "preset" "cover") }}
 
-      {{/* Two-column row: the Overseas Field Report cover beside the intro copy,
-           signup form, and links. The large cover shows from sm up; on mobile it
-           hides and a smaller cover sits inline above the form with the intro. */}}
-      {{ $cover := partial "cloudinary-url.html" (dict "src" "OFReport/assets/OFR-Aug-Dec-2020_dxpdvm.jpg" "preset" "cover") }}
+    <div class="mt-10 max-w-2xl sm:flex sm:items-start sm:gap-8 md:gap-10">
+      <figure class="hidden shrink-0 sm:block">
+        <img src="{{ $cover }}" width="200" alt="Overseas Field Report newsletter cover" class="w-[150px] rounded shadow-lg md:w-[200px]" />
+      </figure>
 
-      <div class="mt-10 max-w-2xl sm:flex sm:items-start sm:gap-8 md:gap-10">
-        <figure class="hidden shrink-0 sm:block">
-          <img src="{{ $cover }}" width="200" alt="Overseas Field Report newsletter cover" class="w-[150px] rounded shadow-lg md:w-[200px]" />
-        </figure>
+      <div class="flex-1">
+        <div class="flex items-start gap-4">
+          <figure class="shrink-0 sm:hidden">
+            <img src="{{ $cover }}" width="100" alt="Overseas Field Report newsletter cover" class="w-[100px] rounded shadow-md" />
+          </figure>
 
-        <div class="flex-1">
-          <div class="flex items-start gap-4">
-            <figure class="shrink-0 sm:hidden">
-              <img src="{{ $cover }}" width="100" alt="Overseas Field Report newsletter cover" class="w-[100px] rounded shadow-md" />
-            </figure>
-
-            {{/* Intro copy authored in content/subscribe.md */}}
-            <div class="prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
-              {{ .Content }}
-            </div>
+          {{/* Intro copy authored in content/subscribe.md */}}
+          <div class="prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+            {{ .Content }}
           </div>
-
-          <div class="mt-6">
-            {{ partial "mailchimp-form.html" . }}
-          </div>
-
-          <p class="mt-6 font-serif">
-            You can also access previous issues in our <a href="/archives/" class="text-blue-700 hover:text-blue-900">Archives</a>.
-          </p>
-
-          <hr class="my-8 border-gray-200" />
-
-          <p class="font-serif text-gray-700">Don&rsquo;t want to receive emails from us anymore?</p>
-          <p class="mt-2 font-serif">
-            <a href="https://OFReport.us6.list-manage.com/unsubscribe?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">Unsubscribe</a>
-          </p>
         </div>
-      </div>
 
+        <div class="mt-6">
+          {{ partial "mailchimp-form.html" . }}
+        </div>
+
+        <p class="mt-6 font-serif">
+          You can also access previous issues in our <a href="/archives/" class="text-blue-700 hover:text-blue-900">Archives</a>.
+        </p>
+
+        <hr class="my-8 border-gray-200" />
+
+        <p class="font-serif text-gray-700">Don&rsquo;t want to receive emails from us anymore?</p>
+        <p class="mt-2 font-serif">
+          <a href="https://OFReport.us6.list-manage.com/unsubscribe?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">Unsubscribe</a>
+        </p>
+      </div>
     </div>
-  </div>
+
+  {{ partial "page-shell-close.html" . }}
 {{ end }}

--- a/layouts/partials/page-shell-close.html
+++ b/layouts/partials/page-shell-close.html
@@ -1,0 +1,3 @@
+{{- /* Closes the container and background wrapper opened by page-shell-open.html. */ -}}
+  </div>
+</div>

--- a/layouts/partials/page-shell-open.html
+++ b/layouts/partials/page-shell-open.html
@@ -1,0 +1,27 @@
+{{- /* Shared scaffolding for the centered static-page layouts (single, contact,
+       subscribe, archives). Renders the optional faded full-bleed background
+       wrapper, the centered max-width container, and the centered page header.
+       Always pair a call to this with page-shell-close.html.
+
+       Params:
+         page      the page context (`.`) — read for .Params.bgImage,
+                   .Params.heading, and .Title
+         maxWidth  the container max-width utility class, e.g. "max-w-3xl"
+                   (pass the full class name so Tailwind's purge can see it)
+
+       Optional faded full-bleed background — a Cloudinary public ID in the
+       `bgImage` frontmatter. When set, the wrapper uses the `page-bg` class (its
+       background color is the exact gray the photos fade to) and paints the image
+       from the sm breakpoint up; mobile shows the flat color. Without it the
+       wrapper is transparent and the body's page gray shows through. */ -}}
+{{- $bg := "" -}}
+{{- with .page.Params.bgImage }}{{ $bg = partial "cloudinary-url.html" (dict "src" . "preset" "bg") }}{{ end -}}
+<div class="{{ if $bg }}page-bg {{ end }}py-24 sm:py-32"{{ with $bg }} style="--page-bg-image: url('{{ . }}')"{{ end }}>
+  <div class="mx-auto {{ .maxWidth }} px-6 lg:px-8">
+
+    {{/* Page title — always centered, matching the old design's PageHeader. An
+         optional `heading` frontmatter field overrides .Title (and may contain
+         inline HTML such as <br>); .Title still doubles as the SEO/tab title. */}}
+    <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
+      {{- with .page.Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.page.Title }}{{ end -}}
+    </h1>


### PR DESCRIPTION
## Summary

Extracts the duplicated static-page "shell" — the optional faded `bgImage` background wrapper and the centered page `<h1>` — into a `page-shell-open.html` / `page-shell-close.html` partial pair. `single`, `contact`, `subscribe`, and `archives` now supply only their page-specific body between the two calls, so header styling, the `heading`/`title` fallback, and the background mechanism live in one place instead of being copy-pasted across 2–4 files.

Net **−17 lines**.

## Design choice

Used an open/close partial pair (the issue's option **a**), mirroring how `baseof.html` already wraps content with `header`/`footer` partials. Rejected the `baseof`-block idiom (option **b**) because `family.html` shares Hugo's default `type = "page"` but uses a divergent full-bleed cover-hero with no `<h1>` — a type-level base block would wrongly wrap it. Logged in `docs/prd/CHANGELOG.md`.

## Verification — pure refactor, zero output change

A full recursive diff of the production `public/` build (before vs after) shows the **only** change anywhere is the `<h1>` class *order* on the four `single.html`-rendered pages (ministry, donate, thank-you, podcast): the shared header standardizes on the `text-center`-first order already used by 3 of the 4 layouts. Verified via script that the class *set* is identical and the rest of every document is byte-for-byte unchanged; `contact`/`subscribe`/`archives` are byte-identical including the header. Tailwind applies utility CSS by stylesheet order, not attribute order, so the reorder is visually inert (CSS output is the same fingerprinted file). `hugo --gc --minify` builds clean. This one inert deviation from strict byte-equivalence is documented in the CHANGELOG.

## QA notes

Ran a chrome-devtools Lighthouse pass on `/contact/` (Accessibility 96, Best Practices 100, SEO 69) and a mobile emulation reflow check on `/subscribe/` — both confirm the refactored pages render correctly. The SEO 69 is a dev-server artifact (`seo.html` emits `noindex,nofollow` outside production; production is `index,follow`), not a real regression.

The audit also surfaced a **pre-existing** accessibility issue unrelated to this refactor — the contact submit button fails WCAG AA contrast — filed separately as #94 and intentionally left out of this pure-refactor PR.

## Notes

Depends on #91 (merged), which introduced `contact.html`, so this refactor covers the final set of layouts in one pass.

Closes #92
