### PR TITLE
fix: meet WCAG AA contrast on primary filled buttons

### DIFF
--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -79,7 +79,7 @@
 
   <button
     type="submit"
-    class="w-full cursor-pointer rounded-full bg-blue-600 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:w-auto"
+    class="w-full cursor-pointer rounded-full bg-blue-800 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:w-auto"
   >
     Send Message
   </button>

--- a/layouts/partials/mailchimp-form.html
+++ b/layouts/partials/mailchimp-form.html
@@ -43,7 +43,7 @@
       type="submit"
       name="subscribe"
       value="Subscribe"
-      class="cursor-pointer rounded-full bg-blue-600 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:rounded-l-none"
+      class="cursor-pointer rounded-full bg-blue-800 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:rounded-l-none"
     />
   </form>
 </div>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -32,7 +32,7 @@
 {{- $outline := eq (printf "%v" (.Get "outline")) "true" -}}
 {{- $external := eq (printf "%v" (.Get "external")) "true" -}}
 {{- $center := ne (.Get "align") "left" -}}
-{{- $variant := cond $outline "text-blue-700 ring-1 ring-inset ring-blue-700/30 hover:bg-blue-50" "bg-blue-600 text-white shadow-sm hover:bg-blue-700" -}}
+{{- $variant := cond $outline "text-blue-700 ring-1 ring-inset ring-blue-700/30 hover:bg-blue-50" "bg-blue-800 text-white shadow-sm hover:bg-blue-900" -}}
 <div class="my-6 md:my-8{{ if $center }} text-center{{ end }}">
   <a
     href="{{ $href }}"


### PR DESCRIPTION
## Summary

- Fixes a WCAG 2.1 AA color-contrast failure on the site's primary **filled** buttons: white text on `bg-blue-600` (#1992d4) measured **3.44:1**, below the 4.5:1 minimum for normal-size text; the `hover:bg-blue-700` (#127fbf) state was also short at ≈4.36:1.
- Darkens the shared filled-button convention to `bg-blue-800` (#0b69a3, ≈**5.9:1**) with `hover:bg-blue-900` (#035388, ≈**8.1:1**) — both clear AA comfortably.
- Applied to all three usages of the pattern so the buttons stay visually consistent, not just the one button named in the issue.

## Changes

- `layouts/partials/contact-form.html` — Send Message submit button
- `layouts/partials/mailchimp-form.html` — Subscribe submit button
- `layouts/shortcodes/button.html` — filled variant of the `{{< button >}}` CTA shortcode

The outline/secondary button variant (`hover:bg-blue-50`) and the `focus:ring-blue-500` ring are intentionally unchanged — neither was part of the failing audit.

## Testing

- [x] `hugo --gc --minify` builds clean; the referenced CSS generates `.bg-blue-800` and the `hover:bg-blue-900` utility (verified `#0b69a3` is emitted).
- [x] Lighthouse accessibility audit on `/contact/` (chrome-devtools): **96 → 100**, `color-contrast` now passes with **0 offending nodes**.
- [x] Contact and Subscribe buttons both render `bg-blue-800 … hover:bg-blue-900`; the shortcode's filled variant shares the same generated CSS rule.

## Notes

- Scope was expanded from the literal issue (contact button only) to the shared filled-button convention, with sign-off — fixing one button alone would have left the Subscribe button failing **and** visibly lighter than the corrected Contact button.
- The remaining Lighthouse SEO finding on `/contact/` (`is-crawlable`) is a dev-server artifact (`seo.html` emits `noindex,nofollow` outside production); it is unrelated to this change and does not occur in the production build.

Closes #94
