### PR TITLE
style(callout): port thick-rule design from original site

### DIFF
--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,13 +1,17 @@
 {{- /*
-  callout — highlighted box for important info / CTAs, with an optional PDF link.
+  callout — centered, bold text delimited by thick top + bottom rules, with an
+  optional PDF download link. Ports the original ArticleCallout.vue treatment, a
+  recurring site design element (the same thick rule sits above the
+  article-footer newsletter block — see partials/article-footer.html).
 
   Paired shortcode used with angle brackets ({{< callout >}}…{{< /callout >}}),
   so .Inner is raw and we render it as markdown ourselves. display=block ensures
   paragraphs/lists wrap properly (RenderString defaults to inline otherwise).
 
-  The [&>:first-child]:mt-0 / [&>:last-child]:mb-0 utilities reset the outer
-  margins of the prose-rendered content so the box padding stays even — the
-  inner <p> isn't a direct child of .prose, so its margins aren't auto-trimmed.
+  font-bold / text-center / sm:text-xl on the container are inherited by the
+  prose-rendered content (and center the inline PDF link). The
+  [&>:first-child]:mt-0 / [&>:last-child]:mb-0 utilities reset the outer margins
+  of that content so the vertical padding stays even.
 
   Params:
     pdf (optional) newsletter PDF filename; appended to site.Params.pdfBase
@@ -21,16 +25,16 @@
     Get the full newsletter PDF.
     {{< /callout >}}
 */ -}}
-<div class="callout my-6 rounded-r-lg border-l-4 border-blue-500 bg-blue-50 px-5 py-4 [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+<div class="callout my-12 border-t-4 border-b-4 border-gray-200 py-4 text-center font-bold sm:py-6 sm:text-xl [&>:first-child]:mt-0 [&>:last-child]:mb-0">
   {{ .Page.RenderString (dict "display" "block") .Inner }}
   {{- with .Get "pdf" }}
   <a
     href="{{ site.Params.pdfBase }}{{ . }}"
-    class="callout-download inline-flex items-center gap-1.5 font-sans font-semibold text-blue-700 no-underline transition-colors hover:text-blue-900"
+    class="callout-download inline-flex items-center gap-1.5 font-sans text-blue-700 no-underline transition-colors hover:text-blue-900"
     target="_blank"
     rel="noopener noreferrer"
   >
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5 text-[#e53e3e]" aria-hidden="true"><path fill-rule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875H5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875Zm5.845 17.03a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V12a.75.75 0 0 0-1.5 0v4.19l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3Z" clip-rule="evenodd" /><path d="M14.25 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 16.5 7.5h-1.875a.375.375 0 0 1-.375-.375V5.25Z" /></svg>
     Download PDF
   </a>
   {{- end }}


### PR DESCRIPTION
## Summary

Reconciles the `callout` shortcode with the original Nuxt site's design (`ArticleCallout.vue`). The shortcode now renders centered, bold text delimited by a thick top + bottom rule — the same recurring `border-t-4 border-gray-200` divider used above the article-footer newsletter block — replacing the previous blue left-accent box.

The optional `pdf=` download link is preserved and restyled to match: centered under the rule, using the solid red Heroicon `document-arrow-down` (`#e53e3e`) beside the "Download PDF" link, evoking the original's red PDF glyph while staying in the Heroicons family.

## Changes

- `layouts/shortcodes/callout.html`:
  - Container: `border-t-4 border-b-4 border-gray-200`, `py-4 sm:py-6`, `my-12`, `text-center font-bold sm:text-xl` (inherited by the prose-rendered content and the inline PDF link).
  - PDF icon: outline `document-arrow-down` → **solid**, colored red (`text-[#e53e3e]`).
  - Kept the existing `[&>:first-child]:mt-0 / [&>:last-child]:mb-0` margin resets and `text-blue-700`/`hover:text-blue-900` link color.

## Verification

- `hugo --gc --minify` builds clean (38 pages).
- In-browser visual check (chrome-devtools):
  - **Plain variant** (`content/podcast.md`, the only migrated usage): centered bold text between thick rules — matches the original.
  - **PDF variant** (throwaway test page, removed): centered bold text + centered "Download PDF" link with the solid red icon.

## Notes / scope

- **Shared partial deferred.** The thick rule now appears inline in two templates (article-footer + callout). Per rule-of-three, extraction into a shared partial is intentionally deferred until a 3rd distinct template uses it.
- **Archive page tracked separately.** The archives page still uses the old Font Awesome cloud-download icon; switching it to this same Heroicon is tracked in #105 to keep this PR atomic.

Closes #104
