### PR TITLE
style(archives): swap Font Awesome cloud for solid Heroicon PDF icon

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -26,7 +26,7 @@
           <ul class="space-y-2 md:space-y-4">
             {{ range (index $archives .) }}
               <li class="flex items-start gap-2">
-                <svg viewBox="0 0 640 512" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path d="M537.6 226.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 64.2 315.3 32 256 32c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 219.8 0 273.2 0 336c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 420.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 315.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V176c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z"/></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path fill-rule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875H5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875Zm5.845 17.03a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V12a.75.75 0 0 0-1.5 0v4.19l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3Z" clip-rule="evenodd" /><path d="M14.25 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 16.5 7.5h-1.875a.375.375 0 0 1-.375-.375V5.25Z" /></svg>
                 <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">
                   {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
                 </a>


### PR DESCRIPTION
## Summary

Standardizes the PDF-download icon on the archive page. The page previously rendered the old Font Awesome cloud-download icon (carried over verbatim during the archive build); this swaps it for the solid red Heroicon `document-arrow-down` — the same icon now used by the `callout` shortcode's `pdf=` link (#106) — for a consistent download affordance site-wide.

## Changes

- `layouts/_default/archives.html`: replaced the Font Awesome cloud SVG (`viewBox="0 0 640 512"`) with the solid `document-arrow-down` Heroicon (`viewBox="0 0 24 24"`). Preserved the existing color (`text-[#e53e3e]`), size (`size-5`), and alignment (`mt-1 shrink-0`) classes, so layout is unchanged.

## Verification

- `hugo --gc --minify` builds clean (38 pages).
- In-browser visual check (chrome-devtools): each newsletter issue renders the solid red Heroicon, matching the callout icon; color, size, and top alignment intact.

Closes #105
