### PR TITLE
feat: integrate GLightbox for article images

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -21,7 +21,7 @@ links to the relevant PRD document for full requirements.
 | 10 | SEO & Meta Tags | Phase 3 | Complete |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Complete |
 | 12 | Newsletter Integration | Phase 3 | Complete |
-| 13 | Lightbox Integration | Phase 6 | Not started |
+| 13 | Lightbox Integration | Phase 6 | In progress |
 | 14 | Analytics | Phase 3 | Not started |
 | 15 | Content Migration | Phase 6 | Not started |
 | 16 | Deployment | Phase 15 | Not started |
@@ -150,10 +150,11 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 13: Lightbox Integration
 
-- [ ] GLightbox CSS/JS loaded (see [`01-architecture.md`](./01-architecture.md))
-- [ ] `partials/glightbox.html` — conditional loading on article pages
-- [ ] Figure shortcode outputs lightbox-compatible HTML
-- [ ] Tested with actual Cloudinary images
+- [x] GLightbox CSS/JS loaded (see [`01-architecture.md`](./01-architecture.md))
+- [x] `partials/glightbox.html` — conditional loading on article pages
+- [x] Figure shortcode outputs lightbox-compatible HTML
+- [x] Tested with actual Cloudinary images
+- [ ] Article cover image is lightbox-enabled (cover joins the figure gallery — #109)
 
 **Key learning:** GLightbox setup, shortcode enhancement
 

--- a/layouts/partials/glightbox.html
+++ b/layouts/partials/glightbox.html
@@ -1,1 +1,33 @@
-{{/* GLightbox CSS/JS — implemented in Phase 13 */}}
+{{- /*
+  GLightbox — click-to-enlarge for article images.
+
+  Loaded only on pages that actually contain zoomable images, so text-only
+  pages stay JS/CSS-free. Today that means pages using the figure shortcode;
+  cover-image support extends this condition in a companion change (#109).
+
+  The figure shortcode already emits the lightbox-compatible markup
+  (class="glightbox", data-gallery, data-description) with the <a href> pointing
+  at a larger Cloudinary "lightbox" preset, so this partial only loads the
+  library and initializes it — no per-image glue needed.
+
+  Library: GLightbox 3.3.1 from cdnjs, pinned with SRI integrity hashes. The
+  script is deferred; the inline init runs on DOMContentLoaded, which fires
+  after deferred scripts execute, so GLightbox is defined by the time it runs.
+*/ -}}
+{{- if .HasShortcode "figure" -}}
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/glightbox/3.3.1/css/glightbox.min.css"
+    integrity="sha512-T+KoG3fbDoSnlgEXFQqwcTC9AdkFIxhBlmoaFqYaIjq2ShhNwNao9AKaLUPMfwiBPL0ScxAtc+UYbHAgvd+sjQ=="
+    crossorigin="anonymous">
+  <script
+    defer
+    src="https://cdnjs.cloudflare.com/ajax/libs/glightbox/3.3.1/js/glightbox.min.js"
+    integrity="sha512-XL54SjceXZFzblziNnaFFaXggzqCuZrFS4loWPpvPJ6Kg0kc2HyL89+cPeH0GMq0sKL2SegzUmA8Lx9a0st2ow=="
+    crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      GLightbox({ selector: '.glightbox' });
+    });
+  </script>
+{{- end -}}


### PR DESCRIPTION
## Summary

- Fills in the `glightbox.html` partial so article images rendered via the `figure` shortcode become click-to-enlarge, with keyboard/swipe navigation.
- Loads GLightbox 3.3.1 from cdnjs (CSS + JS) pinned with SRI integrity hashes, **only on pages that actually use the figure shortcode** — text-only and cover-only pages stay JS/CSS-free.
- Initializes on `DOMContentLoaded`; no per-image glue needed since the figure shortcode already emits compatible markup pointing at a larger Cloudinary `lightbox` preset.

## Changes

- `layouts/partials/glightbox.html` — conditional load (`.HasShortcode "figure"`) of GLightbox 3.3.1 CSS/JS (SRI + `crossorigin`), deferred script + `DOMContentLoaded` init.
- `docs/prd/ROADMAP.md` — checked off the four Phase 13 GLightbox items, added a line for the cover-image lightbox (#109), and set Phase 13 to *In progress*.

## Testing

- [x] `hugo --gc --minify` builds clean.
- [x] **Conditional load** verified in built HTML: assets present on a figure page; absent on a cover-but-no-figure article and on text-only pages.
- [x] **SRI**: both tags carry the correct cdnjs `sha512` hashes + `crossorigin`.
- [x] **Runtime (chrome-devtools)**: overlay opens the Cloudinary `w_1600` image; caption shows as the description; two figures form one `data-gallery="article"` gallery; ArrowRight navigates; Escape closes.
- Temporary test figures (real OFReport Cloudinary images) were used for verification and reverted — the only changes here are the partial and ROADMAP.

## Notes

- **Cloudinary + GLightbox are independent layers**: cdnjs serves the library code; Cloudinary serves the images via the `<a href>` (`w_1600` for the zoom, `w_768` inline). No integration glue.
- "Swipe" (touch) was not literally simulated, but it drives the same prev/next slide mechanism verified via keyboard.
- Cover-image lightbox is intentionally out of scope here — it extends this partial's load condition in #109.

Closes #108
