### PR TITLE
feat: enable lightbox on the article cover image

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -21,7 +21,7 @@ links to the relevant PRD document for full requirements.
 | 10 | SEO & Meta Tags | Phase 3 | Complete |
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Complete |
 | 12 | Newsletter Integration | Phase 3 | Complete |
-| 13 | Lightbox Integration | Phase 6 | In progress |
+| 13 | Lightbox Integration | Phase 6 | Complete |
 | 14 | Analytics | Phase 3 | Not started |
 | 15 | Content Migration | Phase 6 | Not started |
 | 16 | Deployment | Phase 15 | Not started |
@@ -154,7 +154,7 @@ links to the relevant PRD document for full requirements.
 - [x] `partials/glightbox.html` — conditional loading on article pages
 - [x] Figure shortcode outputs lightbox-compatible HTML
 - [x] Tested with actual Cloudinary images
-- [ ] Article cover image is lightbox-enabled (cover joins the figure gallery — #109)
+- [x] Article cover image is lightbox-enabled (cover joins the figure gallery — #109)
 
 **Key learning:** GLightbox setup, shortcode enhancement
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -5,13 +5,16 @@
       {{/* Cover image */}}
       {{- with .Params.cover }}
         {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" "article") }}
+        {{- $lightbox := partial "cloudinary-url.html" (dict "src" . "preset" "lightbox") }}
         <figure class="mb-10">
-          <img
-            src="{{ $imgURL }}"
-            alt="{{ $.Title }}"
-            class="aspect-video w-full rounded-xl bg-gray-50 object-cover"
-            loading="eager"
-          >
+          <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $.Params.caption }} data-description="{{ . }}"{{ end }}>
+            <img
+              src="{{ $imgURL }}"
+              alt="{{ $.Title }}"
+              class="aspect-video w-full rounded-xl bg-gray-50 object-cover"
+              loading="eager"
+            >
+          </a>
           {{- with $.Params.caption }}
             <figcaption class="mt-3 text-sm/6 text-gray-500">{{ . }}</figcaption>
           {{- end }}

--- a/layouts/partials/glightbox.html
+++ b/layouts/partials/glightbox.html
@@ -2,19 +2,22 @@
   GLightbox — click-to-enlarge for article images.
 
   Loaded only on pages that actually contain zoomable images, so text-only
-  pages stay JS/CSS-free. Today that means pages using the figure shortcode;
-  cover-image support extends this condition in a companion change (#109).
+  pages stay JS/CSS-free. Two cases qualify:
+    1. Any page that uses the figure shortcode (it emits .glightbox anchors).
+    2. A single blog article with a cover image — blog/single.html wraps the
+       cover in a .glightbox anchor. Scoped to blog singles so cover-bearing
+       pages outside the blog (e.g. the Family cover hero) don't false-load.
 
-  The figure shortcode already emits the lightbox-compatible markup
-  (class="glightbox", data-gallery, data-description) with the <a href> pointing
-  at a larger Cloudinary "lightbox" preset, so this partial only loads the
-  library and initializes it — no per-image glue needed.
+  Both the figure shortcode and the cover anchor emit the same lightbox-
+  compatible markup (class="glightbox", data-gallery, data-description) with the
+  <a href> pointing at a larger Cloudinary "lightbox" preset, so this partial
+  only loads the library and initializes it — no per-image glue needed.
 
   Library: GLightbox 3.3.1 from cdnjs, pinned with SRI integrity hashes. The
   script is deferred; the inline init runs on DOMContentLoaded, which fires
   after deferred scripts execute, so GLightbox is defined by the time it runs.
 */ -}}
-{{- if .HasShortcode "figure" -}}
+{{- if or (.HasShortcode "figure") (and (eq .Kind "page") (eq .Section "blog") .Params.cover) -}}
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/glightbox/3.3.1/css/glightbox.min.css"


### PR DESCRIPTION
## Summary

- Makes the blog article **cover image click-to-zoom**, joining the same GLightbox gallery as inline figures, with the cover leading the gallery.
- Extends the `glightbox.html` load condition to cover-bearing blog articles — **scoped to blog singles** so cover-bearing pages outside the blog (e.g. the Family cover hero) don't load the library for nothing.
- Completes **Phase 13 — Lightbox Integration** (builds on #108).

## Changes

- `layouts/blog/single.html` — wrap the cover `<img>` in `<a class="glightbox" data-gallery="article" href="{cover @ lightbox preset}">`, with `data-description` from `.Params.caption`. Img classes and `loading="eager"` are unchanged.
- `layouts/partials/glightbox.html` — load condition is now `or (.HasShortcode "figure") (and (eq .Kind "page") (eq .Section "blog") .Params.cover)`; comment updated to document the two qualifying cases.
- `docs/prd/ROADMAP.md` — checked off the cover-image item and marked Phase 13 **Complete**.

## Testing

- [x] `hugo --gc --minify` builds clean.
- [x] **Conditional load** (built HTML) across page types:

  | Page | Library loaded | `.glightbox` anchors |
  |---|---|---|
  | Blog: cover + 2 figures | ✅ | 3 (cover first) |
  | Blog: cover, no figure | ✅ | 1 (cover) |
  | Blog: no cover, no figure | ❌ | 0 |
  | Family (cover, non-blog) | ❌ | 0 |

- [x] **Runtime (chrome-devtools)**: cover opens as **slide 1** of a single 3-slide gallery with its caption as the description; ArrowRight flows cover → figures; Esc closes; Family page reports `GLightbox` undefined (no false-load).
- [x] **Layout unchanged**: cover `<img>` keeps `loading="eager"` and `aspect-video w-full rounded-xl bg-gray-50 object-cover`.

Verified with temporary test content (a real cover + two figures on a seed article), which was reverted — this PR is only the two templates and the ROADMAP.

## Notes

- **Family hero is intentionally not lightboxed** (confirmed decision). It's a cropped, full-bleed decorative header, not gallery content; lightbox stays scoped to article photos. Rationale is documented inline in `glightbox.html`.
- Blog **seed covers are fabricated placeholders that 404** — real covers arrive in Phase 15, so the cover lightbox can't be visually QA'd on the dev site without a temporary real URL (as used above).

Closes #109
