### PR TITLE
feat: implement inert Umami analytics partial (credentials deferred to deploy)

### DIFF
--- a/docs/prd/01-architecture.md
+++ b/docs/prd/01-architecture.md
@@ -215,19 +215,30 @@ analytics.
 GoatCounter and Plausible Community Edition were the other candidates
 considered; Umami won on cross-project standardization.
 
-**Implementation:**
+**Implementation (Phase 14 — done):**
 
-- Fill in the swappable partial (`partials/analytics.html`) with the Umami
-  tracking `<script>` (async, with `data-website-id` and the script `src` from
-  the Umami instance)
-- The partial is already included before `</body>` in `baseof.html`; switching
-  or removing analytics means changing only this one file
-- Make the website ID and script `src` configurable via `hugo.toml [params]`
-  rather than hard-coding them in the partial
-- Conditional loading: production only
-  (`{{ if hugo.IsProduction }}...{{ end }}`)
-- Best implemented alongside Phase 16 (Deployment) — verification requires a
-  live production URL plus the Umami instance URL and website ID
+- `partials/analytics.html` emits the Umami tracking `<script>` (deferred, with
+  `data-website-id` and the script `src`), double-gated so it stays inert until
+  go-live: `hugo.IsProduction` **and** a non-empty `scriptUrl` + `websiteId`.
+- The partial is included before `</body>` in `baseof.html`; switching or
+  removing analytics means changing only this one file.
+- The website ID and script `src` are configured via `hugo.toml`
+  `[params.umami]` rather than hard-coded — **left empty in Phase 14**, so no
+  script is emitted on any build.
+- `data-domains="ofreport.com"` scopes tracking to the canonical host, so a
+  stray `*.netlify.app` load during pre-cutover testing cannot pollute the
+  production record.
+
+**Deferred to Phase 16 (Deployment):**
+
+- Populate `[params.umami]` with the live `scriptUrl`
+  (`https://lens.euroteamoutreach.org/script.js`) and `websiteId`
+  (`34d2cfa4-e623-418a-936d-670c9d163ead`) — the actual go-live flip.
+- **Reuse the existing OFReport.com Umami website ID** (the same one the Nuxt
+  site uses) so pageviews keep appending to the existing dashboard record — do
+  not create a new Umami website.
+- Verify pageviews land on the existing record once the Hugo site serves the
+  live domain.
 
 ---
 

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -22,7 +22,7 @@ links to the relevant PRD document for full requirements.
 | 11 | Contact Form (Netlify Forms) | Phase 8 | Complete |
 | 12 | Newsletter Integration | Phase 3 | Complete |
 | 13 | Lightbox Integration | Phase 6 | Complete |
-| 14 | Analytics | Phase 3 | Not started |
+| 14 | Analytics | Phase 3 | Complete (credentials deferred to Phase 16) |
 | 15 | Content Migration | Phase 6 | Not started |
 | 16 | Deployment | Phase 15 | Not started |
 
@@ -160,9 +160,10 @@ links to the relevant PRD document for full requirements.
 
 ## Phase 14: Analytics
 
-- [ ] `partials/analytics.html` — swappable analytics partial (see [`01-architecture.md`](./01-architecture.md))
-- [ ] Conditional loading (production only)
-- [ ] Analytics tool selected and configured
+- [x] `partials/analytics.html` — swappable analytics partial (see [`01-architecture.md`](./01-architecture.md))
+- [x] Conditional loading (production only, double-gated on `hugo.IsProduction` + configured website ID)
+- [x] Analytics tool selected and configured (Umami; `[params.umami]` left empty)
+- [—] Live credentials populated (deferred to Phase 16 — go-live flip; reuses the existing OFReport.com Umami website ID)
 
 **Key learning:** Privacy-friendly analytics partial
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -38,6 +38,16 @@ enableRobotsTXT = true
     twitter = "https://twitter.com/joshukraine"
     github = "https://github.com/joshukraine/ofreport.com"
 
+  # Umami analytics. Left empty until the Phase 16 production cutover; the
+  # analytics.html partial emits nothing while these are blank, so it stays
+  # inert on every build. At go-live, reuse the EXISTING OFReport.com website
+  # so Umami keeps appending to the same dashboard record (no new entry):
+  #   scriptUrl = "https://lens.euroteamoutreach.org/script.js"
+  #   websiteId = "34d2cfa4-e623-418a-936d-670c9d163ead"
+  [params.umami]
+    scriptUrl = ""
+    websiteId = ""
+
 # Build stats for Tailwind CSS purging
 [build]
   [build.buildStats]

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,1 +1,16 @@
-{{/* Analytics script — implemented in Phase 14 */}}
+{{/*
+  Umami analytics — swappable partial, included before </body> in baseof.html.
+  Double-gated so it stays inert until the Phase 16 production cutover:
+    1. hugo.IsProduction — Netlify sets HUGO_ENVIRONMENT=preview for deploy
+       previews and branch deploys, so they never emit (same gate as seo.html).
+    2. A configured scriptUrl + websiteId — both are blank until go-live.
+  data-domains scopes tracking to the canonical host as a final safeguard, so a
+  stray *.netlify.app load can never pollute the OFReport.com record.
+*/}}
+{{- if hugo.IsProduction }}
+  {{- with site.Params.umami }}
+    {{- if and .scriptUrl .websiteId }}
+<script defer src="{{ .scriptUrl }}" data-website-id="{{ .websiteId }}" data-domains="ofreport.com"></script>
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Implements Phase 14 (Analytics) by filling in the swappable `analytics.html` partial for **Umami**, the locked-in analytics standard.
- Lands all the infrastructure now as **inert code** — the partial is double-gated so it emits nothing until the Phase 16 production cutover, at which point go-live is a one-line config flip rather than new code shipped under deploy pressure.
- Preserves a **seamless analytics transition**: the cutover reuses the existing OFReport.com Umami website ID, so pageviews keep appending to the same dashboard record (no new entry, no data split).

## Changes

**`feat`**
- `hugo.toml`: add an empty `[params.umami]` block (`scriptUrl` / `websiteId`), with a comment documenting the live values to drop in at cutover.
- `layouts/partials/analytics.html`: replace the stub with the Umami `<script>`, double-gated on `hugo.IsProduction` **and** a non-empty `scriptUrl` + `websiteId`. Adds `data-domains="ofreport.com"` to scope tracking to the canonical host.

**`docs`**
- `docs/prd/ROADMAP.md`: mark Phase 14 complete (live credentials marked deferred to Phase 16).
- `docs/prd/01-architecture.md`: document the implemented gating and the explicit Phase 16 carry-forward.

## How it stays safe before go-live

Two independent guards keep the real website ID from polluting the production Umami record during pre-cutover testing:

1. **Production gate** — emits only when `hugo.IsProduction` is true. Netlify sets `HUGO_ENVIRONMENT=preview` for deploy previews and branch deploys (same gate already used by `seo.html` / `robots.txt`), so they never emit.
2. **Configured-ID gate** — emits only when both params are non-empty; they ship empty in this PR, so the partial is inert on every build.
3. **`data-domains` scope** — belt-and-suspenders: even a stray `*.netlify.app` load skips tracking for any host outside `ofreport.com`.

## Testing

- [x] `hugo --gc --minify` with empty params → **0** Umami references in `public/` (inert confirmed).
- [x] Params temporarily populated + production build → script present on all pages with correct `defer` / `data-website-id` / `data-domains` attributes.
- [x] Params temporarily populated + `HUGO_ENVIRONMENT=preview` build → **0** Umami references (production gate holds).
- [x] `npm run lint` clean (53 files, 0 errors).

## Notes

- **Deferred to Phase 16 (Deployment):** populate `[params.umami]` with the live `scriptUrl` (`https://lens.euroteamoutreach.org/script.js`) and `websiteId` (`34d2cfa4-…`), and verify pageviews land on the existing OFReport.com record. These remain unchecked on the issue by design.
- Switching or removing analytics in future requires editing only the one partial + the param block.

Closes #112
