### PR TITLE
style: typography parity — Inter body/UI, Lato bold headings, 18px reading body

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,9 +26,15 @@
      utility and is also referenced as var(--color-page) by the .page-bg rule. */
   --color-page: #f7fafc;
 
-  /* Font families — sans (Lato) is the default for UI, headings, and body;
-     serif (Noto Serif) is opt-in for long-form copy; fancy (Mate SC) is decorative. */
-  --font-sans: "Lato", sans-serif;
+  /* Font families:
+     - sans (Inter) — default for body, UI, nav, buttons, forms. An SF-style
+       neutral sans that renders consistently across every platform (the original
+       site used the OS system font here, which varied per device).
+     - header (Lato) — headings only, matching the original site's heading font.
+     - serif (Noto Serif) — long-form / article copy.
+     - fancy (Mate SC) — decorative (the "Joshua & Kelsie" wordmark, footer). */
+  --font-sans: "Inter", sans-serif;
+  --font-header: "Lato", sans-serif;
   --font-serif: "Noto Serif", ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-fancy: "Mate SC", serif;
 }

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
     {{/* Intro prose (left-aligned), authored in archives.md. */}}
-    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
       {{ .Content }}
     </div>
 
@@ -22,7 +22,7 @@
     <div class="mt-10 max-w-2xl">
       {{ range sort $years "value" "desc" }}
         <div class="flex border-b border-gray-200 pb-6 mb-6 last:mb-0 last:border-b-0 last:pb-0 sm:pb-8 sm:mb-8">
-          <h2 class="shrink-0 pr-4 font-sans text-2xl/none font-semibold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
+          <h2 class="shrink-0 pr-4 font-header text-2xl/none font-bold text-gray-700 sm:pr-6 md:pr-10 md:text-3xl/none">{{ . }}</h2>
           <ul class="space-y-2 md:space-y-4">
             {{ range (index $archives .) }}
               <li class="flex items-start gap-2">

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
     {{/* Intro prose (left-aligned), authored in archives.md. */}}
-    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-2xl") }}
 
     {{/* Intro copy authored in content/contact.md */}}
-    <div class="mt-10 prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-2xl") }}
 
     {{/* Intro copy authored in content/contact.md */}}
-    <div class="mt-10 prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/family.html
+++ b/layouts/_default/family.html
@@ -45,7 +45,7 @@
     </p>
 
     {{/* Bio body — left-aligned prose authored in content/family.md. */}}
-    <div class="mt-8 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
+    <div class="mt-8 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/family.html
+++ b/layouts/_default/family.html
@@ -45,7 +45,7 @@
     </p>
 
     {{/* Bio body — left-aligned prose authored in content/family.md. */}}
-    <div class="mt-8 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
+    <div class="mt-8 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
   <div class="mx-auto max-w-4xl px-4 py-8">
-    <h1 class="font-sans text-4xl font-bold text-ink">{{ .Title }}</h1>
+    <h1 class="font-header text-4xl font-bold text-ink">{{ .Title }}</h1>
     {{- with .Content }}
-      <div class="prose mt-4 max-w-none font-serif prose-headings:font-sans">{{ . }}</div>
+      <div class="prose mt-4 max-w-none font-serif prose-headings:font-header">{{ . }}</div>
     {{- end }}
     {{- if .Pages }}
       <ul class="mt-8 space-y-4">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="font-header text-4xl font-bold text-ink">{{ .Title }}</h1>
     {{- with .Content }}
-      <div class="prose mt-4 max-w-none font-serif prose-headings:font-header">{{ . }}</div>
+      <div class="prose sm:prose-lg mt-4 max-w-none font-serif prose-headings:font-header">{{ . }}</div>
     {{- end }}
     {{- if .Pages }}
       <ul class="mt-8 space-y-4">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
 
     {{/* Page content — "centered: true" centers the body (e.g. Ministry);
          otherwise it stays left-aligned. */}}
-    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
+    <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
 
     {{/* Page content — "centered: true" centers the body (e.g. Ministry);
          otherwise it stays left-aligned. */}}
-    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
+    <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center{{ end }}">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/subscribe.html
+++ b/layouts/_default/subscribe.html
@@ -18,7 +18,7 @@
           </figure>
 
           {{/* Intro copy authored in content/subscribe.md */}}
-          <div class="prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+          <div class="prose prose-gray sm:prose-lg font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
             {{ .Content }}
           </div>
         </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,7 @@
   <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
+        <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
           {{ .Title }}
         </h1>
         {{- with .Content }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -53,7 +53,7 @@
       {{- end }}
 
       {{/* Article content */}}
-      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
         {{ .Content }}
       </div>
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -22,7 +22,7 @@
       {{- end }}
 
       {{/* Article title */}}
-      <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
+      <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:text-5xl">
         {{- .Title -}}
       </h1>
 
@@ -53,7 +53,7 @@
       {{- end }}
 
       {{/* Article content */}}
-      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-sans prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      <div class="mt-10 max-w-2xl prose prose-gray font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
         {{ .Content }}
       </div>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -108,7 +108,7 @@
           </figure>
 
           <div class="flex-1">
-            <h2 class="text-3xl font-semibold tracking-tight text-ink font-sans sm:text-4xl">Read the News</h2>
+            <h2 class="text-3xl font-bold tracking-tight text-ink font-header sm:text-4xl">Read the News</h2>
             <div class="mt-4 prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
               <p><em>Overseas Field Report</em> is our bi-monthly newsletter containing updates on our family and ministry here in Ukraine. We&rsquo;d be tickled if you&rsquo;d subscribe and pray for us!</p>
             </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -109,7 +109,7 @@
 
           <div class="flex-1">
             <h2 class="text-3xl font-bold tracking-tight text-ink font-header sm:text-4xl">Read the News</h2>
-            <div class="mt-4 prose prose-gray font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+            <div class="mt-4 prose prose-gray sm:prose-lg font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
               <p><em>Overseas Field Report</em> is our bi-monthly newsletter containing updates on our family and ministry here in Ukraine. We&rsquo;d be tickled if you&rsquo;d subscribe and pray for us!</p>
             </div>
           </div>

--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="group relative max-w-xl">
-      <h3 class="mt-3 text-lg/6 font-semibold text-gray-900 group-hover:text-gray-600">
+      <h3 class="mt-3 text-lg/6 font-bold font-header text-gray-900 group-hover:text-gray-600">
         <a href="{{ $page.Permalink }}">
           <span class="absolute inset-0"></span>
           {{ $page.Title }}

--- a/layouts/partials/article-footer.html
+++ b/layouts/partials/article-footer.html
@@ -28,7 +28,7 @@
   {{/* Newsletter CTA — centered two-line headline above the shared inline signup
        form. */}}
   <div class="mx-auto max-w-lg">
-    <h2 class="text-center text-2xl font-semibold tracking-tight text-ink font-sans md:text-3xl">
+    <h2 class="text-center text-2xl font-bold tracking-tight text-ink font-header md:text-3xl">
       Like what you&rsquo;re reading?<br />Let&rsquo;s keep in touch!
     </h2>
     <div class="mt-6">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,10 +4,10 @@
 {{/* SEO + social metadata: title, description, canonical, robots, Open Graph, Twitter */}}
 {{ partial "seo.html" . }}
 
-{{/* Google Fonts: Lato (sans — default UI, headings, body), Noto Serif (long-form copy), Mate SC (decorative) */}}
+{{/* Google Fonts: Inter (sans — body, UI, nav), Lato (headings), Noto Serif (article copy), Mate SC (decorative) */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Mate+SC&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Lato:wght@700&family=Mate+SC&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
 {{/* Favicons */}}
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/layouts/partials/page-shell-open.html
+++ b/layouts/partials/page-shell-open.html
@@ -22,6 +22,6 @@
     {{/* Page title — always centered, matching the old design's PageHeader. An
          optional `heading` frontmatter field overrides .Title (and may contain
          inline HTML such as <br>); .Title still doubles as the SEO/tab title. */}}
-    <h1 class="text-center text-4xl font-semibold tracking-tight text-pretty text-ink font-sans sm:text-5xl">
+    <h1 class="text-center text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:text-5xl">
       {{- with .page.Params.heading }}{{ . | safeHTML }}{{ else }}{{ $.page.Title }}{{ end -}}
     </h1>

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -3,7 +3,7 @@
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $tagCount := len .Data.Terms -}}
-        <h1 class="text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
+        <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -4,7 +4,7 @@
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $count := len .Pages -}}
         <p class="text-base/7 font-semibold text-blue-600">Tag</p>
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-ink sm:text-5xl font-sans">
+        <h1 class="mt-2 text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">


### PR DESCRIPTION
## Summary

- First PR in the design-parity pass (#114): establishes the **typography token system** to match the original site while rendering consistently across platforms.
- Locks in **Inter** for body/UI (an explicit, freely-licensed SF-style sans — the original relied on the per-device OS system font), keeps **Lato** for headings, **Noto Serif** for article copy, and **Mate SC** for decoration.
- Fixes heading weight from `font-semibold` (600) back to `font-bold` (700), the original's heading weight.
- Restores **18px reading-body copy** on tablet/desktop (16px on mobile) via `sm:prose-lg`, matching the original (the rebuild had dropped to the `prose` 16px default).

## Changes

**`style`**
- `assets/css/main.css`: `--font-sans` → Inter; add `--font-header` → Lato. Commented to document each tier.
- `layouts/partials/head.html`: load Inter (400/600/700); trim Lato to 700 (headings only).
- Headings retargeted from `font-sans`/`font-semibold` to `font-header`/`font-bold` across `single.html`, `blog/list.html`, `index.html`, `_default/list.html`, `_default/archives.html`, `taxonomy/{taxonomy,term}.html`, `article-footer.html`, `page-shell-open.html`, `article-card.html`.
- Article (prose) headings: `prose-headings:font-sans` → `prose-headings:font-header` across the six content templates.
- Added `sm:prose-lg` to all 8 reading-content prose containers (article body, single/list, homepage newsletter blurb, contact / subscribe / family / archives intros) → 16px mobile, 18px from `sm` up.

## Why these specific changes

Switching `--font-sans` to Inter means all body/UI/nav/button/form text inherits it automatically — no per-element edits. The only elements that needed touching were **headings**, which had to be explicitly pointed at the new `--font-header` (Lato) token so they wouldn't follow the body font to Inter. Body system-vs-Lato was the subtlest difference found; Inter resolves it with consistent cross-device rendering and the SF look (verified against SF/Inter/Figtree side-by-side in the browser).

## Testing

- [x] `hugo --gc --minify` builds clean (327ms)
- [x] `npm run lint` clean (53 files, 0 errors)
- [x] Browser computed-style check: body/nav/UI = Inter · "Read the News" = Lato 700 · article body = Noto Serif
- [x] Char distribution flipped from all-Lato to Inter 333 / Lato 13 / Noto Serif 42 / Mate SC 19
- [x] Article body measured at 18px (desktop) / 16px (mobile), matching the original's responsive sizing

## Notes

- **Does not close #114** — that's the umbrella design-parity issue; header (nav style + full-width) and homepage hero scale remain, logged in the issue's per-page findings.
- `xs: 460px` breakpoint was descoped (lean into Tailwind v4 defaults, no monkey-patching).

Part of #114

