### PR TITLE
style: restore the original site header (full-width nav, Lato links, logo)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,10 +17,10 @@
       {{ range site.Menus.main }}
         <a href="{{ .URL }}"
            class="relative font-header text-xl font-semibold transition-colors duration-150
-                  before:absolute before:-bottom-1 before:left-0 before:h-0.5 before:w-full before:origin-left before:scale-x-0 before:bg-blue-600 before:transition-transform before:duration-200 before:content-['']
+                  before:absolute before:-bottom-1 before:left-0 before:h-0.5 before:w-full before:origin-center before:scale-x-0 before:bg-blue-600 before:transition-transform before:duration-200 before:content-['']
                   hover:before:scale-x-100
                   {{ if $currentPage.IsMenuCurrent "main" . }}
-                    text-blue-700 before:scale-x-100
+                    text-blue-700
                   {{ else }}
                     text-slate-400 hover:text-blue-600
                   {{ end }}">
@@ -65,7 +65,7 @@
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     bg-blue-50 text-blue-900
                   {{ else }}
-                    text-gray-700 hover:bg-gray-50 hover:text-blue-900
+                    text-slate-400 hover:bg-gray-50 hover:text-blue-900
                   {{ end }}">
           {{ .Name }}
         </a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,23 +1,28 @@
 <header x-data="{ mobileMenuOpen: false }" class="fixed top-0 z-50 w-full border-b border-gray-200 bg-white">
-  <div class="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+  {{/* Full-width bar: logo hard-left, links hard-right (matches the original —
+       no centered max-width container). */}}
+  <div class="flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
 
     {{/* Logo */}}
     <a href="{{ "/" | relURL }}" class="flex shrink-0 items-center" aria-label="{{ site.Title }} — Home">
       {{ with resources.Get "img/ofr-logo.svg" }}
-        <img src="{{ .Permalink }}" alt="{{ site.Title }}" class="h-8 w-auto">
+        <img src="{{ .RelPermalink }}" alt="{{ site.Title }}" class="w-40 md:w-48">
       {{ end }}
     </a>
 
-    {{/* Desktop navigation */}}
-    <nav class="hidden lg:flex lg:items-center lg:gap-x-6" aria-label="Main navigation">
+    {{/* Desktop navigation — Lato (font-header), 20px, semibold, light cool-gray,
+         with the original's slide-in blue underline on hover / current page. */}}
+    <nav class="hidden lg:flex lg:items-center lg:gap-x-8" aria-label="Main navigation">
       {{ $currentPage := . }}
       {{ range site.Menus.main }}
         <a href="{{ .URL }}"
-           class="font-sans text-sm font-bold uppercase tracking-wide transition-colors duration-150
+           class="relative font-header text-xl font-semibold transition-colors duration-150
+                  before:absolute before:-bottom-1 before:left-0 before:h-0.5 before:w-full before:origin-left before:scale-x-0 before:bg-blue-600 before:transition-transform before:duration-200 before:content-['']
+                  hover:before:scale-x-100
                   {{ if $currentPage.IsMenuCurrent "main" . }}
-                    text-blue-900
+                    text-blue-700 before:scale-x-100
                   {{ else }}
-                    text-gray-600 hover:text-blue-900
+                    text-slate-400 hover:text-blue-600
                   {{ end }}">
           {{ .Name }}
         </a>
@@ -56,11 +61,11 @@
       {{ $currentPage := . }}
       {{ range site.Menus.main }}
         <a href="{{ .URL }}"
-           class="block rounded-md px-3 py-2 font-sans text-base font-bold uppercase tracking-wide transition-colors duration-150
+           class="block rounded-md px-3 py-2 font-header text-base font-semibold transition-colors duration-150
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     bg-blue-50 text-blue-900
                   {{ else }}
-                    text-gray-600 hover:bg-gray-50 hover:text-blue-900
+                    text-gray-700 hover:bg-gray-50 hover:text-blue-900
                   {{ end }}">
           {{ .Name }}
         </a>


### PR DESCRIPTION
## Summary

- Restores the original site's header in the Hugo rebuild: a **full-width bar** (logo hard-left, links hard-right), **Lato Title-Case** nav links, and the original's **center-out hover underline**.
- Also corrects a latent logo bug surfaced during this work — the logo used `.Permalink` (absolute production URL), which left it broken on the dev server and any off-domain host.

## Changes

**`style`**
- Full-width header — dropped the centered `max-w-7xl` container; logo left, links right.
- Desktop nav links: Lato (`font-header`), 20px, `font-semibold`, Title Case (was UPPERCASE / 14px / bold), `slate-400` with a `blue-600` hover. Animated 2px `blue-600` underline that expands from the **center** on hover, built with `before:` utilities (no custom CSS).
- Current page indicated by **blue text only** (`text-blue-700`); the underline is reserved strictly for hover, so there's never more than one underline at a time.
- Mobile dropdown links: Lato, Title Case, `font-semibold`, `slate-400` (matching desktop).
- Logo sized `w-40 md:w-48` (160 → 192px) to match the original's responsive sizing (was `h-8`, ~16% small on desktop).

**`fix`**
- Logo `src` switched `.Permalink` → `.RelPermalink` (root-relative `/img/...`), so it resolves on any host. The absolute form embedded the production domain.

## Testing

- [x] `hugo --gc --minify` builds clean
- [x] `npm run lint` clean (53 files, 0 errors)
- [x] Browser-verified at `/ministry/`: nav = Lato / 600 / 20px / Title Case / `slate-400`; logo loads at 192×38 (desktop); hover underline `scale 0 1` at rest with center `transform-origin`; current page = blue text, no underline at rest; mobile links `slate-400`

## Notes

- Nav `slate-400` is faithful to the original's intentionally-light nav. It sits below WCAG AA contrast (~2.7:1), as did the original's design — accepted for parity; accessibility can be revisited as a dedicated pass.
- The mobile menu remains the existing white dropdown; the original's full-screen blue-gradient overlay was intentionally not reproduced (separate decision).

Tracked by #114 — the umbrella design-parity issue. Header + mobile-overlay items remain open there; this PR is one slice of that work and leaves the issue open.
