### PR TITLE
fix: restore homepage hero section padding for column parity

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,14 +12,19 @@
        the rest of the viewport with min-h-[calc(100vh-4rem)] on mobile; from md
        up it relaxes to 75vh, mirroring the old md:min-h-3/4-vh. (calc needs
        spaces around the minus; underscores become spaces in the arbitrary
-       value.) */}}
+       value.)
+
+       sm:p-10 reproduces the original Alpha.vue section padding (40px from sm
+       up). It only insets the content column — the absolute cover image is
+       positioned independently and stays full-bleed — restoring the original's
+       content-column width (the md:w-2/5 column was ~6% too wide without it). */}}
 
   {{ $base := site.Params.cloudinaryBase }}
   {{ $bgMobile := printf "%s/image/upload/c_scale,f_auto,q_auto:best,w_640/v1571750972/OFReport/assets/joshandkels-OFReport.com-cover-mobile_wry9lu.jpg" $base }}
   {{ $bgDesktop := printf "%s/image/upload/c_scale,f_auto,q_auto:best,w_2000/v1571770785/OFReport/assets/joshandkels-OFReport.com-cover_hrc85f.jpg" $base }}
 
   <section
-    class="relative flex min-h-[calc(100vh_-_4rem)] items-center overflow-hidden md:min-h-[75vh]"
+    class="relative flex min-h-[calc(100vh_-_4rem)] items-center overflow-hidden sm:p-10 md:min-h-[75vh]"
     style="background: linear-gradient(to bottom, #1f415c 0%, #0f2847 100%)"
   >
     {{/* Full-bleed background photo. The object-position steps keep the family


### PR DESCRIPTION
## Summary

Restores the homepage hero's content-column scale to match the production original, as part of the design-parity walk.

The Hugo port of the original `Alpha.vue` hero dropped the section's `sm:p-10` (40px inset from the `sm` breakpoint up). Without it, that 80px of horizontal space flowed into the `w-11/12` wrapper and widened the `md:w-2/5` content column by ~6% — so the wordmark, subtitle, and button rendered **larger** than production, not smaller.

This adds `sm:p-10` back to the hero section. The absolute cover image (`absolute inset-0`) is positioned independently and stays full-bleed; only the content column is inset.

## Heads-up: the recorded finding was reversed

The #114 checklist noted *"original 'Joshua & Kelsie' is larger; subtitle column wider (2 lines vs 3)."* Measured at matched viewports (`getComputedStyle` on both sites, not screenshots), the truth is the **reverse** — the Hugo hero was ~6% larger and both wrap to 3 lines. The original note was an eyeball comparison across mismatched window widths.

## Verification (production vs. local @ 1440px)

| Metric | Production | Hugo before | Hugo after |
|---|---|---|---|
| Section padding | 40px | 0px | **40px** ✓ |
| Content column | 461px | 491px | **461px** ✓ |
| Wordmark | 461×74 | 491×79 | **461×74** ✓ |
| Subtitle width | 461px | 491px | **461px** ✓ |
| Cover image | full-bleed | full-bleed | **full-bleed** (x=0) ✓ |
| Section height | 675px (75vh) | 675px | **675px** ✓ |

`sm:p-10` is breakpoint-gated (≥640px), so mobile is unchanged. `hugo --gc --minify` green; `npm run lint` clean.

## Out of scope (intentional, not regressions)

- **Subtitle leading** is 32px vs production's 36px (Tailwind v4 ships a tighter paired line-height on `text-2xl`). Left as-is per review.
- **"Est. 2004" + button** render in Inter, not the original's Lato — intentional per the locked font system (#115).

Tracked by #114.
