### PR TITLE
fix: restore global antialiased font-smoothing on body

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     {{ partial "css.html" . }}
   {{ end }}
 </head>
-<body class="min-h-screen bg-page font-sans text-gray-900">
+<body class="min-h-screen bg-page font-sans text-gray-900 antialiased">
   {{ partial "header.html" . }}
   <main class="pt-16">
     {{ block "main" . }}{{ end }}


### PR DESCRIPTION
## Summary

Restores the original site's global font-smoothing, a global-token slice of the design-parity pass.

You'll notice serif body copy (e.g. the homepage hero subtitle) renders **heavier** on the Hugo rebuild than on production. It's **not a weight difference** — both are `font-weight: 400`. It's font-smoothing:

| | `-webkit-font-smoothing` | macOS stroke rendering |
|---|---|---|
| Production (Nuxt) | `antialiased` | grayscale AA → lighter |
| Hugo (before) | `auto` (default) | subpixel AA → heavier |

The original set this globally — `assets/css/components/typography.css` does `body { @apply …antialiased; }`. The rebuild never carried it over.

A wrinkle specific to **Tailwind v4 + Hugo**: utilities are only generated when the class appears in a template (via `hugo_stats.json`). Since `antialiased` wasn't used anywhere, the rule was absent from `main.css` entirely — there was no `font-smoothing` declaration to find in DevTools.

## Change

One class on `<body>` in `baseof.html`:

```diff
- <body class="min-h-screen bg-page font-sans text-gray-900">
+ <body class="min-h-screen bg-page font-sans text-gray-900 antialiased">
```

`antialiased` expands to `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;` and cascades to all text site-wide — matching the original's body-level treatment.

## Verification

- Compiled `public/css/main.css` now contains `font-smoothing: antialiased` + `grayscale` (previously **no** `font-smoothing` rule at all).
- In-browser: `<body>` and descendants (incl. hero subtitle) compute `-webkit-font-smoothing: antialiased`; font-weights unchanged (400).
- `hugo --gc --minify` green; `npm run lint` clean.

## Notes

- This is a **macOS/WebKit** rendering setting; on Windows/Linux it has little effect. Restoring it matches the original and lightens text for Mac visitors.
- Scope is intentionally site-wide (every page), which is why it ships separately from the hero-padding slice (#117).

Tracked by #114.
