### PR TITLE
fix: restore original blog-list card design

### DIFF
--- a/content/blog/2024-07-30-july-ministry-report.md
+++ b/content/blog/2024-07-30-july-ministry-report.md
@@ -7,7 +7,7 @@ description: >-
   Bible study groups, and partnership development.
 tags:
   - newsletter
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-07-30-july-ministry-report/summer-bible-study.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573555930/OFReport/2016-09-22-platform-rising/josh-preaching-cmo-2016_ulanjs.jpg"
 caption: "Our summer evening Bible study group"
 pdf: "OFR-Jul-Aug-2024.pdf"
 slug: "2024-07-30-july-ministry-report"

--- a/content/blog/2024-08-20-summer-in-the-carpathians.md
+++ b/content/blog/2024-08-20-summer-in-the-carpathians.md
@@ -8,7 +8,7 @@ description: >-
 tags:
   - family
   - photos
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-08-20-summer-in-the-carpathians/carpathian-hiking-trail.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573400861/OFReport/2017-06-29-lviv-rope-course/rope-course-12-6_xxdjsy.jpg"
 caption: "Hiking through the Carpathian Mountains with the family"
 slug: "2024-08-20-summer-in-the-carpathians"
 ---

--- a/content/blog/2024-09-15-church-plant-update.md
+++ b/content/blog/2024-09-15-church-plant-update.md
@@ -7,7 +7,7 @@ description: >-
   new small groups, and the search for a permanent meeting location.
 tags:
   - ministry
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-09-15-church-plant-update/church-meeting-room.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1571908092/OFReport/2018-09-30-vision-to-reality/dobro-zlo-group-12-6_eitj7q.jpg"
 caption: "Our Sunday gathering in the rented meeting hall"
 pdf: "OFR-Sep-Oct-2024.pdf"
 slug: "2024-09-15-church-plant-update"

--- a/content/blog/2024-10-05-cmo-2024-recap.md
+++ b/content/blog/2024-10-05-cmo-2024-recap.md
@@ -8,7 +8,7 @@ description: >-
 tags:
   - ministry
   - newsletter
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-10-05-cmo-2024-recap/cmo-team-mountains.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573560131/OFReport/2014-05-13-gearing-up-cmo/IMG_4615-12-6_rclemh.jpg"
 caption: "The CMO 2024 team in the Carpathian Mountains"
 pdf: "OFR-Sep-Oct-2024.pdf"
 slug: "2024-10-05-cmo-2024-recap"

--- a/content/blog/2024-11-10-bible-first-progress.md
+++ b/content/blog/2024-11-10-bible-first-progress.md
@@ -7,7 +7,7 @@ description: >-
   enrollment numbers, student testimonies, and plans for new lessons.
 tags:
   - ministry
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-11-10-bible-first-progress/bible-first-lesson-stack.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573401900/OFReport/2017-06-13-bible-first-kids/bible-first-kids-12-6_og2mea.jpg"
 caption: "A stack of Bible First lessons ready for mailing"
 slug: "2024-11-10-bible-first-progress"
 ---

--- a/content/blog/2024-11-30-fall-outreach-report.md
+++ b/content/blog/2024-11-30-fall-outreach-report.md
@@ -8,7 +8,7 @@ description: >-
 tags:
   - newsletter
   - ministry
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-11-30-fall-outreach-report/outreach-team-village.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1571908949/OFReport/2018-06-24-sharpening-arrows/teaching-forum-mall-12-6_vbjilu.jpg"
 caption: "Our outreach team visiting a nearby village"
 pdf: "OFR-Nov-Dec-2024.pdf"
 slug: "2024-11-30-fall-outreach-report"

--- a/content/blog/2024-12-20-christmas-in-ukraine.md
+++ b/content/blog/2024-12-20-christmas-in-ukraine.md
@@ -8,7 +8,7 @@ description: >-
 tags:
   - family
   - photos
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2024-12-20-christmas-in-ukraine/christmas-church-service.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1571938781/OFReport/2017-12-21-one-sunday-afternoon/kids-in-snow-12-6_ot5lzj.jpg"
 caption: "Our church family gathered for the Christmas service"
 slug: "2024-12-20-christmas-in-ukraine"
 ---

--- a/content/blog/2025-01-02-new-year-reflections.md
+++ b/content/blog/2025-01-02-new-year-reflections.md
@@ -7,7 +7,7 @@ description: >-
   our family and ministry in the new year.
 tags:
   - family
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2025-01-02-new-year-reflections/family-new-year.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573559996/OFReport/2014-05-23-baby-way/steele-2014-12-6_s3iuym.jpg"
 caption: "Our family ringing in the new year together"
 slug: "2025-01-02-new-year-reflections"
 ---

--- a/content/blog/2025-01-15-winter-ministry-update.md
+++ b/content/blog/2025-01-15-winter-ministry-update.md
@@ -8,7 +8,7 @@ description: >-
 tags:
   - newsletter
   - ministry
-cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1629283967/OFReport/2025-01-15-winter-ministry-update/winter-town-square.jpg"
+cover: "https://res.cloudinary.com/dnkvsijzu/image/upload/v1573557624/OFReport/2015-09-01-gaining-ground/06-IMG_6462_r7jny1.jpg"
 caption: "A quiet winter morning in our town square"
 pdf: "OFR-Jan-Feb-2025.pdf"
 slug: "2025-01-15-winter-ministry-update"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
       <ul class="mt-8 space-y-4">
         {{- range .Pages }}
           <li>
-            <a href="{{ .Permalink }}" class="text-blue-700 hover:text-blue-900 hover:underline">
+            <a href="{{ .RelPermalink }}" class="text-blue-700 hover:text-blue-900 hover:underline">
               {{ .Title }}
             </a>
           </li>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,43 +1,45 @@
 {{ define "main" }}
-  <div class="py-24 sm:py-32">
-    <div class="mx-auto max-w-7xl px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
-          {{ .Title }}
-        </h1>
-        {{- with .Content }}
-          <div class="mt-2 text-lg/8 text-gray-600">{{ . }}</div>
-        {{- end }}
+  {{/* Blog listing — ports the original ArticlesList.vue: a centered max-w-3xl
+       column with a full-width featured card on page 1, followed by a 2-column
+       grid of preview cards. White cards sit on the page-gray (#f7fafc) body, so
+       no section background is needed.
 
-        {{- $paginator := .Paginate .Pages -}}
-        {{- $isFirstPage := not $paginator.HasPrev -}}
+       Spacing matches the original: cards open mt-6 below the nav (md:mt-10), the
+       grid uses a 32px column gutter (gap-x-8) and 24px→40px row gap (gap-y-6
+       md:gap-y-10), mirroring the old md:mx-4 + mt-6/md:mt-10 rhythm.
 
-        <div class="mt-16 space-y-20 lg:mt-20">
-          {{- if and $isFirstPage $paginator.Pages }}
-            {{/* Featured first article on page 1 */}}
-            {{ partial "article-card.html" (dict "page" (index $paginator.Pages 0) "featured" true) }}
+       The original blog index had no visible page heading (it went straight to
+       cards); we keep that but add a visually-hidden h1 so the page still has a
+       top-level heading for assistive tech and SEO. */}}
+  <div class="mx-auto max-w-3xl px-4 pb-16">
+    <h1 class="sr-only">{{ .Title }}</h1>
 
-            {{/* Remaining articles in 2-column grid */}}
-            {{- $rest := after 1 $paginator.Pages -}}
-            {{- if $rest }}
-              <div class="grid grid-cols-1 gap-x-8 gap-y-20 md:grid-cols-2">
-                {{- range $rest }}
-                  {{ partial "article-card.html" (dict "page" . "featured" false) }}
-                {{- end }}
-              </div>
-            {{- end }}
-          {{- else }}
-            {{/* Pages 2+ — all articles in grid, no featured */}}
-            <div class="grid grid-cols-1 gap-x-8 gap-y-20 md:grid-cols-2">
-              {{- range $paginator.Pages }}
-                {{ partial "article-card.html" (dict "page" . "featured" false) }}
-              {{- end }}
-            </div>
+    {{- $paginator := .Paginate .Pages -}}
+    {{- $isFirstPage := not $paginator.HasPrev -}}
+
+    {{- if and $isFirstPage $paginator.Pages }}
+      {{/* Featured first article (page 1 only), full width */}}
+      <div class="mt-6 md:mt-10">
+        {{ partial "article-card.html" (dict "page" (index $paginator.Pages 0) "featured" true) }}
+      </div>
+
+      {{- $rest := after 1 $paginator.Pages -}}
+      {{- if $rest }}
+        <div class="mt-6 grid grid-cols-1 gap-x-8 gap-y-6 md:mt-10 md:grid-cols-2 md:gap-y-10">
+          {{- range $rest }}
+            {{ partial "article-card.html" (dict "page" . "featured" false) }}
           {{- end }}
         </div>
-
-        {{ partial "pagination.html" . }}
+      {{- end }}
+    {{- else }}
+      {{/* Pages 2+ — all articles in the grid, no featured */}}
+      <div class="mt-6 grid grid-cols-1 gap-x-8 gap-y-6 md:mt-10 md:grid-cols-2 md:gap-y-10">
+        {{- range $paginator.Pages }}
+          {{ partial "article-card.html" (dict "page" . "featured" false) }}
+        {{- end }}
       </div>
-    </div>
+    {{- end }}
+
+    {{ partial "pagination.html" . }}
   </div>
 {{ end }}

--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -30,8 +30,8 @@
       </div>
     {{- end }}
 
-    <h2 class="mt-0 font-header text-4xl leading-none font-bold">
-      <a href="{{ $page.Permalink }}" class="text-gray-900 hover:text-blue-600">{{ $page.Title }}</a>
+    <h2 class="mt-0 font-header text-4xl leading-tight font-bold">
+      <a href="{{ $page.RelPermalink }}" class="text-gray-900 hover:text-blue-600">{{ $page.Title }}</a>
     </h2>
 
     <p class="mt-1 text-sm text-gray-500">
@@ -44,19 +44,17 @@
   </div>
 
   <div class="mt-6 flex items-center justify-between border-t border-gray-200 pt-2">
-    <a href="{{ $page.Permalink }}" class="text-base text-blue-600 hover:text-blue-800">Read more</a>
+    <a href="{{ $page.RelPermalink }}" class="text-base text-blue-600 hover:text-blue-800">Read more</a>
     {{- with $page.Params.pdf }}
       <a
         href="{{ site.Params.pdfBase }}{{ . }}"
         title="Download PDF Newsletter"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-gray-400 hover:text-red-500"
+        class="transition-opacity hover:opacity-70"
       >
         <span class="sr-only">Download PDF</span>
-        <svg class="size-6 fill-current" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <path d="M537.6 290.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 128.2 315.3 96 256 96c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 283.8 0 337.2 0 400c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 484.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 379.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V240c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z" />
-        </svg>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5 text-[#e53e3e]" aria-hidden="true"><path fill-rule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875H5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875Zm5.845 17.03a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V12a.75.75 0 0 0-1.5 0v4.19l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3Z" clip-rule="evenodd" /><path d="M14.25 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 16.5 7.5h-1.875a.375.375 0 0 1-.375-.375V5.25Z" /></svg>
       </a>
     {{- end }}
   </div>

--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -1,69 +1,63 @@
+{{- /* Blog preview card — ports the original ArticlePreview.vue. A white card
+       (rounded-lg + shadow-md) with the cover image bleeding to the top/side
+       edges, then title, author·date, a serif preview, and a footer with a
+       "Read more" link and an optional PDF icon.
+
+       The card is `flex flex-col justify-between h-full` so that, in a grid row,
+       shorter cards stretch to the tallest and their footers stay bottom-aligned
+       (the original's equal-height-row effect). The image bleeds via -mx-4 -mt-4
+       (cancelling the card's p-4); the card's overflow-hidden + rounded-lg clips
+       the image's top corners, so the <img> itself needs no radius.
+
+       `featured` only switches the Cloudinary width preset (740 vs 610), exactly
+       like the original's customWidth — the layout/typography is identical for
+       featured and regular cards. */ -}}
 {{- $page := .page -}}
 {{- $featured := default false .featured -}}
 {{- $preset := cond $featured "featured" "regular" -}}
 
-<article class="{{ if $featured }}relative isolate flex flex-col gap-8 lg:flex-row{{ else }}relative isolate flex flex-col gap-6{{ end }}">
-  {{- with $page.Params.cover }}
-    {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" $preset) }}
-    <div class="{{ if $featured }}relative aspect-video sm:aspect-2/1 lg:aspect-square lg:w-64 lg:shrink-0{{ else }}relative aspect-video{{ end }}">
-      <img
-        src="{{ $imgURL }}"
-        alt="{{ $page.Title }}"
-        class="absolute inset-0 size-full rounded-2xl bg-gray-50 object-cover"
-        loading="lazy"
-      >
-      <div class="absolute inset-0 rounded-2xl inset-ring inset-ring-gray-900/10"></div>
-    </div>
-  {{- end }}
-
+<article class="flex h-full flex-col justify-between overflow-hidden rounded-lg bg-white p-4 shadow-md">
   <div>
-    <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-      {{- $isoDate := $page.Date.Format "2006-01-02" -}}
-      <time datetime="{{ $isoDate }}" class="text-gray-500">
-        {{- $page.Date.Format "January 2, 2006" -}}
-      </time>
-      {{- range $page.Params.tags }}
-        <a
-          href="{{ "/tags/" | relURL }}{{ . | urlize }}/"
-          class="relative z-10 inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
+    {{- with $page.Params.cover }}
+      {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" $preset) }}
+      <div class="-mx-4 -mt-4 mb-4">
+        <img
+          src="{{ $imgURL }}"
+          alt="{{ with $page.Params.caption }}{{ . }}{{ end }}"
+          class="block w-full"
+          loading="lazy"
         >
-          {{- . -}}
-        </a>
-      {{- end }}
-    </div>
-
-    <div class="group relative max-w-xl">
-      <h3 class="mt-3 text-lg/6 font-bold font-header text-gray-900 group-hover:text-gray-600">
-        <a href="{{ $page.Permalink }}">
-          <span class="absolute inset-0"></span>
-          {{ $page.Title }}
-        </a>
-      </h3>
-      {{- with $page.Description }}
-        <p class="mt-5 text-sm/6 text-gray-600">{{ . }}</p>
-      {{- end }}
-    </div>
-
-    <div class="mt-6 flex items-center border-t border-gray-900/5 pt-6">
-      <div class="text-sm/6">
-        {{- with $page.Params.author }}
-          <p class="font-semibold text-gray-900">{{ . }}</p>
-        {{- end }}
       </div>
-      {{- with $page.Params.pdf }}
-        <a
-          href="{{ site.Params.pdfBase }}{{ . }}"
-          class="relative z-10 ml-auto flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-blue-700"
-          title="Download PDF"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-          </svg>
-          <span>PDF</span>
-        </a>
-      {{- end }}
-    </div>
+    {{- end }}
+
+    <h2 class="mt-0 font-header text-4xl leading-none font-bold">
+      <a href="{{ $page.Permalink }}" class="text-gray-900 hover:text-blue-600">{{ $page.Title }}</a>
+    </h2>
+
+    <p class="mt-1 text-sm text-gray-500">
+      {{- with $page.Params.author }}<span>{{ . }}</span> {{ end }}<span>&middot; {{ $page.Date.Format "January 2, 2006" }}</span>
+    </p>
+
+    {{- with $page.Description }}
+      <p class="mt-4 font-serif text-base text-ink">{{ . }}</p>
+    {{- end }}
+  </div>
+
+  <div class="mt-6 flex items-center justify-between border-t border-gray-200 pt-2">
+    <a href="{{ $page.Permalink }}" class="text-base text-blue-600 hover:text-blue-800">Read more</a>
+    {{- with $page.Params.pdf }}
+      <a
+        href="{{ site.Params.pdfBase }}{{ . }}"
+        title="Download PDF Newsletter"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-400 hover:text-red-500"
+      >
+        <span class="sr-only">Download PDF</span>
+        <svg class="size-6 fill-current" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M537.6 290.6c4.1-10.7 6.4-22.4 6.4-34.6 0-53-43-96-96-96-19.7 0-38.1 6-53.3 16.2C367 128.2 315.3 96 256 96c-88.4 0-160 71.6-160 160 0 2.7.1 5.4.2 8.1C40.2 283.8 0 337.2 0 400c0 79.5 64.5 144 144 144h368c70.7 0 128-57.3 128-128 0-61.9-44-113.6-102.4-125.4zm-132.9 88.7L299.3 484.7c-6.2 6.2-16.4 6.2-22.6 0L171.3 379.3c-10.1-10.1-2.9-27.3 11.3-27.3H248V240c0-8.8 7.2-16 16-16h48c8.8 0 16 7.2 16 16v112h65.4c14.2 0 21.4 17.2 11.3 27.3z" />
+        </svg>
+      </a>
+    {{- end }}
   </div>
 </article>


### PR DESCRIPTION
## Summary

Restores the blog listing to the original site's card design, as part of the design-parity walk. You chose "match the original cards" over keeping the Tailwind UI editorial layout the rebuild had shipped.

The rebuild's blog list was a flat, modern editorial layout (no card chrome, tag pills, side-by-side featured, sans-serif preview). This rewrites it to port the original `ArticlePreview.vue` / `ArticlesList.vue`.

## Changes

**`layouts/partials/article-card.html`** — full rewrite to the original card:
- White card: `rounded-lg` + `shadow-md`, `p-4`.
- Cover image bleeds to the top/side edges (`-mx-4 -mt-4`); the card's `overflow-hidden` clips the corners, so the image itself needs no radius.
- Title: Lato (`font-header`) 36px, `font-bold`, `leading-none`.
- Meta: "Author · Date".
- Preview: Noto Serif, 16px.
- Footer: blue "Read more" link + the original cloud PDF icon (only when the post has a `pdf`).
- **Dropped** the blue tag pills and the side-by-side featured layout.

**`layouts/blog/list.html`** — port of `ArticlesList.vue`:
- Centered `max-w-3xl` (768px) column on the page-gray (`#f7fafc`) body.
- Full-width featured card on page 1, then a 2-column grid (`gap-x-8` = 32px, `gap-y-6`/`md:gap-y-10`).
- Pages 2+ are grid-only (no featured).
- Replaced the visible "Blog" `h1` with a visually-hidden one — the original had no visible page heading, but keeping an `h1` preserves heading hierarchy for assistive tech / SEO.

## Verification (computed styles, local vs production)

| Property | Production | This PR |
|---|---|---|
| Body bg | `#f7fafc` | `#f7fafc` ✓ |
| Card | white · `8px` radius · `shadow-md` · `16px` pad | same ✓ |
| Title | 36px / 36px / 700 Lato | same ✓ |
| Preview | 16px Noto Serif `#2d3748` | same ✓ (exact) |
| "Read more" | `#1992d4` | `#1992d4` ✓ (exact) |
| Footer rule | `1px` · `pt-8` · `mt-24` | same ✓ |
| Column / gutter | 768px / 32px | same ✓ |

Verified both page 1 (featured + grid) and page 2 (grid-only + pagination). `hugo --gc --minify` green; `npm run lint` clean.

## Notes / judgment calls

- **Grays**: Tailwind v4's gray scale shifted darker vs the original's v1 grays. Preview color (`text-ink` = `#2d3748`) and the "Read more" blue (`#1992d4`) map exactly; meta uses `text-gray-500` to approximate the old `gray-600` (`#718096`). Title link / footer border use v4 `gray-900` / `gray-200` (visually equivalent near-black / light-gray).
- **Grays**: Tailwind v4's scale runs darker than the original's v1 grays. Exact where it mattered (preview, "Read more"); meta → `gray-500`.

## Follow-up refinements (review feedback)

Added on top of the original card port, in response to review:

- **PDF icon → standard Heroicon.** Swapped the card's one-off cloud icon for the solid Heroicon `document-arrow-down` (`text-[#e53e3e]`), matching the callout shortcode and archives page.
- **Looser title leading.** `leading-none` → `leading-tight` (36px title now wraps at 45px line-height) so 2-line titles aren't cramped.
- **Relative internal links.** `.Permalink` → `.RelPermalink` in `article-card.html` (title + "Read more") and `_default/list.html`. With `baseURL` set to production, `.Permalink` emitted absolute `https://ofreport.com/...` links that bounced local navigation out to production; `.RelPermalink` emits host-agnostic `/blog/slug/`. (RSS/canonical/OG keep `.Permalink` — they need absolute URLs.)
- **Seed covers repointed (review aid).** The 9 fabricated seed covers (which 404'd) now point at real, existing OFReport Cloudinary images so the list renders properly for review. Temporary — Phase 15 content migration replaces all seed content. (3 seed posts intentionally have no cover and render image-less.)

Verified after refinements: links render relative (`/blog/...`), title line-height 45px, PDF icon `viewBox 0 0 24 24` / `#e53e3e`, images load 7/7 on page 1. Build green, lint clean.

Tracked by #114.

