### PR TITLE
fix: restore full-bleed cover hero on single article pages

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -52,8 +52,10 @@
         {{- .Title -}}
       </h1>
 
-      {{/* Meta line: author, date, reading time */}}
-      <div class="mt-4 flex flex-wrap items-center gap-x-3 text-sm/6 text-gray-500">
+      {{/* Meta line: author, date, reading time. mt-1 keeps the byline tight to
+           the title (the original's 4px), grouped with it rather than drifting
+           toward the tags below (which keep their mt-4 / 16px separation). */}}
+      <div class="mt-1 flex flex-wrap items-center gap-x-3 text-sm/6 text-gray-500">
         {{- with .Params.author }}
           <span>{{ . }}</span>
           <span aria-hidden="true">&middot;</span>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -28,15 +28,27 @@
       </div>
     {{- end }}
 
-    <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if .Params.cover }}pt-6 sm:pt-8{{ else }}pt-24 sm:pt-32{{ end }}">
+    <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if not .Params.cover }}pt-24 sm:pt-32{{ end }}">
 
-      {{/* Caption — centered + semibold beneath the full-bleed cover (original). */}}
+      {{/* Caption — sits tight under the cover (mt-2) and well clear of the
+           title (which carries the larger top margin below), grouping it with
+           the photo as in the original. Color is gray-500: lighter than the body
+           text for visual separation, but still ~4.6:1 on the page bg (WCAG AA
+           pass — the original's #718096 was only 3.83:1). */}}
+      {{- $titleMargin := "" -}}
+      {{- if .Params.cover -}}
+        {{- if .Params.caption -}}
+          {{- $titleMargin = "mt-8 sm:mt-12 lg:mt-14" -}}
+        {{- else -}}
+          {{- $titleMargin = "mt-6 sm:mt-8" -}}
+        {{- end -}}
+      {{- end -}}
       {{- if and .Params.cover .Params.caption }}
-        <p class="mt-2 text-center text-sm font-semibold text-gray-600 sm:text-base">{{ .Params.caption }}</p>
+        <p class="mt-2 text-center text-sm font-semibold text-gray-500 sm:text-base">{{ .Params.caption }}</p>
       {{- end }}
 
       {{/* Article title */}}
-      <h1 class="mt-3 text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:mt-6 sm:text-5xl lg:mt-8">
+      <h1 class="{{ $titleMargin }} text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:text-5xl">
         {{- .Title -}}
       </h1>
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,28 +1,42 @@
 {{ define "main" }}
-  <article class="pt-24 pb-16 sm:pt-32 sm:pb-20">
-    <div class="mx-auto max-w-3xl px-6 lg:px-8">
+  <article class="pb-16 sm:pb-20">
 
-      {{/* Cover image */}}
-      {{- with .Params.cover }}
-        {{- $imgURL := partial "cloudinary-url.html" (dict "src" . "preset" "article") }}
-        {{- $lightbox := partial "cloudinary-url.html" (dict "src" . "preset" "lightbox") }}
-        <figure class="mb-10">
-          <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $.Params.caption }} data-description="{{ . }}"{{ end }}>
-            <img
-              src="{{ $imgURL }}"
-              alt="{{ $.Title }}"
-              class="aspect-video w-full rounded-xl bg-gray-50 object-cover"
-              loading="eager"
-            >
-          </a>
-          {{- with $.Params.caption }}
-            <figcaption class="mt-3 text-sm/6 text-gray-500">{{ . }}</figcaption>
-          {{- end }}
-        </figure>
+    {{/* Full-bleed cover hero — ports the original _slug.vue banner: an
+         edge-to-edge image on a navy gradient (the gradient shows as a load-time
+         fallback), using the original's responsive height scale
+         (250 → 450 → 500 → 600px → 75vh). We keep it lightbox-able (#110/#111) by
+         wrapping the <img> in a GLightbox link rather than using a CSS
+         background. The xs (460px) step from the original is omitted per the
+         #114 breakpoint decision (lean on v4 defaults). */}}
+    {{- with .Params.cover }}
+      {{- $hero := partial "cloudinary-url.html" (dict "src" . "preset" "hero") }}
+      {{- $lightbox := partial "cloudinary-url.html" (dict "src" . "preset" "lightbox") }}
+      <div style="background: linear-gradient(to bottom, #1f415c 0%, #0f2847 100%)">
+        <a
+          href="{{ $lightbox }}"
+          class="glightbox block"
+          data-gallery="article"
+          {{- with $.Params.caption }} data-description="{{ . }}"{{ end }}
+        >
+          <img
+            src="{{ $hero }}"
+            alt="{{ $.Title }}"
+            class="block w-full object-cover min-h-[250px] sm:min-h-[450px] md:min-h-[500px] lg:min-h-[600px] xl:min-h-[75vh]"
+            loading="eager"
+          >
+        </a>
+      </div>
+    {{- end }}
+
+    <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if .Params.cover }}pt-6 sm:pt-8{{ else }}pt-24 sm:pt-32{{ end }}">
+
+      {{/* Caption — centered + semibold beneath the full-bleed cover (original). */}}
+      {{- if and .Params.cover .Params.caption }}
+        <p class="mt-2 text-center text-sm font-semibold text-gray-600 sm:text-base">{{ .Params.caption }}</p>
       {{- end }}
 
       {{/* Article title */}}
-      <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:text-5xl">
+      <h1 class="mt-3 text-4xl font-bold tracking-tight text-pretty text-ink font-header sm:mt-6 sm:text-5xl lg:mt-8">
         {{- .Title -}}
       </h1>
 
@@ -38,13 +52,13 @@
         <span>{{ .ReadingTime }} min read</span>
       </div>
 
-      {{/* Tag badges */}}
+      {{/* Tags — filled blue pills (original), translucent until hover */}}
       {{- with .Params.tags }}
         <div class="mt-4 flex flex-wrap gap-2">
           {{- range . }}
             <a
               href="{{ "/tags/" | relURL }}{{ . | urlize }}/"
-              class="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
+              class="inline-flex items-center rounded-full bg-blue-600 px-3 py-1 text-xs font-bold leading-none text-white opacity-50 transition-opacity hover:opacity-100"
             >
               {{- . -}}
             </a>

--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -13,6 +13,7 @@
     "regular"  "c_scale,f_auto,q_auto,w_610"
     "figure"   "c_scale,f_auto,q_auto,w_768"
     "article"  "c_scale,f_auto,q_auto:best"
+    "hero"     "c_scale,f_auto,q_auto:best,w_2000"
     "cover"    "c_scale,f_auto,q_auto:best,w_200"
     "lightbox" "c_scale,f_auto,q_auto,w_1600"
     "og"       "c_fill,f_auto,h_630,q_auto,w_1200"


### PR DESCRIPTION
## Summary

Aligns the single-article page with the original `_slug.vue` design, as the next step in the design-parity walk. Keeps the recent Hugo enhancements (cover lightbox from #110/#111, reading time, prev/next nav) per review.

## Changes

**`layouts/blog/single.html`**
- **Cover → full-bleed hero.** Replaced the contained, rounded `aspect-video` image with the original's edge-to-edge hero banner on a navy gradient fallback, using the original responsive height scale: `min-h-[250px]` → `sm:450` → `md:500` → `lg:600` → `xl:75vh`. The xs (460px) step is omitted per the #114 breakpoint decision. **The lightbox is preserved** — the hero is a GLightbox-wrapped `<img>` (not a CSS background), so click-to-zoom still works.
- **Caption → centered + semibold** beneath the cover (was left-aligned, normal weight).
- **Tags → filled `blue-600` pills**, white text, translucent until hover (`opacity-50` → `100`), matching the original (was `blue-50`/`blue-700` outline pills).
- No-cover articles get `pt-24 sm:pt-32` so the title clears the fixed nav.

**`layouts/partials/cloudinary-url.html`**
- Added a `hero` preset (`c_scale,f_auto,q_auto:best,w_2000`) matching the original cover transform.

## Kept as intentional enhancements (your call)
- **Reading time** (`1 min read`) in the meta line.
- **Prev/next** article navigation.

## Verification (computed styles, local vs production)

| Element | Production | This PR |
|---|---|---|
| Cover | full-bleed, edge-to-edge, responsive height (e.g. 600px @ lg, 75vh @ xl) | full-bleed, x=0, same scale ✓ |
| Cover lightbox | n/a (original not clickable) | `glightbox` preserved ✓ |
| Caption | centered, weight 600 | centered, weight 600 ✓ |
| Tags | filled `#1992d4`, white, `opacity 0.5` → 1 | `#1992d4`, white, `opacity 0.5` ✓ |
| Title | 48px / leading-none / 700 | 48px, left-aligned ✓ |

Checked both a cover article and a cover-less article (title spacing correct). `hugo --gc --minify` green; `npm run lint` clean.

## Follow-up (review feedback): caption spacing + color

- **Grouped the caption with the photo.** Dropped the column's top padding when a cover is present so the caption sits **8px** below the cover (was ~40px) and moved the spacing onto the title (**~56px** below the caption). Matches the original's 8/56 rhythm.
- **Lightened the caption** from `gray-600` (7.2:1) to `gray-500` (**4.61:1 — still WCAG AA**). The original's `#718096` was only 3.83:1 (fails AA), so this is lighter for visual separation without the original's contrast problem.

Verified: 8px above / 56px below, color `gray-500`.

## Follow-up (review feedback): title → meta spacing

The meta byline used `mt-4` (16px) below the title, where the original uses `mt-1` (4px) — leaving the author/date/read-time visually equidistant between the title (16px) and the tags (16px) instead of grouped with the title. This was a carried-over template default, **not** an accessibility/Lighthouse requirement (heading-to-byline spacing isn't governed by WCAG or scored by Lighthouse). Restored `mt-1` so the byline hugs the title; tags keep their `mt-4`.

Verified: title→meta **4px**, meta→tags **16px** (matches original exactly).

Tracked by #114.


