### PR TITLE
fix: polish tag index and tag detail pages

### DIFF
--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -1,27 +1,24 @@
 {{ define "main" }}
-  <div class="py-24 sm:py-32">
-    <div class="mx-auto max-w-7xl px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        {{- $tagCount := len .Data.Terms -}}
-        <h1 class="text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
-          {{ .Title }}
-        </h1>
-        <p class="mt-2 text-lg/8 text-gray-600">
-          {{ $tagCount }} {{ cond (eq $tagCount 1) "tag" "tags" }} across the blog.
-        </p>
+  {{/* Tags index — the original (pages/tags/index.vue) was a centered "Article Tags"
+       heading over a narrow column. Joshua's parity call: keep the rebuild's pill
+       badges (a deliberate, more scannable divergence from the original list) but
+       restore the centered layout + "Article Tags" heading. Heading is Lato 48px
+       (font-header + text-5xl) in ink (#2d3748), matching every other page h1. */}}
+  <div class="mx-auto max-w-2xl px-4 pt-12 pb-16 text-center">
+    <h1 class="font-header text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl">
+      Article Tags
+    </h1>
 
-        <div class="mt-10 flex flex-wrap gap-3">
-          {{- range .Data.Terms.Alphabetical }}
-            <a
-              href="{{ .Page.RelPermalink }}"
-              class="inline-flex items-center gap-x-2 rounded-full bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 inset-ring inset-ring-blue-700/10 hover:bg-blue-100 transition-colors"
-            >
-              {{ .Term }}
-              <span class="text-xs text-blue-700/60">{{ .Count }}</span>
-            </a>
-          {{- end }}
-        </div>
-      </div>
+    <div class="mt-10 flex flex-wrap justify-center gap-3">
+      {{- range .Data.Terms.Alphabetical }}
+        <a
+          href="{{ .Page.RelPermalink }}"
+          class="inline-flex items-center gap-x-2 rounded-full bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 inset-ring inset-ring-blue-700/10 transition-colors hover:bg-blue-100"
+        >
+          {{ .Term }}
+          <span class="text-xs text-blue-700/60">{{ .Count }}</span>
+        </a>
+      {{- end }}
     </div>
   </div>
 {{ end }}

--- a/layouts/taxonomy/term.html
+++ b/layouts/taxonomy/term.html
@@ -3,12 +3,17 @@
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-2xl lg:max-w-4xl">
         {{- $count := len .Pages -}}
-        <p class="text-base/7 font-semibold text-blue-600">Tag</p>
+        <p class="text-base/7 font-semibold text-gray-600">Tag</p>
         <h1 class="mt-2 text-4xl font-bold tracking-tight text-pretty text-ink sm:text-5xl font-header">
           {{ .Title }}
         </h1>
         <p class="mt-2 text-lg/8 text-gray-600">
           {{ $count }} {{ cond (eq $count 1) "article" "articles" }} tagged &ldquo;{{ .Data.Term }}&rdquo;.
+        </p>
+        <p class="mt-4">
+          <a href="{{ "/tags/" | relURL }}" class="text-base/7 font-semibold text-blue-600 transition-colors hover:text-blue-800">
+            View all tags <span aria-hidden="true">&rarr;</span>
+          </a>
         </p>
 
         {{- $paginator := .Paginate .Pages -}}


### PR DESCRIPTION
## Summary

Design-parity polish for the tag/taxonomy pages, continuing the page-by-page walk in the parity pass.

### Tags index (`/tags/`)

- Centered the **"Article Tags"** heading (Lato 48px, ink `#2d3748`) and the tag pills, matching the original Nuxt site's centered layout.
- Dropped the "N tags across the blog" subtitle.
- **Decision:** kept the rebuild's pill badges rather than restoring the original's vertical divider list — a deliberate, more scannable divergence.

### Tag detail (`/tags/{tag}/`)

- **Decision:** kept the Hugo-default layout (eyebrow → prominent tag title → count) rather than the original site's centered "Articles tagged …" header — it surfaces the current tag name more clearly.
- Added an explicit **"View all tags →"** link beneath the article count so visitors have a clear, well-labeled path back to the tags index.
- Recolored the **"Tag" eyebrow from blue to `gray-600`** so it reads as a label, not a link — blue is reserved for links in the site's design language. (It previously looked clickable but had no link.)

## Verification

- `hugo --gc --minify` — green (38 pages, no errors)
- `npm run lint` — 0 errors
- Computed-style checks at 1440px and 375px: h1 Lato 48px/700 `#2d3748`; "View all tags" link `#1992d4`; eyebrow `gray-600` (distinct from the ink title); centered index heading + pills.

Tracked by #114.
