### PR TITLE
fix: unify inline link styling site-wide

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -52,6 +52,26 @@
   content: "";
 }
 
+/* Inline links in prose/body content. The original site styled all links
+   globally (blue-600, semibold); we centralize the rebuild's equivalent here
+   rather than repeating `prose-a:*` utilities on every template — so the articles
+   migrated in Phase 15 inherit it automatically. Color is set via the Typography
+   plugin's --tw-prose-links variable (so a per-link text-* utility still wins
+   when needed); weight and hover have no plugin variable, so they're explicit
+   rules mirroring the plugin's own :where()/not-prose selector. The plugin's
+   default underline is intentionally kept — it's the clearest link affordance (a
+   deliberate divergence from the original, which had none). Hover darkens to
+   blue-800, matching the site's buttons/nav (not the original's lighten-on-hover). */
+.prose {
+  --tw-prose-links: var(--color-blue-600);
+}
+.prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-weight: 600;
+}
+.prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
+  color: var(--color-blue-800);
+}
+
 /* Faded full-bleed page background for static pages (see #69). The per-page
    Cloudinary URL is injected via the --page-bg-image custom property on a
    .page-bg element. The background color is the site-wide page gray (the exact

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-3xl") }}
 
     {{/* Intro prose (left-aligned), authored in archives.md. */}}
-    <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header">
       {{ .Content }}
     </div>
 
@@ -27,7 +27,7 @@
             {{ range (index $archives .) }}
               <li class="flex items-start gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="mt-1 size-5 shrink-0 text-[#e53e3e]"><path fill-rule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875H5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875Zm5.845 17.03a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V12a.75.75 0 0 0-1.5 0v4.19l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3Z" clip-rule="evenodd" /><path d="M14.25 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 16.5 7.5h-1.875a.375.375 0 0 1-.375-.375V5.25Z" /></svg>
-                <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-xl text-blue-700 hover:text-blue-900">
+                <a href="{{ site.Params.pdfBase }}{{ .file }}" target="_blank" rel="noopener noreferrer" class="text-xl font-semibold text-blue-600 hover:text-blue-800">
                   {{ .title }} <span class="whitespace-nowrap">({{ .issue }})</span>
                 </a>
               </li>

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -2,7 +2,7 @@
   {{ partial "page-shell-open.html" (dict "page" . "maxWidth" "max-w-2xl") }}
 
     {{/* Intro copy authored in content/contact.md */}}
-    <div class="mt-10 prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+    <div class="mt-10 prose prose-gray sm:prose-lg font-serif prose-headings:font-header">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/family.html
+++ b/layouts/_default/family.html
@@ -45,7 +45,7 @@
     </p>
 
     {{/* Bio body — left-aligned prose authored in content/family.md. */}}
-    <div class="mt-8 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900 sm:mt-12 md:mt-16">
+    <div class="mt-8 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header sm:mt-12 md:mt-16">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
       <ul class="mt-8 space-y-4">
         {{- range .Pages }}
           <li>
-            <a href="{{ .RelPermalink }}" class="text-blue-700 hover:text-blue-900 hover:underline">
+            <a href="{{ .RelPermalink }}" class="text-blue-600 hover:text-blue-800 hover:underline">
               {{ .Title }}
             </a>
           </li>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
 
     {{/* Page content — "centered: true" centers the body (e.g. Ministry);
          otherwise it stays left-aligned. */}}
-    <div class="{{ if not .Params.hideHeading }}mt-10 {{ end }}max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900{{ if .Params.centered }} mx-auto text-center sm:px-8{{ end }}">
+    <div class="{{ if not .Params.hideHeading }}mt-10 {{ end }}max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header{{ if .Params.centered }} mx-auto text-center sm:px-8{{ end }}">
       {{ .Content }}
     </div>
 

--- a/layouts/_default/subscribe.html
+++ b/layouts/_default/subscribe.html
@@ -18,7 +18,7 @@
           </figure>
 
           {{/* Intro copy authored in content/subscribe.md */}}
-          <div class="prose prose-gray sm:prose-lg font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+          <div class="prose prose-gray sm:prose-lg font-serif">
             {{ .Content }}
           </div>
         </div>
@@ -28,14 +28,14 @@
         </div>
 
         <p class="mt-6 font-serif">
-          You can also access previous issues in our <a href="/archives/" class="text-blue-700 hover:text-blue-900">Archives</a>.
+          You can also access previous issues in our <a href="/archives/" class="font-semibold text-blue-600 underline hover:text-blue-800">Archives</a>.
         </p>
 
         <hr class="my-8 border-gray-200" />
 
         <p class="font-serif text-gray-700">Don&rsquo;t want to receive emails from us anymore?</p>
         <p class="mt-2 font-serif">
-          <a href="https://OFReport.us6.list-manage.com/unsubscribe?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559" target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:text-blue-900">Unsubscribe</a>
+          <a href="https://OFReport.us6.list-manage.com/unsubscribe?u=1e0c65850b60905f65b151819&amp;id=97b9f6a559" target="_blank" rel="noopener noreferrer" class="font-semibold text-blue-600 underline hover:text-blue-800">Unsubscribe</a>
         </p>
       </div>
     </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -81,7 +81,7 @@
       {{- end }}
 
       {{/* Article content */}}
-      <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header prose-a:text-blue-700 prose-a:hover:text-blue-900">
+      <div class="mt-10 max-w-2xl prose prose-gray sm:prose-lg font-serif prose-headings:font-header">
         {{ .Content }}
       </div>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -114,7 +114,7 @@
 
           <div class="flex-1">
             <h2 class="text-3xl font-bold tracking-tight text-ink font-header sm:text-4xl">Read the News</h2>
-            <div class="mt-4 prose prose-gray sm:prose-lg font-serif prose-a:text-blue-700 prose-a:hover:text-blue-900">
+            <div class="mt-4 prose prose-gray sm:prose-lg font-serif">
               <p><em>Overseas Field Report</em> is our bi-monthly newsletter containing updates on our family and ministry here in Ukraine. We&rsquo;d be tickled if you&rsquo;d subscribe and pray for us!</p>
             </div>
           </div>
@@ -125,7 +125,7 @@
         </div>
 
         <p class="mt-6 font-serif">
-          You can also access previous issues in our <a href="/archives/" class="text-blue-700 hover:text-blue-900">Archives</a>.
+          You can also access previous issues in our <a href="/archives/" class="font-semibold text-blue-600 underline hover:text-blue-800">Archives</a>.
         </p>
       </div>
     </div>

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -30,7 +30,7 @@
   {{- with .Get "pdf" }}
   <a
     href="{{ site.Params.pdfBase }}{{ . }}"
-    class="callout-download inline-flex items-center gap-1.5 font-sans text-blue-700 no-underline transition-colors hover:text-blue-900"
+    class="callout-download inline-flex items-center gap-1.5 font-sans text-blue-600 no-underline transition-colors hover:text-blue-800"
     target="_blank"
     rel="noopener noreferrer"
   >


### PR DESCRIPTION
## Summary

PR B of the design-parity pass (Tracked by #114): unify inline/body link styling across the site.

Production body links are **blue-600, semibold (600), underlined, hover blue-800**. The rebuild was blue-700 / weight 500 / hover blue-900, with the styling duplicated as `prose-a:*` utilities on 7 templates. This centralizes it and brings the stray explicit-class links in line.

The resting + hover colors are a deliberate **cohesion** choice (not a strict port): blue-600 → blue-800 darkens on hover like the site's buttons and nav, rather than the original's lighten-on-hover (blue-400). Underline is kept as the clearest link affordance — a chosen divergence from the original, which had none.

## Changes

- **`assets/css/main.css`** — centralized prose link styling in one block:
  - color via the Typography plugin's `--tw-prose-links` variable (so per-link `text-*` utilities still win)
  - `font-weight: 600` and `:hover` → blue-800 as explicit rules that mirror the plugin's own `:not(not-prose)` selector, so buttons/CTAs inside prose are correctly skipped
  - the plugin's default underline is kept
- **7 prose templates** — dropped the repeated `prose-a:text-blue-700 prose-a:hover:text-blue-900` chains (`index`, `blog/single`, `_default/single`, `archives`, `contact`, `subscribe`, `family`). The 219 articles migrated in Phase 15 inherit the centralized styling automatically.
- **Explicit-class links unified** to blue-600/blue-800:
  - inline Archives/Unsubscribe links → full bold + underline treatment
  - archives PDF list links → recolor + `font-semibold` (matching the original's weight); standalone, so no underline
  - callout download CTA → recolor (keeps `no-underline`)
  - fallback `_default/list.html` link → recolor

## Verification

Computed styles checked in-browser against the running dev server:

- Prose body links (Family): `#1992d4` / 600 / underline; hover rule resolves to `#0b69a3` (blue-800)
- Homepage inline Archives link (outside prose): `#1992d4` / 600 / underline
- Archives PDF list links: `#1992d4` / 600 / 20px / no underline (→ `#0b69a3` on hover)
- Podcast Subscribe button (a `button` shortcode inside prose): correctly skipped by the `not-prose` guard

`hugo --gc --minify` green (38 pages); `npm run lint` clean.

## Notes

- The callout download CTA's weight goes 700 → 600 (it now follows the centralized rule instead of inheriting the callout's bold). No current content uses a callout *with a PDF*, so this wasn't verifiable live; flag if it should stay 700.
- The prev/next nav hover (`group-hover:text-blue-700`, approved in #120) is left as-is — out of scope, optional follow-up for full hover-color cohesion.
