### PR TITLE
refactor: extract shared button-classes partial

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -73,7 +73,7 @@
 
           <a
             href="/family/"
-            class="inline-flex items-center rounded-full bg-blue-800 px-6 py-3 font-sans text-base font-semibold text-white shadow-sm transition-colors hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            class="inline-flex items-center px-6 py-3 text-base {{ partial "button-classes.html" (dict "variant" "filled") }}"
           >
             Meet our Family
           </a>

--- a/layouts/partials/button-classes.html
+++ b/layouts/partials/button-classes.html
@@ -1,0 +1,20 @@
+{{- /*
+  button-classes — single source of truth for the filled-primary / outline button styling.
+
+  Returns the shared base classes (shape, color, hover, focus ring, font) for a
+  button-like control, WITHOUT size or layout classes — call sites add their own
+  padding, width, display, etc. Works from both templates and shortcodes: a shortcode
+  can't be called from a template, but a partial can, so this bridges the hero CTA
+  (template) and the {{< button >}} shortcode (content) without duplication.
+
+  Param:
+    variant  "filled" (default) | "outline"
+
+  Usage:
+    class="inline-flex items-center px-6 py-3 text-base {{ partial "button-classes.html" (dict "variant" "filled") }}"
+*/ -}}
+{{- $variant := .variant | default "filled" -}}
+{{- $base := "rounded-full font-sans font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" -}}
+{{- $filled := "bg-blue-800 text-white shadow-sm hover:bg-blue-900" -}}
+{{- $outline := "text-blue-600 ring-1 ring-inset ring-blue-600/30 hover:bg-blue-50" -}}
+{{- printf "%s %s" $base (cond (eq $variant "outline") $outline $filled) -}}

--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -79,7 +79,7 @@
 
   <button
     type="submit"
-    class="w-full cursor-pointer rounded-full bg-blue-800 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:w-auto"
+    class="w-full cursor-pointer px-6 py-2.5 text-sm sm:w-auto {{ partial "button-classes.html" (dict "variant" "filled") }}"
   >
     Send Message
   </button>

--- a/layouts/partials/mailchimp-form.html
+++ b/layouts/partials/mailchimp-form.html
@@ -43,7 +43,7 @@
       type="submit"
       name="subscribe"
       value="Subscribe"
-      class="cursor-pointer rounded-full bg-blue-800 px-6 py-2.5 font-sans text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:rounded-l-none"
+      class="cursor-pointer px-6 py-2.5 text-sm sm:rounded-l-none {{ partial "button-classes.html" (dict "variant" "filled") }}"
     />
   </form>
 </div>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -32,11 +32,11 @@
 {{- $outline := eq (printf "%v" (.Get "outline")) "true" -}}
 {{- $external := eq (printf "%v" (.Get "external")) "true" -}}
 {{- $center := ne (.Get "align") "left" -}}
-{{- $variant := cond $outline "text-blue-600 ring-1 ring-inset ring-blue-600/30 hover:bg-blue-50" "bg-blue-800 text-white shadow-sm hover:bg-blue-900" -}}
+{{- $btnClasses := partial "button-classes.html" (dict "variant" (cond $outline "outline" "filled")) -}}
 <div class="not-prose my-6 md:my-8{{ if $center }} text-center{{ end }}">
   <a
     href="{{ $href }}"
-    class="inline-flex items-center gap-1.5 rounded-full px-6 py-3 font-sans text-base font-semibold no-underline transition-colors {{ $variant }}"
+    class="inline-flex items-center gap-1.5 px-6 py-3 text-base no-underline {{ $btnClasses }}"
     {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
   >
     {{- $text -}}


### PR DESCRIPTION
## Summary

- Extracts the filled/outline button base styling (shape, color, hover, focus ring, font) into a single `layouts/partials/button-classes.html`, eliminating the class-list duplication that had spread across four button sites.
- The `button` shortcode, the homepage hero CTA, and both form submit buttons (contact + mailchimp) now consume that one source — so the next brand/color/focus change touches one file instead of four.

## Changes

- **New:** `layouts/partials/button-classes.html` — returns the shared base class string for `variant` `filled` (default) | `outline`. Implemented as a class-string partial (rather than a full-`<a>` partial) so the `<button>`/`<input type="submit">` form controls can share it too, not just the link buttons.
- **`layouts/shortcodes/button.html`** — delegates its variant classes to the partial.
- **`layouts/index.html`** (hero CTA), **`layouts/partials/contact-form.html`**, **`layouts/partials/mailchimp-form.html`** — swapped their duplicated base classes for the partial, keeping only their own size/layout classes.

## Testing

- [x] `hugo --gc --minify` builds clean (38 pages, no errors/warnings)
- [x] `npm run lint` clean (0 errors)
- [x] Rendered class sets at hero / contact / mailchimp are byte-identical to before (verified by sorted-token diff)
- [x] Mailchimp button verified at all three mount points (homepage newsletter, article footer, subscribe page)
- [x] No `bg-blue-800` button base remains outside the partial (single source of truth confirmed)

## Notes

- **One intentional, approved visual change:** the `button` shortcode previously lacked the focus-visible ring the other three sites already had. Consolidation gives it the shared ring — a minor accessibility consistency fix that affects only the `:focus` state. Signed off in the issue thread; all other sites render unchanged.
- Implemented as a class-string partial rather than the issue's literal `button-link.html` (full-`<a>`) proposal — that choice is what lets all four sites, including the form controls, share the base. The issue flagged this tension in its step 4.
- Rule-of-three satisfied (4 duplication sites); no unused `size`/`variant` options added, per the issue's "keep it minimal" note.

Closes #101
