### PR TITLE
docs: correct article count to 223 and date range to 2026 (Phase 15 pre-flight)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-OFReport.com is a missionary family blog (Joshua and Kelsie Steele) being rebuilt from Nuxt.js 2 to Hugo. The site has 219 blog articles spanning 2008–2025, 5+ static pages, and 26 tags. Full requirements are in the `docs/prd/` directory (start with `README.md`; see `ROADMAP.md` for build phases).
+OFReport.com is a missionary family blog (Joshua and Kelsie Steele) being rebuilt from Nuxt.js 2 to Hugo. The site has 223 blog articles spanning 2008–2026, 5+ static pages, and 26 tags. Full requirements are in the `docs/prd/` directory (start with `README.md`; see `ROADMAP.md` for build phases).
 
 The original Nuxt.js 2 source lives in the sibling directory `../ofreport.com-nuxt2/` (relative to this repo root). Consult it when matching the old site's design or migrating content — e.g. `pages/` for page layouts, `components/` for Vue components being ported to shortcodes, and `tailwind.config.js` for the old custom utility values.
 
@@ -140,7 +140,7 @@ The developer has a Tailwind Plus subscription. Licensed snippets go in `docs/ta
 
 ## Content Migration
 
-A Ruby migration script will convert 219 articles from the Nuxt source repo. Key transformations:
+A Ruby migration script will convert 223 articles from the Nuxt source repo. Key transformations:
 
 - Vue components (`<article-image>`, `<article-callout>`, etc.) → Hugo shortcodes
 - `preview` frontmatter → `description` (markdown stripped)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A missionary family blog by Joshua and Kelsie Steele, documenting 17 years of
 ministry work in Ukraine. This is a ground-up rebuild from Nuxt.js 2 to
 [Hugo](https://gohugo.io/).
 
-The site includes 219 blog articles (2008-2025), 5 static pages, and 26 tags.
+The site includes 223 blog articles (2008-2026), 5 static pages, and 26 tags.
 
 ## Tech Stack
 

--- a/docs/prd/00-overview.md
+++ b/docs/prd/00-overview.md
@@ -11,14 +11,14 @@
 
 Rebuild [OFReport.com](https://ofreport.com), a missionary family blog
 documenting 17 years of ministry work in Ukraine, from Nuxt.js 2 to Hugo. The
-site has 219 blog articles, 5 static pages, and 26 tags spanning October 2008
-to August 2025.
+site has 223 blog articles, 5 static pages, and 26 tags spanning October 2008
+to May 2026.
 
 ---
 
 ## Goals
 
-- **Preserve all existing content** — 219 articles, static pages, PDFs, images,
+- **Preserve all existing content** — 223 articles, static pages, PDFs, images,
   and PDF newsletter archives
 - **Preserve key URL structures** for SEO continuity (`/blog/{slug}/`,
   `/tags/{tag}/`)

--- a/docs/prd/06-content-migration.md
+++ b/docs/prd/06-content-migration.md
@@ -56,7 +56,7 @@ inconsistencies.
 
 **Approach for the Hugo migration:**
 
-- The migration script should process all 219 articles consistently
+- The migration script should process all 223 articles consistently
 - After migration, a manual review pass should identify articles with
   formatting issues (inconsistent headings, raw HTML, missing images, broken
   layout patterns)
@@ -71,7 +71,7 @@ inconsistencies.
 
 ## Migration Checklist
 
-- [ ] All 219 articles converted
+- [ ] All 223 articles converted
 - [ ] All 5 static pages created in Hugo
 - [ ] Frontmatter schema matches Hugo expectations
 - [ ] All Vue component syntax converted to shortcodes

--- a/docs/prd/07-deployment.md
+++ b/docs/prd/07-deployment.md
@@ -103,7 +103,7 @@ Thumbs.db
 
 ## Build Performance
 
-Hugo builds are near-instant for 219 articles. Expected build time: under 1
+Hugo builds are near-instant for 223 articles. Expected build time: under 1
 second for Hugo itself, plus a few seconds for Tailwind CSS processing.
 
 ---

--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,6 +34,14 @@ Each entry records one deviation or decision:
 
 ## Entries
 
+### 2026-06-21 — `docs/prd/00-overview.md`, `docs/prd/06-content-migration.md`, `docs/prd/07-deployment.md`, `docs/prd/README.md`, `docs/prd/ROADMAP.md`, `CLAUDE.md`, `README.md`
+
+**What changed:** Corrected the article count from 219 → 223 and the date range from 2008–2025 → 2008–2026 across all PRD and project docs (issue #125, Phase 15 pre-flight). Also recorded that the lone file in the Nuxt repo's `content/drafts/` is the `COPY-ME-YYYY-MM-DD-catchy-article-title.md` authoring scaffold (Lorem ipsum, not real content) and is therefore excluded from the migration.
+
+**Why:** Four new posts landed on the live Nuxt site after the PRD's counts were written (the latest is dated 2026-05-27). A `git pull` of the source repo (`../ofreport.com-nuxt2/`) confirmed **223** published articles in `content/articles/` — nothing newer than the local clone — spanning **October 2008 to May 2026**. The "5 static pages" and "26 source tags" figures were re-verified and remain accurate (the 26 tags include both `good and evil` and `good-and-evil`, which the migration consolidates, yielding 25). Migration scope is now locked at 223 articles.
+
+**Category:** Correction
+
 ### 2026-06-13 — `layouts/partials/page-shell-open.html`, `layouts/partials/page-shell-close.html`, `layouts/_default/{single,contact,subscribe,archives}.html`
 
 **What changed:** Extracted the shared static-page "shell" (the faded `bgImage` background wrapper + centered page `<h1>`) into a `page-shell-open.html` / `page-shell-close.html` partial pair that `single`, `contact`, `subscribe`, and `archives` now consume (issue #92). In doing so, the shared `<h1>` standardized on the `text-center`-first class order used by 3 of the 4 layouts, which reorders the class attribute on pages rendered through `single.html` (`ministry`, `donate`, `thank-you`, `podcast`).

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -22,7 +22,7 @@ The [Hugo Migration Brief](../hugo-migration-brief.md) documents the existing Nu
 | `03-site-structure.md` | Content organization, URL structure, Hugo configuration | Adding content types, touching `hugo.toml`, or changing URLs |
 | `04-templates.md` | Layout and template specifications | Building or editing a layout, partial, or list/single template |
 | `05-shortcodes.md` | Hugo shortcode specifications | Implementing or changing a shortcode (figure, callout, button, svg) |
-| `06-content-migration.md` | Migration script, legacy articles, validation checklist | Migrating the 219 Nuxt articles or debugging converted content |
+| `06-content-migration.md` | Migration script, legacy articles, validation checklist | Migrating the 223 Nuxt articles or debugging converted content |
 | `07-deployment.md` | Source control, Netlify config, deployment | Configuring Netlify, redirects, headers, or the production deploy |
 | `08-risks-and-future.md` | New features, risks, out-of-scope items | Scoping a future enhancement or weighing a known risk |
 | `appendix.md` | Reference links and existing data files | Looking up a source reference or data file detail |

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -170,7 +170,7 @@ links to the relevant PRD document for full requirements.
 ## Phase 15: Content Migration
 
 - [ ] Ruby migration script written (see [`06-content-migration.md`](./06-content-migration.md))
-- [ ] All 219 articles converted
+- [ ] All 223 articles converted
 - [ ] Frontmatter transformed (preview → description, slug added, etc.)
 - [ ] Vue components converted to Hugo shortcodes
 - [ ] Duplicate tag consolidated (`good-and-evil`)


### PR DESCRIPTION
## Summary

- **Phase 15 pre-flight:** re-synced the migration source and locked the true article count *before* any migration code is written.
- A `git pull` of the Nuxt repo confirmed **223** published articles spanning **Oct 2008 – May 2026** (four new posts since the PRD counts were written; latest 2026-05-27). The lone `content/drafts/` file is the COPY-ME authoring scaffold and is excluded from migration.

## Changes

- Corrected the article count **219 → 223** across the PRD (`00-overview`, `06-content-migration` ×2, `07-deployment`, `README`, `ROADMAP`), root `CLAUDE.md` (×2), and root `README.md` — 10 occurrences total.
- Corrected the date range **2008–2025 → 2008–2026** (3 occurrences).
- Logged the correction in `docs/prd/CHANGELOG.md` (Category: Correction), recording the skipped draft scaffold.
- Re-verified "5 static pages" and "26 source tags" as still accurate — left unchanged.

## Testing

- [x] `npm run lint` clean (0 errors)
- [x] `grep` confirms zero `219` references remain; 10 `223` present; date ranges fixed
- [x] Docs-only — no code or build impact

## Notes

- The pull returned **"Already up to date"** — the local clone was current; no posts newer than the four already present (only new dependabot branches were fetched).
- **Draft decision:** skip `COPY-ME-YYYY-MM-DD-catchy-article-title.md` (Lorem ipsum scaffold, not content); the Hugo archetype replaces it.
- **Side-finding for the migration issues (#126/#128):** the article *frontmatter* tags are clean (26 distinct), but tag extraction must be **frontmatter-only** — a naive parser bleeds into the body and sweeps up the newsletters' "Pray for…" bullet lists. `good and evil` + `good-and-evil` both appear → consolidation yields 25 tags.

Closes #125
