### PR TITLE
fix(figure): match original caption styling, markdown, and spacing

### DIFF
--- a/content/blog/2024-09-24-of-books-baptisms-and-blessings.md
+++ b/content/blog/2024-09-24-of-books-baptisms-and-blessings.md
@@ -150,13 +150,13 @@ Keep scrolling for more photos and video! First up, the baptism...
   <source src="https://d21yo20tm8bmc2.cloudfront.net/2024/hosanna-baptism.mov" type="video/mp4">
   Your browser does not support the video tag.
 </video>
-<figcaption class="mx-auto mt-2 font-serif font-semibold text-center">Hosanna's baptism - September 7, 2024</figcaption>
+<figcaption class="mx-auto mt-2 text-base font-serif font-semibold text-center">Hosanna's baptism - September 7, 2024</figcaption>
 
 <video class="baptism-video mx-auto" controls>
   <source src="https://d21yo20tm8bmc2.cloudfront.net/2024/kathryn-baptism.mov" type="video/mp4">
   Your browser does not support the video tag.
 </video>
-<figcaption class="mx-auto mt-2 font-serif font-semibold text-center">Kathryn's baptism - September 7, 2024</figcaption>
+<figcaption class="mx-auto mt-2 text-base font-serif font-semibold text-center">Kathryn's baptism - September 7, 2024</figcaption>
 
 {{< figure src="OFReport/2024-09-24-of-books-baptisms-and-blessings/baptism-hosanna-testimony_mngjvf" caption="Hosanna shares a brief testimony of how she came to faith in Christ." >}}
 

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -34,6 +34,6 @@
   </a>
   {{- with $caption }}
   {{- /* markdownify renders inline markdown and (via unsafe=true) inline HTML like <br>; single-line captions stay unwrapped (no <p>). */ -}}
-  <figcaption class="mx-auto mt-2 font-serif font-semibold text-center">{{ . | markdownify }}</figcaption>
+  <figcaption class="mx-auto mt-2 text-base font-serif font-semibold text-center">{{ . | markdownify }}</figcaption>
   {{- end }}
 </figure>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -22,15 +22,18 @@
   {{- errorf "figure shortcode: 'src' param is required (%s)" .Position -}}
 {{- end -}}
 {{- $caption := .Get "caption" -}}
-{{- $alt := or (.Get "alt") $caption -}}
+{{- /* Plain-text caption for attributes (alt, GLightbox description): strip markdown/HTML. */ -}}
+{{- $captionPlain := chomp (plainify (markdownify $caption)) -}}
+{{- $alt := or (.Get "alt") $captionPlain -}}
 {{- /* src may be a full Cloudinary URL or a bare public ID; cloudinary-url.html handles both. */ -}}
 {{- $display := partial "cloudinary-url.html" (dict "src" $src "preset" "figure") -}}
 {{- $lightbox := partial "cloudinary-url.html" (dict "src" $src "preset" "lightbox") -}}
-<figure class="not-prose my-8">
-  <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $caption }} data-description="{{ . }}"{{ end }}>
+<figure class="not-prose my-10 md:my-16">
+  <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $captionPlain }} data-description="{{ . }}"{{ end }}>
     <img src="{{ $display }}" alt="{{ $alt }}" loading="lazy" class="w-full rounded-xl bg-gray-50">
   </a>
   {{- with $caption }}
-  <figcaption class="mt-3 text-center text-sm/6 text-gray-500">{{ . }}</figcaption>
+  {{- /* markdownify renders inline markdown and (via unsafe=true) inline HTML like <br>; single-line captions stay unwrapped (no <p>). */ -}}
+  <figcaption class="mx-auto mt-2 font-serif font-semibold text-center">{{ . | markdownify }}</figcaption>
   {{- end }}
 </figure>


### PR DESCRIPTION
## Summary

- Restores design parity for the `figure` shortcode's captions and spacing, fixing three Phase 15 regressions from the original Nuxt site.
- Captions now render dark, bold, body-size, and centered — and process inline markdown and HTML — matching `../ofreport.com-nuxt2/components/ArticleImage.vue`.

## Changes

- **Caption styling:** `mt-3 text-center text-sm/6 text-gray-500` → `mx-auto mt-2 text-base font-serif font-semibold text-center`, identical to the hand-authored video figcaptions in the books/baptisms article.
- **Caption size:** pinned to `text-base` (16px). Captions are `not-prose` but still *inherit* the article's `sm:prose-lg` 18px, so they were rendering body-size; the original site's captions are 16px against 18px body. The two hand-authored video figcaptions in the books/baptisms article get the same `text-base` so they stay in sync.
- **Inter-image spacing:** figure wrapper `my-8` → `my-10 md:my-16`.
- **Markdown + inline HTML in captions:** caption content now rendered with `markdownify`, so `_italic_`/`**bold**` render and `<br>` produces a line break (inline HTML works via `markup.goldmark.renderer.unsafe = true`). Single-line captions stay unwrapped (no `<p>`).
- **Clean attributes:** `alt` and the GLightbox `data-description` derive a plain-text caption (`markdownify | plainify`) so they contain no markdown markers or tags.

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages, no errors)
- [x] Spot-checked `2024-09-24-of-books-baptisms-and-blessings`: shortcode figcaptions now match the article's hand-authored video figcaptions exactly (style + 16px size)
- [x] `_Good and Evil_` → `<em>Good and Evil</em>` in the visible caption; `alt`/`data-description` render clean plain text (`Good and Evil`)
- [x] Throwaway test confirmed `<br>` → line break, `_x_` → `<em>`, `**x**` → `<strong>` (test file removed)

## Notes

- Coordinates with the separate figure-orientation-sizing issue, which also edits `figure.html`. This change is the smaller, lower-risk one and is intended to land first.
- A separate lightbox bug (inline figure images open as a blank box) was found during review and filed as #145 — out of scope for this PR.

Closes #140
