### PR TITLE
fix(lightbox): force GLightbox image type for extension-less Cloudinary URLs

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -12,9 +12,12 @@
       {{- $hero := partial "cloudinary-url.html" (dict "src" . "preset" "hero") }}
       {{- $lightbox := partial "cloudinary-url.html" (dict "src" . "preset" "lightbox") }}
       <div style="background: linear-gradient(to bottom, #1f415c 0%, #0f2847 100%)">
+        {{- /* data-type="image": cover URLs may lack a file extension (Cloudinary f_auto),
+               which GLightbox would otherwise treat as external and show as a blank box. */}}
         <a
           href="{{ $lightbox }}"
           class="glightbox block"
+          data-type="image"
           data-gallery="article"
           {{- with $.Params.caption }} data-description="{{ . }}"{{ end }}
         >

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -29,7 +29,8 @@
 {{- $display := partial "cloudinary-url.html" (dict "src" $src "preset" "figure") -}}
 {{- $lightbox := partial "cloudinary-url.html" (dict "src" $src "preset" "lightbox") -}}
 <figure class="not-prose my-10 md:my-16">
-  <a href="{{ $lightbox }}" class="glightbox" data-gallery="article"{{ with $captionPlain }} data-description="{{ . }}"{{ end }}>
+  {{- /* data-type="image" is required: Cloudinary f_auto URLs have no file extension, so GLightbox's auto-detection would treat them as external (iframe) and show a blank box. */ -}}
+  <a href="{{ $lightbox }}" class="glightbox" data-type="image" data-gallery="article"{{ with $captionPlain }} data-description="{{ . }}"{{ end }}>
     <img src="{{ $display }}" alt="{{ $alt }}" loading="lazy" class="w-full rounded-xl bg-gray-50">
   </a>
   {{- with $caption }}


### PR DESCRIPTION
## Summary

- Fixes the GLightbox lightbox showing a blank white box (with only the caption) when an inline article image is clicked.
- Root cause: GLightbox infers a slide's type from the URL's file extension and treats unrecognized URLs as `external` (an iframe). Our Cloudinary URLs use `f_auto` and carry **no extension**, so figure images were classified as external and never rendered.

## Changes

- `layouts/shortcodes/figure.html` — add `data-type="image"` to the lightbox anchor.
- `layouts/blog/single.html` — add `data-type="image"` to the cover-image anchor too, so it's robust to extension-less cover URLs (the cover only worked before because its migrated URL happened to end in `.jpg`).

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages); all 35 lightbox anchors on the books/baptisms article now carry `data-type=image`.
- [x] Verified in a real browser (`hugo server`, `2024-09-24-of-books-baptisms-and-blessings`): clicking an inline figure now opens the full image — `<img>` of type `image` (not an iframe), `naturalWidth` 1600, `complete: true` — with the caption beneath. No console errors.

## Notes

- GLightbox's documented remedy for extension-less image URLs is exactly an explicit `data-type="image"` on the anchor (confirmed against the GLightbox docs).
- Per-element fix; no GLightbox config change needed.

Closes #145
