### PR TITLE
fix(blog): keep page-1 grid even, no dangling card

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -14,27 +14,26 @@
   <div class="mx-auto max-w-3xl px-4 pb-16">
     <h1 class="sr-only">{{ .Title }}</h1>
 
-    {{- $paginator := .Paginate .Pages -}}
+    {{/* Paginate the articles *after* the newest one, then prepend that newest
+         article as the featured card on page 1. Paginating the remainder (rather
+         than all pages and carving the featured out of page 1's slice) keeps the
+         page-1 grid even — featured + a full pagerSize grid, no dangling card —
+         and gives a page count of ceil((N-1)/pagerSize), which matches the
+         original Nuxt blogPageCount and so avoids a trailing orphan page. */}}
+    {{- $rest := after 1 .Pages -}}
+    {{- $paginator := .Paginate $rest -}}
     {{- $isFirstPage := not $paginator.HasPrev -}}
 
-    {{- if and $isFirstPage $paginator.Pages }}
+    {{- if and $isFirstPage .Pages }}
       {{/* Featured first article (page 1 only), full width */}}
       <div class="mt-6 md:mt-10">
-        {{ partial "article-card.html" (dict "page" (index $paginator.Pages 0) "featured" true) }}
+        {{ partial "article-card.html" (dict "page" (index .Pages 0) "featured" true) }}
       </div>
+    {{- end }}
 
-      {{- $rest := after 1 $paginator.Pages -}}
-      {{- if $rest }}
-        <div class="mt-6 grid grid-cols-1 gap-x-8 gap-y-6 md:mt-10 md:grid-cols-2 md:gap-y-10">
-          {{- range $rest }}
-            {{ partial "article-card.html" (dict "page" . "featured" false) }}
-          {{- end }}
-        </div>
-      {{- end }}
-    {{- else }}
-      {{/* Pages 2+ — all articles in the grid, no featured */}}
+    {{- with $paginator.Pages }}
       <div class="mt-6 grid grid-cols-1 gap-x-8 gap-y-6 md:mt-10 md:grid-cols-2 md:gap-y-10">
-        {{- range $paginator.Pages }}
+        {{- range . }}
           {{ partial "article-card.html" (dict "page" . "featured" false) }}
         {{- end }}
       </div>


### PR DESCRIPTION
## Summary

- Fixes the dangling/odd card on `/blog/` page 1: the listing paginated all 223 articles with `.Paginate .Pages`, then carved the featured card out of page 1's slice, leaving **7** cards in the grid (odd) — and a page count of `ceil(N/8)` that could trail an orphan page when `N % 8 == 1`.
- Paginates the remainder instead (`after 1 .Pages` → `.Paginate`) and prepends the newest article as the featured card on page 1 only. This yields featured + a full 8-card grid on page 1 (even), 8 on later pages, and a page count of `ceil((N-1)/8)` — provably equal to the original Nuxt `blogPageCount`, so the orphan-page correction comes for free.

## Changes

- `layouts/blog/list.html`:
  - `fix(blog): keep page-1 grid even, no dangling card`
  - Paginate `after 1 .Pages` rather than the full collection; render the newest article (`index .Pages 0`) as the page-1 featured card.
  - Collapsed the page 1 / page 2+ branches into a single shared grid (`with $paginator.Pages`), since both now render identically.

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages, 89 paginator pages)
- [x] Page 1 = **9 cards** (1 featured + 8 grid, even); pages 2 & 27 = **8 cards** each; page 28 (last) = 6
- [x] **223 cards = 223 unique = 223 articles** across all pages — no duplicates, no gaps; featured article appears exactly once
- [x] Page count = **28** = `ceil(222/8)`, no empty/orphan final page
- [x] Prev/Next + URLs correct at boundaries — p1: Next→`/blog/page/2/`, no Prev; p2: Prev→`/blog/`, Next→`/blog/page/3/`; p28: Prev→`/blog/page/27/`, no Next

## Notes

- Pure template change; no content edits and no config change (`pagerSize = 8` unchanged).
- Mirrors the original Nuxt behavior from `ArticlesList.vue` (featured + full 8-card grid on page 1) and `Paginator.vue` (`blogPageCount` drops the orphan page).

Closes #139
