### PR TITLE
fix: external links open in a new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,20 @@
+{{- /*
+  render-link — Hugo link render hook for markdown links.
+
+  Restores the original site's behavior: external links open in a new tab. An
+  external link is any link whose host is present and differs from the site's
+  own host. This (not a bare `hasPrefix "http"`) keeps absolute same-domain
+  links like https://ofreport.com/podcast/ internal, and leaves mailto:, tel:,
+  anchor, and relative links untouched (they have no host).
+
+  Raw-HTML <a> tags in legacy articles are not markdown, so this hook never
+  touches them — several already carry their own target="_blank".
+*/ -}}
+{{- $siteHost := (urls.Parse site.BaseURL).Host -}}
+{{- $u := urls.Parse .Destination -}}
+{{- $external := and (ne $u.Host "") (ne $u.Host $siteHost) -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $external }} target="_blank" rel="noopener noreferrer"{{ end -}}
+>{{ .Text }}{{ if $external }}<span class="sr-only"> (opens in a new tab)</span>{{ end }}</a>
+{{- /* chomp trailing newline */ -}}


### PR DESCRIPTION
## Summary

Adds a Hugo link render hook so external links open in a new tab, restoring the original site's behavior (Phase 15 design-parity). The Hugo site previously had no link render hook, so external markdown links opened in the same tab.

`layouts/_default/_markup/render-link.html` classifies a markdown link as external when its parsed **host** is present and differs from the site host. External links get `target="_blank" rel="noopener noreferrer"` plus an `sr-only` "(opens in a new tab)" affordance — matching the existing `button.html` shortcode pattern.

## Why host comparison instead of `hasPrefix "http"`

The issue suggested `hasPrefix "http"` as a fallback, but several articles link to our own domain with absolute URLs (e.g. `https://ofreport.com/podcast/`). Host comparison keeps those internal (same tab), and naturally leaves `mailto:`, `tel:`, anchors, and relative links untouched since they have no host.

(Those absolute same-domain links are a pre-existing content smell this hook surfaces — tracked separately in #148.)

## Verification

Built with `hugo --gc --minify` (clean, 289 pages) and inspected the output HTML:

| Case | Result |
|------|--------|
| External markdown link (`podcasts.apple.com`) | gets `target="_blank" rel="noopener noreferrer"` + sr-only note ✓ |
| Own-domain absolute (`https://ofreport.com/...`) | no attributes — treated internal ✓ |
| Internal relative (`/contact/`, `/family/`) | untouched ✓ |
| Legacy raw-HTML `<a target="_blank">` | unchanged, not double-processed ✓ |

69 output files now carry the affordance.

### Note on the spot-check article

The issue named `2013-06-15-pillars-genesis-part-4-abraham.md` for the spot-check, but that article's getbiblefirst.com link is **raw HTML**, not markdown — render hooks only apply to markdown links, so it's intentionally untouched (and was already correct with its own `target="_blank"`). Verified against a genuine markdown external link instead.

## Test plan

- [x] `hugo --gc --minify` builds clean
- [x] External markdown links open in a new tab with `rel="noopener noreferrer"`
- [x] Internal/relative and own-domain links unaffected
- [x] `sr-only` "(opens in a new tab)" affordance present for screen-reader users

Closes #142
