### PR TITLE
fix(links): use relative paths for same-domain links, repoint dead newsletter link

### DIFF
--- a/content/blog/2009-03-02-our-love-story.md
+++ b/content/blog/2009-03-02-our-love-story.md
@@ -9,7 +9,7 @@ tags:
 slug: 2009-03-02-our-love-story
 ---
 
-Joshua and I have often expressed how much we wished we had written our love story in a more detailed manner. Outside of a short <a href="http://www.ofreport.com/wp-content/plugins/download-monitor/download.php?id=5">newsletter version</a> for our missionary report, we have never recorded all that God did in bringing us together. Every time we retell the story of how we met, we stand in awe of the great God that we serve, and His love and care for His children. Recently, as we were discussing this, it occurred to us that our blog would provide us with the perfect opportunity to write our story in short snippets, without having to leave out any juicy details.  =) We are quite excited about publishing a series of posts over the coming weeks that document the story of how we began our lives together.
+Joshua and I have often expressed how much we wished we had written our love story in a more detailed manner. Outside of a short [newsletter version](https://d21yo20tm8bmc2.cloudfront.net/ofr/steele_ofr_engagement_2004.pdf) for our missionary report, we have never recorded all that God did in bringing us together. Every time we retell the story of how we met, we stand in awe of the great God that we serve, and His love and care for His children. Recently, as we were discussing this, it occurred to us that our blog would provide us with the perfect opportunity to write our story in short snippets, without having to leave out any juicy details.  =) We are quite excited about publishing a series of posts over the coming weeks that document the story of how we began our lives together.
 
 ---
 

--- a/content/blog/2022-02-13-are-we-safe.md
+++ b/content/blog/2022-02-13-are-we-safe.md
@@ -43,7 +43,7 @@ work.
 ### Reference
 
 - [Message to US Citizens: Ukraine Land Border (ua.usembassy.gov)](https://ua.usembassy.gov/message-to-us-citizens-ukraine-land-border/)
-- [Home Sweet Ukraine (OFReport.com)](https://ofreport.com/blog/2022-01-24-home-sweet-ukraine/)
+- [Home Sweet Ukraine (OFReport.com)](/blog/2022-01-24-home-sweet-ukraine/)
 - [Russia’s Possible Invasion of Ukraine (csis.org)](https://www.csis.org/analysis/russias-possible-invasion-ukraine)
 - [Malaysia Airlines Flight 17 (wikipedia.org)](https://en.wikipedia.org/wiki/Malaysia_Airlines_Flight_17)
 - [NATO Member Countries (worldpopulationreview.com)](https://worldpopulationreview.com/country-rankings/nato-countries)

--- a/content/blog/2022-06-11-yellow-blue-bus.md
+++ b/content/blog/2022-06-11-yellow-blue-bus.md
@@ -132,7 +132,7 @@ Report_, has been our primary communication medium for ministry and family
 updates for over 20 years. However, during the chaos of evacuation, we found it
 simpler/faster to record brief audio updates to let people know how we were.
 These updates were well-received, and we soon turned them into a podcast which
-we call [_Journey to Ukraine_](https://ofreport.com/podcast/). Hence the
+we call [_Journey to Ukraine_](/podcast/). Hence the
 question many have asked: now that we have a podcast, will we continue
 publishing our newsletter? Simple answer: **yes, we absolutely will!**
 

--- a/content/blog/2023-10-19-loving-ukraine.md
+++ b/content/blog/2023-10-19-loving-ukraine.md
@@ -29,11 +29,11 @@ Ukrainians in Eastern Europe.
 
 ## Links from the Episode
 
-- News and updates going forward: [OFReport.com](https://ofreport.com/)
+- News and updates going forward: [OFReport.com](/)
 - Subscribe to our blog:
-  [OFReport.com/subscribe](https://ofreport.com/subscribe/)
+  [OFReport.com/subscribe](/subscribe/)
 - Listen to all our podcast episodes:
-  [OFReport.com/podcast](https://ofreport.com/podcast/)
+  [OFReport.com/podcast](/podcast/)
 - CMO 2023 updates:
   [euroteamoutreach.org/blog](https://euroteamoutreach.org/blog/)
 - CMO photo albums:


### PR DESCRIPTION
## Summary

- Convert six hardcoded same-domain links (`https://ofreport.com/...`) across four articles to root-relative paths, matching the rest of the content.
- These were a leftover from the WordPress → Middleman → Nuxt → Hugo lineage. The link render hook from #142 classifies links by host, so these same-domain links were incorrectly opening in a new tab and announcing "(opens in a new tab)" to screen-reader users.
- Also repoint one dead WordPress newsletter link to its original PDF, still hosted on CloudFront.

## Changes

**Category A — `2023-10-19-loving-ukraine.md`** (visible "find us" text kept; only hrefs changed):
- `https://ofreport.com/` → `/`
- `https://ofreport.com/subscribe/` → `/subscribe/`
- `https://ofreport.com/podcast/` → `/podcast/`

**Category B — ordinary inline links:**
- `2022-06-11-yellow-blue-bus.md`: `https://ofreport.com/podcast/` → `/podcast/`
- `2022-02-13-are-we-safe.md`: `https://ofreport.com/blog/2022-01-24-home-sweet-ukraine/` → `/blog/2022-01-24-home-sweet-ukraine/`

**Category C — `2009-03-02-our-love-story.md`:**
- The "newsletter version" link pointed at a WordPress download-monitor path (`download.php?id=5`) from two CMSes ago, which 404s. Repointed to the original newsletter PDF on CloudFront (`steele_ofr_engagement_2004.pdf`) and converted the legacy raw `<a>` tag to a markdown link so the render hook gives this external PDF the standard new-tab treatment.

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages)
- [x] Built HTML: none of the 5 relative anchors render with `target="_blank"`, `rel="noopener noreferrer"`, or the sr-only "(opens in a new tab)" affordance
- [x] Built HTML: the Category C external PDF correctly opens in a new tab
- [x] Regression: a genuinely-external link in the same file (euroteamoutreach.org) still opens in a new tab — render hook behavior unchanged
- [x] Visible link text preserved across all four articles

## Notes

- Plain root-relative paths chosen over Hugo's `relref` shortcode to match existing content conventions (lower ceremony).
- The ROADMAP item "Legacy WordPress articles reviewed and fixed" (Phase 15) is an umbrella for a broader sweep; this PR is one slice and does not complete it, so it remains unchecked.

Closes #148
