### PR TITLE
fix(figure): size article images by long side for orientation parity

### DIFF
--- a/layouts/partials/cloudinary-url.html
+++ b/layouts/partials/cloudinary-url.html
@@ -27,7 +27,7 @@
   {{- $presets := dict
     "featured" "c_scale,f_auto,q_auto,w_740"
     "regular"  "c_scale,f_auto,q_auto,w_610"
-    "figure"   "c_scale,f_auto,q_auto,w_768"
+    "figure"   "c_limit,f_auto,q_auto,w_1344,h_1344"
     "article"  "c_scale,f_auto,q_auto:best"
     "hero"     "c_scale,f_auto,q_auto:best,w_2000"
     "cover"    "c_scale,f_auto,q_auto:best,w_200"

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,9 +1,12 @@
 {{- /*
   figure — inline Cloudinary image, clickable to a larger lightbox view.
 
-  Inline <img> is served at ~768px (the article body width) so pages stay light;
-  the wrapping <a> points at a larger version for the lightbox zoom. GLightbox
-  itself is wired up in Phase 13 — this only emits the compatible markup
+  The inline <img> is delivered inside a 1344x1344 box (c_limit, ~2x the 672px
+  content column for retina crispness) and constrained in CSS to a 672x672 box,
+  so the LONG SIDE is a consistent ~672px regardless of orientation — landscapes
+  fill the column, portraits render narrower and centered (see #141). The
+  wrapping <a> points at a larger version for the lightbox zoom. GLightbox itself
+  is wired up in Phase 13 — this only emits the compatible markup
   (class="glightbox", data-gallery, data-description), which is forward-compatible.
 
   not-prose keeps the typography plugin from styling the figure/img/figcaption,
@@ -31,10 +34,14 @@
 <figure class="not-prose my-10 md:my-16">
   {{- /* data-type="image" is required: Cloudinary f_auto URLs have no file extension, so GLightbox's auto-detection would treat them as external (iframe) and show a blank box. */ -}}
   <a href="{{ $lightbox }}" class="glightbox" data-type="image" data-gallery="article"{{ with $captionPlain }} data-description="{{ . }}"{{ end }}>
-    <img src="{{ $display }}" alt="{{ $alt }}" loading="lazy" class="w-full rounded-xl bg-gray-50">
+    <img src="{{ $display }}" alt="{{ $alt }}" loading="lazy" class="mx-auto h-auto max-h-[42rem] max-w-full rounded-xl bg-gray-50">
   </a>
   {{- with $caption }}
   {{- /* markdownify renders inline markdown and (via unsafe=true) inline HTML like <br>; single-line captions stay unwrapped (no <p>). */ -}}
-  <figcaption class="mx-auto mt-2 text-base font-serif font-semibold text-center">{{ . | markdownify }}</figcaption>
+  {{- /* max-w-xl (576px) keeps the centered caption to a tidy measure narrower
+         than a full-width landscape; ports the original's portrait-caption rule
+         (it was 576px too), applied universally since orientation is unknown at
+         build time. */ -}}
+  <figcaption class="mx-auto mt-2 max-w-xl text-base font-serif font-semibold text-center">{{ . | markdownify }}</figcaption>
   {{- end }}
 </figure>


### PR DESCRIPTION
## Summary

- Sizes article (`figure`) images by their **long side** so portrait and landscape photos display at a consistent size, restoring the original Nuxt site's behavior (which sized the long side via `width`/`height` on `<article-image>`).
- Previously the `figure` shortcode scaled every image to the column width (`c_scale,w_768` + `w-full`), so portraits towered over landscapes.

## Changes

- **`layouts/partials/cloudinary-url.html`** — `figure` preset `c_scale,f_auto,q_auto,w_768` → `c_limit,f_auto,q_auto,w_1344,h_1344`. `c_limit` fits the image inside a 1344×1344 box (downscale-only — won't upscale tiny legacy images), so the long side is ≤1344px for any orientation (~2× the 672px column for retina crispness).
- **`layouts/shortcodes/figure.html`**
  - `<img>`: dropped `w-full` for `mx-auto h-auto max-h-[42rem] max-w-full`, constraining the displayed image into a 672×672 box (long side ~672px) and centering it. Landscapes fill the column; portraits render narrower and centered.
  - `<figcaption>`: added `max-w-xl` (576px), porting the original's `.portrait-caption` width universally (orientation is unknown at build time).
  - Updated the header comment to describe the new sizing model.

The lightbox preset (`w_1600`) and GLightbox markup are unchanged, so zoom still works.

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages). Tailwind emits `max-h-[42rem]{max-height:42rem}` and `.max-w-xl`.
- [x] Live browser QA on a 34-figure article (`of-books-baptisms-and-blessings`), 12 loaded images (9 landscape + 3 portrait):
  - Content column = 672px (unchanged)
  - Landscape `1344×1009` → renders **672×505** (fills column)
  - Portrait `1008×1344` → renders **504×672** (centered, 84px gaps each side)
  - Every image: long side = 672px, centered; 0 over 674px, 0 off-center
  - GLightbox zoom href still points at the `w_1600` URL

## Notes

- The "small legacy images won't upscale" case (`c_limit` floor) is intentional and handled by the separate broken-legacy-images issue, per this issue's dependency note.

Closes #141
