### PR TITLE
chore: strip legacy kramdown IALs and restore article captions

### DIFF
--- a/content/blog/2008-10-11-whatever-happened-to-september.md
+++ b/content/blog/2008-10-11-whatever-happened-to-september.md
@@ -11,70 +11,44 @@ slug: 2008-10-11-whatever-happened-to-september
 
 The start of September brought the end of our CMO project. We said goodbye to the team of 6 awesome guys who served with us this summer.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_026.jpg" caption="{: .article-image .article-image--has-caption}" alt="Can't you tell we had a lot of fun this year?" >}}
-Can't you tell we had a lot of fun this year?
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_026.jpg" caption="Can't you tell we had a lot of fun this year?" >}}
 
 With the end of the project, the Steeles have been enjoying a few quieter days.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_dsc_3365.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby and Rebekah lounging in their pajamas." >}}
-Abby and Rebekah lounging in their pajamas.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_dsc_3365.jpg" caption="Abby and Rebekah lounging in their pajamas." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_dsc_3377-1.jpg" caption="{: .article-image .article-image--has-caption}" alt="We love having Daddy home more often!" >}}
-We love having Daddy home more often!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_dsc_3377-1.jpg" caption="We love having Daddy home more often!" >}}
 
 ### 4th Anniversary!!
 
 Joshua and I took a 6 day get away trip to Krakow, Poland, over our anniversary!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_012.jpg" caption="{: .article-image .article-image--has-caption}" alt="On the train together" >}}
-On the train together
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_012.jpg" caption="On the train together" >}}
 
 We camped out at a rock climbing site for the first three days of the trip. The rain ruined most of our climbing plans, but Joshua did get one 70-80 foot climb in!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_022.jpg" caption="{: .article-image .article-image--has-caption}" alt="This was one BIG rock!" >}}
-This was one BIG rock!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_022.jpg" caption="This was one BIG rock!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_027.jpg" caption="{: .article-image .article-image--has-caption}" alt="It takes quite a lot of gear to get up that high." >}}
-It takes quite a lot of gear to get up that high.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_027.jpg" caption="It takes quite a lot of gear to get up that high." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_029.jpg" caption="{: .article-image .article-image--has-caption}" alt="Wheres Waldo...uh...I mean, Joshua?" >}}
-Where's Waldo…uh…I mean, Joshua?
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_029.jpg" caption="Where's Waldo…uh…I mean, Joshua?" >}}
 
 If you think I was nervous about this climb…well, you’re right! Joshua admitted it was quite a challenging route.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_049.jpg" caption="{: .article-image .article-image--has-caption}" alt="Kelsie was able to practice and improve at this indoor climbing gym." >}}
-Kelsie was able to practice and improve at this indoor climbing gym.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_049.jpg" caption="Kelsie was able to practice and improve at this indoor climbing gym." >}}
 
 On the night of our anniversary, we ate at a very quaint traditional Polish restaurant. Here we’re trying sausage and quail egg soup in bread bowls.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_055.jpg" caption="{: .article-image .article-image--has-caption}" alt="Best friends and lovers" >}}
-Best friends and lovers
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_055.jpg" caption="Best friends and lovers" >}}
 
 ### Happy 3rd Birthday, Abigail!
 
 We had a blast doing fun things together on Abigail’s birthday. We opened presents all throughout the day, playing with each one. We even saved some until the following morning! It’s hard to believe our little girl is already three.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_1231.jpg" caption="{: .article-image .article-image--has-caption}" alt="Make a wish! (Were still learning to blow out those candles.)" >}}
-Make a wish! (We're still learning to blow out those candles.)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_1231.jpg" caption="Make a wish! (We're still learning to blow out those candles.)" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_0481.jpg" caption="{: .article-image .article-image--has-caption}" alt="New toys are so entertaining!" >}}
-New toys are so entertaining!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_0481.jpg" caption="New toys are so entertaining!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_2141.jpg" caption="{: .article-image .article-image--has-caption}" alt="Posing with Daddy and her new dolly, our big 3-year-old!" >}}
-Posing with Daddy and her new dolly, our big 3-year-old!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_abbys_birthday_2141.jpg" caption="Posing with Daddy and her new dolly, our big 3-year-old!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_062.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abbys not the only one who is getting bigger! Rebekah Praise, 8 months." >}}
-Abby's not the only one who is getting bigger! Rebekah Praise, 8 months.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_062.jpg" caption="Abby's not the only one who is getting bigger! Rebekah Praise, 8 months." >}}

--- a/content/blog/2008-12-08-an-evening-of-christian-fellowship.md
+++ b/content/blog/2008-12-08-an-evening-of-christian-fellowship.md
@@ -13,13 +13,11 @@ slug: 2008-12-08-an-evening-of-christian-fellowship
 
 The postal worker's eyes widened as I handed her my 3 large stacks of business envelopes. "So many lovers to write to, eh?", the gray-headed gentleman next to me teased with a twinkle in his eye. I don't usually enjoy trips to the Ukrainian Post Office, but this one was important. Joshua and I had spent all weekend preparing this mail-out for those of our Bible Correspondence students who live in the L'viv area-- 228 in all. As I sat and licked each individual stamp, (no self-adhesive here!) my thoughts ran in a continuous cycle: Will this person come? Lord, draw their hearts to you. I wonder how many will be there. Will they come? Bring those who are ready to hear, Lord!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_37023.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_37023.jpg" >}}
 
 Not long ago, an acquaintance named Roman approached Joshua and asked the worn out question that missionaries hear quite regularly, "Do you teach English?" Joshua gave him his usual answer, "If you can find a group of ten dedicated people who want to learn, call me and we'll talk about starting an English club." While most who ask never call back, it wasn't long before we heard from Roman again, saying he had found 8 people who would come.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3701.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our friend Roman (left) with his friend, also named Roman." >}}
-Our friend Roman (left) with his friend, also named Roman.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3701.jpg" caption="Our friend Roman (left) with his friend, also named Roman." >}}
 
 About this same time, our missionary team had been making plans to resume the Audio Bible Study that we had carried on over the past fall and winter. Last year, our students could come to hear weekly teaching from the book of John, with each session being recorded on CD for distribution on a wider scale. We did see fruit from this ministry, but only a very limited number of people came to the meetings regularly and it became difficult to continue them.
 
@@ -29,8 +27,6 @@ The invites were taken to the Post Office and sent. We waited and prayed.
 
 Tuesday, December 2nd came. That night we had 8 people join us for the English Club! We discussed topics such as terrorism, why bad things happen, and how much governments should be involved in prevention. This led right into the message Joshua had prepared for that evening: Why does God allow evil in the world? All but one stayed to hear the teaching of the Word! Everyone enjoyed coffee and tea afterward and seemed at ease interacting with us. Many were anxious to practice more English. One man in particular, named Taras, told Joshua that the reason he came was because he was anxious to study the Word of God.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_36981.jpg" caption="{: .article-image .article-image--has-caption}" alt="From left to right: Taras, Bogdan, Anya, Dasha, Kelsie, Marian." >}}
-From left to right: Taras, Bogdan, Anya, Dasha, Kelsie, Marian.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_36981.jpg" caption="From left to right: Taras, Bogdan, Anya, Dasha, Kelsie, Marian." >}}
 
 We are grateful for this beginning, but our prayer is that more people will be reached through this ministry. English is a powerful drawing card that we hope will attract others. Please pray for Roman, Roman, (there are two men by that name) Dasha, Anya, Bogdan, Evelina, Marian, and Taras, that they would continue to come and be changed by the message of Christ.

--- a/content/blog/2008-12-12-missionary-kodak-moments.md
+++ b/content/blog/2008-12-12-missionary-kodak-moments.md
@@ -14,34 +14,20 @@ slug: 2008-12-12-missionary-kodak-moments
 
 Our second evening of English Club and Bible teaching went off very well! 11 people came to participate in the evening's events, most of whom were present for the teaching of the Word!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3732.jpg" caption="{: .article-image .article-image--has-caption}" alt="Anya shows interest in the Gospel of John." >}}
-Anya shows interest in the Gospel of John.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3732.jpg" caption="Anya shows interest in the Gospel of John." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3733.jpg" caption="{: .article-image .article-image--has-caption}" alt="Listeners intent on the preaching" >}}
-Listeners intent on the preaching
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3733.jpg" caption="Listeners intent on the preaching" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3735.jpg" caption="{: .article-image .article-image--has-caption}" alt="Taras has expressed particular interest in studying the Bible." >}}
-Taras has expressed particular interest in studying the Bible.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3735.jpg" caption="Taras has expressed particular interest in studying the Bible." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3730.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua engaged in one of his favorite activities." >}}
-Joshua engaged in one of his favorite activities.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3730.jpg" caption="Joshua engaged in one of his favorite activities." >}}
 
 The microphone you see clipped on Joshua is not for voice projection, it's for recording. Each preaching session is recorded on CD for distribution to other Ukrainians, many of whom we may never meet personally.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3729.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie reads a discussion question during English Club" >}}
-Jessie reads a discussion question during English Club.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3729.jpg" caption="Jessie reads a discussion question during English Club." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3736.jpg" caption="{: .article-image .article-image--has-caption}" alt="Everyone enjoying some fellowship time" >}}
-Everyone enjoying some fellowship time.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3736.jpg" caption="Everyone enjoying some fellowship time." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3744.jpg" caption="{: .article-image .article-image--has-caption}" alt="Tea anyone?" >}}
-Tea anyone?
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3744.jpg" caption="Tea anyone?" >}}
 
 P.S. Wanted: Prayer Warriors! On our way home from this last meeting, Joshua and I were discussing how neat it would be if people in America would stop to pray just as we were beginning each Tuesday night session. We are seeing God's blessing on this ministry and would love to have the prayers of the saints behind it. Our desire is that individuals would completely set aside what they're doing, even for five minutes or so, and pray for the salvation of these souls, every Tuesday at 11:00 am central. (Ukraine is 8 hours ahead, so you would be praying exactly at the time we are starting our evening meeting.) If you would be willing to participate in prayer for us consistently in this way, please [send us an e-mail](/contact/) and let us know. We would be encouraged!

--- a/content/blog/2008-12-19-its-beginning-to-look-a-lot-like-christmas.md
+++ b/content/blog/2008-12-19-its-beginning-to-look-a-lot-like-christmas.md
@@ -12,30 +12,18 @@ slug: 2008-12-19-its-beginning-to-look-a-lot-like-christmas
 
 Our family is getting things ready for the holidays!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_37551.jpg" caption="{: .article-image .article-image--has-caption}" alt="The Christmas tree makes our house so cheery during the dark winter days." >}}
-The Christmas tree makes our house so cheery during the dark winter days.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_37551.jpg" caption="The Christmas tree makes our house so cheery during the dark winter days." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3759.jpg" caption="{: .article-image .article-image--has-caption}" alt="Here is what I did today..." >}}
-Here is what I did today...
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3759.jpg" caption="Here is what I did today..." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3766.jpg" caption="{: .article-image .article-image--has-caption}" alt="These will be decorated tomorrow at a small Christmas party Joshua and I are hosting." >}}
-These will be decorated tomorrow at a small Christmas party Joshua and I are hosting.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3766.jpg" caption="These will be decorated tomorrow at a small Christmas party Joshua and I are hosting." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3774.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby thought these were pretty fun." >}}
-Abby thought these were pretty fun.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3774.jpg" caption="Abby thought these were pretty fun." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3781.jpg" caption="{: .article-image .article-image--has-caption}" alt="Taking your own picture with a Nikon D40 is not that easy. (The girls were sleeping; otherwise, they would've made better photo material. =) )" >}}
-Taking your own picture with a Nikon D40 is not that easy. (The girls were sleeping; otherwise, they would've made better photo material. =) )
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3781.jpg" caption="Taking your own picture with a Nikon D40 is not that easy. (The girls were sleeping; otherwise, they would've made better photo material. =) )" >}}
 
 ### Ministry Update
 
 Our good friend and missionary here in Ukraine, Denise Hutchison, helps us tremendously by keeping up our Correspondence Bible Course of over 300 students. She and Nathan Day are responsible for grading lessons, sending out letters to students, addressing envelopes, and much more that goes into maintaining this course. Denise is going to be leaving for the U.S. this weekend, and Nathan is also in the U.S. visiting family. This means that the whole responsibility of the course will be on our shoulders and the Beal's over the next month or so! Our ministry obligations are already mushrooming, so we would appreciate your prayers for us as we take on this additional job.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3788.jpg" caption="{: .article-image .article-image--has-caption}" alt="These lessons just arrived from the printers today." >}}
-These lessons just arrived from the printer today.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3788.jpg" caption="These lessons just arrived from the printer today." >}}

--- a/content/blog/2008-12-27-merry-christmas.md
+++ b/content/blog/2008-12-27-merry-christmas.md
@@ -11,36 +11,20 @@ slug: 2008-12-27-merry-christmas
 
 Thank you to our parents, siblings, and friends, who sent boxes over or gave us gifts to make the day special! Merry Christmas everybody!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3850.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abigail Hope and Rebekah Praise, Christmas Eve 2008" >}}
-Abigail Hope and Rebekah Praise, Christmas Eve 2008
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3850.jpg" caption="Abigail Hope and Rebekah Praise, Christmas Eve 2008" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_39971.jpg" caption="{: .article-image .article-image--has-caption}" alt="We spent Christmas Eve with our dear friends, the Beals." >}}
-We spent Christmas Eve with our dear friends, the Beals.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_39971.jpg" caption="We spent Christmas Eve with our dear friends, the Beals." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_39671.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abigail delighted with her new gift." >}}
-Abigail delighted with her new gift.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_39671.jpg" caption="Abigail delighted with her new gift." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4005.jpg" caption="{: .article-image .article-image--has-caption}" alt="A Christmas morning smile" >}}
-A Christmas morning smile
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4005.jpg" caption="A Christmas morning smile" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4108.jpg" caption="{: .article-image .article-image--has-caption}" alt="Eating yummy turnovers for breakfast." >}}
-Eating yummy turnovers for breakfast.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4108.jpg" caption="Eating yummy turnovers for breakfast." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4138.jpg" caption="{: .article-image .article-image--has-caption}" alt="There's nothing better than spending Christmas with the one you love." >}}
-There's nothing better than spending Christmas with the one you love.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4138.jpg" caption="There's nothing better than spending Christmas with the one you love." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4200.jpg" caption="{: .article-image .article-image--has-caption}" alt="Rebekah thought opening presents was pretty fun!" >}}
-Rebekah thought opening presents was pretty fun!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4200.jpg" caption="Rebekah thought opening presents was pretty fun!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4055.jpg" caption="{: .article-image .article-image--has-caption}" alt="A happy daddy with his girls." >}}
-A happy daddy with his girls.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_4055.jpg" caption="A happy daddy with his girls." >}}
 
 To view more pictures, visit our <a title="Steele Family Photos" href="http://picasaweb.google.com/joshandkels/" target="_blank">Picasa Web Album</a>.

--- a/content/blog/2009-01-02-good-and-evil-shipment-has-arrived.md
+++ b/content/blog/2009-01-02-good-and-evil-shipment-has-arrived.md
@@ -12,26 +12,14 @@ slug: 2009-01-02-good-and-evil-shipment-has-arrived
 
 We are very pleased to report that the entire shipment of *Good and Evil* books has arrived at last. On Tuesday morning, we unloaded all four pallets of books in L'viv. We have a growing list of people who have received the short version of G&amp;E, and have requested a full copy. We are thrilled that we can finally begin filling these requests. We believe that God will use this book to draw Ukrainians to Christ.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4229.jpg" caption="{: .article-image .article-image--has-caption}" alt="The delivery truck pulls into position near our ministry center in L'viv." >}}
-The delivery truck pulls into position near our ministry center in L'viv.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4229.jpg" caption="The delivery truck pulls into position near our ministry center in L'viv." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4231.jpg" caption="{: .article-image .article-image--has-caption}" alt="5,000 copies means quite a load of boxes!" >}}
-5,000 copies means quite a load of boxes!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4231.jpg" caption="5,000 copies means quite a load of boxes!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4235.jpg" caption="{: .article-image .article-image--has-caption}" alt="Sergiy Chepara, a Ukrainian believer who often assists us in ministry, helped unload the boxes." >}}
-Sergiy Chepara, a Ukrainian believer who often assists us in ministry, helped unload the boxes.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4235.jpg" caption="Sergiy Chepara, a Ukrainian believer who often assists us in ministry, helped unload the boxes." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4241.jpg" caption="{: .article-image .article-image--has-caption}" alt="About 600 books went to our ministry center, while the rest (pictured above) were stored at a building on the outskirts of the city." >}}
-About 600 books went to our ministry center, while the rest (pictured above) were stored at a building on the outskirts of the city.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4241.jpg" caption="About 600 books went to our ministry center, while the rest (pictured above) were stored at a building on the outskirts of the city." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4262.jpg" caption="{: .article-image .article-image--has-caption}" alt="Four pallets of Good and Evil's!" >}}
-Four pallets of Good and Evil's!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4262.jpg" caption="Four pallets of Good and Evil's!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4266.jpg" caption="{: .article-image .article-image--has-caption}" alt="We are very grateful to have these books and we're excited to get them into the hands of Ukrainians." >}}
-We are very grateful to have these books and we're excited to get them into the hands of Ukrainians.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4266.jpg" caption="We are very grateful to have these books and we're excited to get them into the hands of Ukrainians." >}}

--- a/content/blog/2009-01-10-caroling-for-comics.md
+++ b/content/blog/2009-01-10-caroling-for-comics.md
@@ -13,8 +13,6 @@ Here in Ukraine, it is common for children to go door to door and sing Christmas
 
 The next day, guess who was at the door? One of the kids had already read his copy of *Good and Evil* Short and now the others wanted one. We showed them the full version of *Good and Evil*, and explained how they could mail in the form at the back of *Good and Evil* Short to receive a copy on the mail. Then we gave them all their own copies of *Good and Evil* Short and they went happily on their way.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4390.jpg" caption="{: .article-image .article-image--has-caption}" alt="The boys who came to carol at our house show off their new copies of Good and Evil." >}}
-The boys who came to carol at our house show off their new copies of Good and Evil.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4390.jpg" caption="The boys who came to carol at our house show off their new copies of Good and Evil." >}}
 
 We are very excited about the *Good and Evil* project in Ukrainian and are already seeing very positive responses to this powerful book. If you are interested in purchasing copies of *Good and Evil* in Ukrainian for friends, churches, missionaries, etc. please contact us for details. We can ship the books to any address in Ukraine or the US.

--- a/content/blog/2009-01-15-keeping-busy.md
+++ b/content/blog/2009-01-15-keeping-busy.md
@@ -13,9 +13,7 @@ slug: 2009-01-15-keeping-busy
 
 After breaking last week for the Ukrainian Christmas (here in Ukraine they celebrate on the 6th and 7th of January), we prepared for English Club and ABS (Audio Bible Study) this week with anticipation. Over the past few weeks attendance had dropped due to the holidays, and we wondered if people would return. We had seen some good momentum and interest, but would it continue? On Monday we called our contact list, reminding people that we were resuming the meetings after Christmas. Everyone seemed excited to hear from us and promised to come. Sure enough, on Tuesday evening, the majority of our core group arrived with enthusiasm!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/abs-jan13-20093.jpg" caption="{: .article-image .article-image--has-caption}" alt="Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya." >}}
-Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya. (Click the picture to enlarge.)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/abs-jan13-20093.jpg" caption="Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya. (Click the picture to enlarge.)" >}}
 
 Joshua's message that evening came out of John 17, with a special emphasis on verses dealing with eternal life. *"And this is life eternal, that they might know thee the only true God, and Jesus Christ, whom thou hast sent." John 17:3* Anya, a young adult seated next to me, seemed to eat up every word that Joshua spoke and eagerly pursued the verses as we read them.
 

--- a/content/blog/2009-01-20-welcome-bryan-shufelt.md
+++ b/content/blog/2009-01-20-welcome-bryan-shufelt.md
@@ -11,16 +11,12 @@ slug: 2009-01-20-welcome-bryan-shufelt
 
 This week, we are excited to announce the arrival of a new ETO team member: missionary Bryan Shufelt. Bryan served here in Ukraine with us during <a href="http://cmoproject.org/" target="_blank">CMO 2006</a>, and proved himself a capable and faithful minister of the Gospel. Bryan is sent out <a href="http://www.fairparkbaptist.org/" target="_blank">Fairpark Baptist Church</a> in Fort Worth, Texas.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/bryan.jpg" caption="{: .article-image .article-image--has-caption}" alt="Bryan Shufelt" >}}
-Bryan Shufelt
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/bryan.jpg" caption="Bryan Shufelt" >}}
 
 As a new missionary on the field, some of Bryan's initial goals include language and culture studies. He will be starting formal Ukrainian classes right away, studying under the same lady who has taught the rest of our team. Bryan will also be living with a Ukrainian brother from the local church we attend. This man does not speak any English, so Bryan should have plenty of opportunity to practice his language skills!
 
 To stay in touch with Bryan and his work in Ukraine, please visit his blog: shufelt.euroteamoutreach.org. If you like, you can subscribe to his e-mail updates and be kept abreast of his latest news and prayer requests.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cmo2006_004_lg.jpg" caption="{: .article-image .article-image--has-caption}" alt="Bryan preaches on the street in L'viv, 2006." >}}
-Bryan preaches on the street in L'viv, 2006.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cmo2006_004_lg.jpg" caption="Bryan preaches on the street in L'viv, 2006." >}}
 
 Please remember Bryan and his ministry in your prayers. We are very grateful to have a new team member serving with us, and we look forward to the things God will do in the days to come.

--- a/content/blog/2009-01-22-we-have-a-one-year-old.md
+++ b/content/blog/2009-01-22-we-have-a-one-year-old.md
@@ -11,9 +11,7 @@ slug: 2009-01-22-we-have-a-one-year-old
 
 It is hard to believe that our little baby girl is already one year old! Her actual birthday was on Saturday, the 17th, but we were so busy we didn't celebrate until last night. At least when they're this little they don't know the difference!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4483.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our little Rebekah Praise" >}}
-Our little Rebekah Praise
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4483.jpg" caption="Our little Rebekah Praise" >}}
 
 Rebekah has brought us great joy, and captures the heart of almost everyone who meets her. She loves to squeal and play and roll on the floor, especially with her daddy. =) She just started crawling about two to three weeks ago, and is following her big sister Abby everywhere. It makes us so happy to see the way they laugh and play together.
 
@@ -21,22 +19,14 @@ A few weeks ago she mastered the skill of waving, and loves practicing with anyo
 
 We love her dearly and are so grateful to the Lord for sending her to us!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4699.jpg" caption="{: .article-image .article-image--has-caption}" alt="What is this candle business about? Abby is happy to help out! (Yes, we stuck the candle in some ice cream since mom didnt have time to make cake!)" >}}
-What is this candle business about? Abby is happy to help out! (Yes, we stuck the candle in some ice cream since mom didn't have time to make cake!)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4699.jpg" caption="What is this candle business about? Abby is happy to help out! (Yes, we stuck the candle in some ice cream since mom didn't have time to make cake!)" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4708.jpg" caption="{: .article-image .article-image--has-caption}" alt="The wrapping paper is sometimes more fun than the present!" >}}
-The wrapping paper is sometimes more fun than the present!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4708.jpg" caption="The wrapping paper is sometimes more fun than the present!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4722.jpg" caption="{: .article-image .article-image--has-caption}" alt="Oh boy! New bath toys." >}}
-Oh boy! New bath toys.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4722.jpg" caption="Oh boy! New bath toys." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4727.jpg" caption="{: .article-image}" alt="dsc_4727" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4727.jpg" alt="dsc_4727" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4731.jpg" caption="{: .article-image .article-image--has-caption}" alt="Grandmas are so wonderful--they send presents for the older kids too!" >}}
-Grandmas are so wonderful–they send presents for the older kids too!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4731.jpg" caption="Grandmas are so wonderful–they send presents for the older kids too!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4737.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4737.jpg" >}}

--- a/content/blog/2009-01-27-this-week-in-lviv.md
+++ b/content/blog/2009-01-27-this-week-in-lviv.md
@@ -17,9 +17,7 @@ With the arrival of a new team member, preparations for this summer's outreach, 
 
 When Bryan got here on January 16, he hit the ground running. For the time being, he has been living at our ministry center and has busied himself by handling some of the paperwork related to our correspondence course. This includes things like putting together "starter packets" for new students in the course, and packaging up full versions of Good and Evil for mailing. I recently gave Bryan the crash course on how we track our CBC students using a web-based application called CBC Admin. While much of the course management requires a knowledge of Ukrainian (such as answering letters or grading lessons) there are several things that Bryan can assist us with right away. And what a blessing that will be!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4742.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua and Bryan work on grading Bible lessons which we recently received in the mail from some of our students." >}}
-Joshua and Bryan work on grading Bible lessons which we recently received in the mail from some of our students.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4742.jpg" caption="Joshua and Bryan work on grading Bible lessons which we recently received in the mail from some of our students." >}}
 
 Yesterday, Bryan had his first language lesson with Veronica. They will be meeting three times a week from now on. We are excited about the prospect of having another Ukrainian speaker on our team! Please pray for Bryan as he studies the language. We believe that this will be a major asset to him and the rest of our team in the months and years to come.
 
@@ -29,28 +27,18 @@ We would also appreciate your prayers for Bryan regarding a roommate. Originally
 
 ABS day is upon us once again. If you are interested in praying for ABS, it takes place every Tuesday at 11:00am CST. Many of you have written to us pledging your prayer support each week, and we are very grateful for your faithful intercession. We are excited to see how God is already answering those prayers. As I write this post, ABS is about 8 hours away. We'll try to post again tomorrow and let you know how it went. Thanks again for praying!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/abs-jan13-20093.jpg" caption="{: .article-image .article-image--has-caption}" alt="Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya." >}}
-Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/abs-jan13-20093.jpg" caption="Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya." >}}
 
 ### Family News
 
 With each passing day, I become more and more aware of what a blessing it is to have a family. Our two daughters are growing cuter all the time (at least we think so!) and they are the delight of our lives. Rebekah started crawling a few weeks ago, and now she's pulling up on everything she sees. Abigail can't seem to put down her books. She is constantly asking us to read to her, and she knows large potions of several books by heart. Kelsie has already started her on phonics training.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4428.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby is our little bookworm." >}}
-Abby is our little bookworm.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4428.jpg" caption="Abby is our little bookworm." >}}
 
 Another development in the children which we have really enjoyed of late is their growing desire to play together. With her now found mobility, Beka is roaming the house and making new discoveries by the hour. Abby is always nearby, liberally dispensing her childhood wisdom and enlightening Rebekah as to how the world works. For her part, Beka is enthralled by her big sister and does her best to follow her everywhere she goes. Both the girls are healthy, joyful reminders to Kelsie and I of God's goodness to us. They are truly His reward. (Ps. 127:3)
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4513.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby loves to help Mommy in the kitchen." >}}
-Abby loves to help Mommy in the kitchen.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4513.jpg" caption="Abby loves to help Mommy in the kitchen." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4505.jpg" caption="{: .article-image .article-image--has-caption}" alt="Everyday chores are a great opportunity for child training!" >}}
-Everyday chores are a great opportunity for child training!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4505.jpg" caption="Everyday chores are a great opportunity for child training!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4575.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby's job is to put away the silverware." >}}
-Abby's job is to put away the silverware.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/dsc_4575.jpg" caption="Abby's job is to put away the silverware." >}}

--- a/content/blog/2009-01-28-how-it-went-last-night.md
+++ b/content/blog/2009-01-28-how-it-went-last-night.md
@@ -12,30 +12,18 @@ slug: 2009-01-28-how-it-went-last-night
 
 As Mondays come around each week, we begin preparing for English Club and ABS. Sometimes it's not without an inward sigh, especially considering other all-consuming to-do's that have to be set aside. And then Tuesday night rolls around and we come home blessed, encouraged, and excited. It is so great to be a part of what God is doing in the lives of these people. We are truly coming to love and appreciate each member of our group, and pray that they will know Christ!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3479.jpg" caption="{: .article-image .article-image--has-caption}" alt="From left: Bryan, Roman, Taras, Joshua, Jessie, Roman." >}}
-From left: Bryan, Roman, Taras, Joshua, Jessie, Roman.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3479.jpg" caption="From left: Bryan, Roman, Taras, Joshua, Jessie, Roman." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3461.jpg" caption="{: .article-image .article-image--has-caption}" alt="Meet Taras and Marian. (Do you know how unusual this photo is? Ukrainians hardly ever smile for pictures.)" >}}
-Meet Taras and Marian. (Do you know how unusual this photo is? Ukrainians hardly ever smile for pictures.)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3461.jpg" caption="Meet Taras and Marian. (Do you know how unusual this photo is? Ukrainians hardly ever smile for pictures.)" >}}
 
 Marian, came to Joshua after the teaching last night and asked many sincere questions. Joshua said they could have talked for hours about things from God's Word. Unlike those whose hearts are hardened, who ask questions in order to debate, argue, or prove someone wrong, Marian seems to have a real desire to know truth.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3470.jpg" caption="{: .article-image .article-image--has-caption}" alt="Here is a guy with a heart for people to be won to Christ. =)" >}}
-Joshua teaches from John 18.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3470.jpg" caption="Joshua teaches from John 18." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3462.jpg" caption="{: .article-image .article-image--has-caption}" alt="Bryan is jumping into ministry here with both feet." >}}
-Bryan is jumping into ministry here with both feet.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3462.jpg" caption="Bryan is jumping into ministry here with both feet." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3473.jpg" caption="{: .article-image .article-image--has-caption}" alt="I love this shot of Jessie and everyone having a great time." >}}
-I love this shot of Jessie and everyone having a great time.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3473.jpg" caption="I love this shot of Jessie and everyone having a great time." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3480-1.jpg" caption="{: .article-image .article-image--has-caption}" alt="On the right is Irina, one of our Correspondence Bible Students. She has come to us recently asking for special prayer for a difficult family situation." >}}
-On the right is Irina, one of our Correspondence Bible Students. She has come to us recently asking for special prayer for a difficult family situation.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/cimg3480-1.jpg" caption="On the right is Irina, one of our Correspondence Bible Students. She has come to us recently asking for special prayer for a difficult family situation." >}}
 
 Thank you to so much to all of you who are praying for this ministry and these people! We value those prayers and are encouraged to know that we're not in this alone. Prayer is half the battle--maybe even more.

--- a/content/blog/2009-02-04-snapshots-from-abs.md
+++ b/content/blog/2009-02-04-snapshots-from-abs.md
@@ -15,33 +15,19 @@ slug: 2009-02-04-snapshots-from-abs
 
 We had a great turn out for English Club and Audio Bible Study (ABS) last night! Thanks to everyone for the prayers that are going up for this ministry!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4834.jpg" caption="{: .article-image .article-image--has-caption}" alt="Roman and Roman practice English in a discussion about occupations." >}}
-Roman and Roman practice English in a discussion about occupations.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4834.jpg" caption="Roman and Roman practice English in a discussion about occupations." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4835.jpg" caption="{: .article-image .article-image--has-caption}" alt="Marian and Bryan." >}}
-Marian and Bryan.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4835.jpg" caption="Marian and Bryan." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4840.jpg" caption="{: .article-image .article-image--has-caption}" alt="We were excited to have to new guys come last night: Igor and Vacil." >}}
-We were excited to have two new guys come last night: Igor and Vacil.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4840.jpg" caption="We were excited to have two new guys come last night: Igor and Vacil." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4839.jpg" caption="{: .article-image .article-image--has-caption}" alt="Dasha is one of the few girls that come. Taras was her discussion partner." >}}
-Dasha is one of the few girls that come. Taras was her discussion partner.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4839.jpg" caption="Dasha is one of the few girls that come. Taras was her discussion partner." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4842.jpg" caption="{: .article-image .article-image--has-caption}" alt="Everyone engrossed in reading from Good and Evil." >}}
-Everyone engrossed in reading the story of the Good Samaritan from Good and Evil.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4842.jpg" caption="Everyone engrossed in reading the story of the Good Samaritan from Good and Evil." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4848.jpg" caption="{: .article-image .article-image--has-caption}" alt="Preaching time! Tonights topic was the crucifixion story from John 19." >}}
-Preaching time! Tonight's topic was the crucifixion story from John 19.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4848.jpg" caption="Preaching time! Tonight's topic was the crucifixion story from John 19." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4845.jpg" caption="{: .article-image .article-image--has-caption}" alt="Listeners are holding copies of the book of John translated by our friend, Yura Popchenko." >}}
-Listeners are holding copies of the book of John translated by our friend, Yura Popchenko.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4845.jpg" caption="Listeners are holding copies of the book of John translated by our friend, Yura Popchenko." >}}
 
 Please continue to pray that the Word of God would be powerful in transforming the lives of these individuals and bringing them to faith in Christ!
 
@@ -49,8 +35,6 @@ Please continue to pray that the Word of God would be powerful in transforming t
 
 In other news, Bryan has been getting involved right away in helping with the Correspondence Bible Course. The areas he is able to cover have been a tremendous help to Joshua and I in keeping up with the course.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4804.jpg" caption="{: .article-image .article-image--has-caption}" >}}
-Bryan Shufelt
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4804.jpg" caption="Bryan Shufelt" >}}
 
 Every week when we visit the P.O. box, there is a stack of lessons waiting to be graded. Many students are asking questions related to the Bible. In addition, Joshua is working on some upgrades to our Course Database System that tracks the progress of each of our students. We feel both blessed and overwhelmed by the amount of work to do. Please pray that we would have wisdom and be faithful to the ministry God has given us!

--- a/content/blog/2009-02-12-the-bible-or-the-church.md
+++ b/content/blog/2009-02-12-the-bible-or-the-church.md
@@ -14,9 +14,7 @@ slug: 2009-02-12-the-bible-or-the-church
 
 Last time at ABS (Audio Bible Study), I taught from John chapter 20 on the resurrection. During the course of the lesson, one of the verses I cited was I Timothy 2:5: *"For there is one God, and one mediator between God and men, the man Christ Jesus;"* After the lesson had ended, one of our students, Marian, came up to ask me about this point.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4871.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua and Marian chat after ABS." >}}
-Joshua and Marian discuss the Bible after ABS.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4871.jpg" caption="Joshua and Marian discuss the Bible after ABS." >}}
 
 He began by explaining that once he had asked his priest why he should pray to an icon. The priest had replied that the icon was a "mediator" between himself and God. In contrast, we had shown clearly from Scripture that Christ is the ONLY mediator between us and the Father. "Why then would the Church promote prayer to icons if the Bible forbids this?" Marian asked.
 
@@ -24,17 +22,11 @@ We had quite a long conversation about the matter, but the primary issue that we
 
 While this is a difficult choice for many, I believe that Marian has a sincere desire to follow the Lord. Each week he comes to me with new questions. Please continue to pray for him and for the other Ukrainians attending ABS. Pray that their eyes will be opened and that they will come to saving faith in Jesus Christ.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4872.jpg" caption="{: .article-image .article-image--has-caption}" alt="Taras (right) brought his friend Igor (left) to ABS last time. Igor said he enjoyed it and would be back again." >}}
-Taras (right) brought his friend Igor (left) to ABS last time. Igor said he enjoyed it and would be back again.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4872.jpg" caption="Taras (right) brought his friend Igor (left) to ABS last time. Igor said he enjoyed it and would be back again." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4867.jpg" caption="{: .article-image .article-image--has-caption}" alt="During English Club, everyone splits up into groups to practice conversational skills." >}}
-During English Club, everyone splits up into groups to practice conversational skills.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4867.jpg" caption="During English Club, everyone splits up into groups to practice conversational skills." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4863.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie (right) chats with Taras (left) during English Club." >}}
-Jessie (right) chats with Taras (left) during English Club.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4863.jpg" caption="Jessie (right) chats with Taras (left) during English Club." >}}
 
 ### A NOTE OF CLARIFICATION
 

--- a/content/blog/2009-02-14-love-at-first-height.md
+++ b/content/blog/2009-02-14-love-at-first-height.md
@@ -14,36 +14,20 @@ Five years ago, around Valentine's Day, my dad took me to a special restaurant f
 
 I feel as if every Valentine's Day were the anniversary of the beginning of our story. How grateful I am to be five years into our relationship, so loved and cherished by the man who is so perfect for me. Marriage just keeps getting better! In celebration of the day, Joshua and I had made special plans to go rock climbing, something we really enjoy doing together.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4966.jpg" caption="{: .article-image .article-image--has-caption}" alt="The rock gym where we spent a fun Valentines Day." >}}
-The rock gym where we spent a very fun Valentine's Day.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4966.jpg" caption="The rock gym where we spent a very fun Valentine's Day." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4894.jpg" caption="{: .article-image .article-image--has-caption}" alt="Giving it my best shot!" >}}
-Giving it my best shot
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4894.jpg" caption="Giving it my best shot" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4909.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua makes it look easy. He is quite good!" >}}
-Joshua makes it look easy. He is quite good!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4909.jpg" caption="Joshua makes it look easy. He is quite good!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4945.jpg" caption="{: .article-image .article-image--has-caption}" alt="Today we were bouldering, so we were only climbing a short way off the ground. The slanted walls force you to build arm strength." >}}
-These are bouldering walls, so we were only climbing a short way off the ground. The slanted walls force you to build arm strength.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4945.jpg" caption="These are bouldering walls, so we were only climbing a short way off the ground. The slanted walls force you to build arm strength." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4903.jpg" caption="{: .article-image .article-image--has-caption}" alt="Trying to figure out where to go next." >}}
-Trying to figure out where to go next.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4903.jpg" caption="Trying to figure out where to go next." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4953.jpg" caption="{: .article-image .article-image--has-caption}" alt="Those big blue pads come in handy for falls." >}}
-Those big blue pads come in handy for falls.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4953.jpg" caption="Those big blue pads come in handy for falls." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4960.jpg" caption="{: .article-image .article-image--has-caption}" alt="At the top!" >}}
-At the top!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4960.jpg" caption="At the top!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_49871.jpg" caption="{: .article-image .article-image--has-caption}" alt="kelsie" >}}
-Afterward we enjoyed coffee and lunch at a favorite cafe. It was the perfect place to stop in out of the constantly falling snow.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_49871.jpg" caption="Afterward we enjoyed coffee and lunch at a favorite cafe. It was the perfect place to stop in out of the constantly falling snow." >}}
 
 **Stay Tuned:** Over the next few weeks, we are planning to begin a series of posts on how God brought us together 5 years ago from opposite sides of the globe, without ever having even met each other!

--- a/content/blog/2009-02-19-gospel-of-john-series-complete.md
+++ b/content/blog/2009-02-19-gospel-of-john-series-complete.md
@@ -12,9 +12,7 @@ slug: 2009-02-19-gospel-of-john-series-complete
 
 Last Tuesday evening at ABS, I finished teaching through the Gospel of John. It's been a great experience, and we're very grateful for all the Ukrainians who have heard the Gospel through this series. In addition to those who actually attend our meetings live, many more will hear the messages on CD and cassette in the days to come. We have recorded every lesson that was taught from John in digital format, and soon we plan to begin mailing CD's to our students.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4845.jpg" caption="{: .article-image .article-image--has-caption}" alt="Listeners are holding copies of the book of John translated by our friend, Yura Popchenko." >}}
-ABS students listen to teaching from the Gospel of John.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4845.jpg" caption="ABS students listen to teaching from the Gospel of John." >}}
 
 Next up at ABS: the book of Romans! We will begin this series on March 24. In addition to our verse-by-verse study of Romans, we will also be adding some topical messages to the mix. When speaking and witnessing to Ukrainians, one notices that many of the same questions seem to come up repeatedly. With this in mind, we're going to start covering these in messages entitled "What the Bible says about \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_."
 
@@ -33,18 +31,10 @@ The following is an overview of the ABS schedule for the next couple of months.
 
 Even as I write this post, our team is working on another large mailout to notify our CBC students of the upcoming schedule for ABS. All of our L'viv-based students (over 230 altogether) will receive a letter including the schedule above. It is our hope that this will serve to generate more interest in our weekly Bible studies. As always, we appreciate your continued prayers for this ministry. Remember: ABS meets every week at 11:00am CST. God bless you for interceding for those who are hearing the Word of God. Pray that the Lord would open their hearts. *"So then faith cometh by hearing, and hearing by the Word of God." (Rom. 10:17)*
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4997.jpg" caption="{: .article-image .article-image--has-caption}" alt="Denise Hutchison and Bryan Shufelt print addresses for our upcoming ABS mailout." >}}
-Denise Hutchison and Bryan Shufelt print addresses for our upcoming ABS mailout.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4997.jpg" caption="Denise Hutchison and Bryan Shufelt print addresses for our upcoming ABS mailout." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4991.jpg" caption="{: .article-image .article-image--has-caption}" alt="Playing &quot;Catch Phrase&quot; with our students at English Club last Tuesday." >}}
-Playing "Catch Phrase" with our students at English Club last Tuesday
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4991.jpg" caption="Playing \"Catch Phrase\" with our students at English Club last Tuesday" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5003.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua works on signing 230+ copies of a letter to our CBC students. Good thing signatures don't really have to be legible." >}}
-Joshua works on signing 230+ copies of a letter to our CBC students. Good thing signatures don't really have to be legible!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5003.jpg" caption="Joshua works on signing 230+ copies of a letter to our CBC students. Good thing signatures don't really have to be legible!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5000.jpg" caption="{: .article-image .article-image--has-caption}" alt="Stuffing envelopes..." >}}
-Stuffing the envelopes...
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5000.jpg" caption="Stuffing the envelopes..." >}}

--- a/content/blog/2009-02-25-authenticity-of-the-bible.md
+++ b/content/blog/2009-02-25-authenticity-of-the-bible.md
@@ -13,24 +13,16 @@ slug: 2009-02-25-authenticity-of-the-bible
 
 This week at ABS, Jessie Beal taught on the authenticity of the Bible. It was a great message, and one that is certainly needed in our day. One of the main ideas that we try to communicate to people here is that the Bible is our final authority in every area. While many Ukrainians acknowledge that the Bible is a "holy book," few have any real knowledge as to the many proofs of its divine inspiration.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5016.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie teaches on the authenticity of the Bible at ABS, while Joshua translates." >}}
-Jessie teaches on the authenticity of the Bible at ABS, while Joshua translates.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5016.jpg" caption="Jessie teaches on the authenticity of the Bible at ABS, while Joshua translates." >}}
 
 One particularly interesting point that Jessie shared was the fact that many people over the centuries have tried in vain to destroy the Bible. This is one of the many proofs of God's preservation of His Word. The students listened eagerly as Jessie recounted the example of Voltaire, the noted French infidel who died in 1778. Voltaire said that in 100 years from his time Christianity would be swept from existence and passed into history. But only fifty years after his death, the Geneva Bible Society used his press and house to produce Bibles for the world.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5014.jpg" caption="{: .article-image .article-image--has-caption}" alt="We have lots of Bibles on hand at our meetings so that students can follow along during the teaching." >}}
-We have lots of Bibles on hand at our meetings so that students can follow along during the teaching.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5014.jpg" caption="We have lots of Bibles on hand at our meetings so that students can follow along during the teaching." >}}
 
 English Club is also going well. We usually start out each meeting with some type of discussion topic (this week we talked about "Friends"), and then finish up by reading through a portion of *Good and Evil*. All our students have their own copies of *Good and Evil* in Ukrainian, and we encourage them to compare the English portions we give them as a way to improve their English. This week we read through the account of Christ's ascension and asked the students questions about the story.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5012.jpg" caption="{: .article-image .article-image--has-caption}" alt="ABS students take turns reading through a selection from Good and Evil." >}}
-ABS students take turns reading through a selection from Good and Evil during English Club.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5012.jpg" caption="ABS students take turns reading through a selection from Good and Evil during English Club." >}}
 
 At the end of the meeting, most of our students stayed for the fellowship time. This provides us a great opportunity to chat with them and get to know them better.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5035.jpg" caption="{: .article-image .article-image--has-caption}" alt="Fellowship time after ABS. A great time to practice English or Ukrainian, depending on which language you're learning!" >}}
-Fellowship time after ABS. A great opportunity to practice English or Ukrainian, depending on which language you're learning!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_5035.jpg" caption="Fellowship time after ABS. A great opportunity to practice English or Ukrainian, depending on which language you're learning!" >}}

--- a/content/blog/2009-03-01-headed-to-krakow.md
+++ b/content/blog/2009-03-01-headed-to-krakow.md
@@ -10,9 +10,7 @@ slug: 2009-03-01-headed-to-krakow
 
 Once again, Kels and I are embarking on one of our mandatory, twice-a-year "vacations." Even though we have Ukrainian multi-entry visas that are good for five years, the law still states that we have to leave the country every six months and come back in again. (sigh) Technically, there are ways around this (yes, we know about registration), but for us, a trip into Poland twice a year has historically been cheaper, simpler, and infinitely more pleasant than the alternative.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/cmo2006_007_lg.jpg" caption="{: .article-image .article-image--has-caption}" alt="One of the many elegant courtyards inside Krakow's famous Wawel Castle." >}}
-One of the many elegant courtyards inside Krakow's famous Wawel Castle.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/cmo2006_007_lg.jpg" caption="One of the many elegant courtyards inside Krakow's famous Wawel Castle." >}}
 
 This time, our trip is a little more complicated. My current visa expires in April, and so I need to apply for a new visa at the Ukrainian consulate in Krakow. I have spoken with the consulate by phone, and it looks like all is in order. I have all my documents ready. Still, there are a lot of variables, and we would appreciate your prayers.
 

--- a/content/blog/2009-03-02-our-love-story.md
+++ b/content/blog/2009-03-02-our-love-story.md
@@ -13,12 +13,9 @@ Joshua and I have often expressed how much we wished we had written our love sto
 
 ---
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/111_1129.jpg" caption="{: .article-image .article-image--has-caption}" >}}
-Joshua & Kelsie - Married September 18, 2004
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/111_1129.jpg" caption="Joshua & Kelsie - Married September 18, 2004" >}}
 
 **Psalm 118: 23 "This is the LORD's doing; it is marvelous in our eyes."**
-{: .article-text--centered}
 
 ### PART ONE
 
@@ -30,9 +27,7 @@ This had been my 3<sup>rd</sup> experience participating in the leadership team 
 
 This was also Jennifer's 3<sup>rd</sup> conference as a team leader and speaker, but this time her mother and younger sister, Jessica, came along as attendees. They were assigned to my team along with 6-8 other mothers and daughters. I well remember young Jessica's contagious energy, and Mrs. Steele's active participation and support for me as I led team activities. Looking out over the sea of faces as I gave my public talks, Mrs. Steele's beaming, encouraging face and regular nods stood out to me like a lighthouse for sea worn travelers. She had told me of her family of six children, four of whom were red-headed. One son who was older than Jennifer was on his way to the mission field very soon. This last point must have rolled off of me like water off a duck's back, because I really have no recollection of it now, although I know we talked about it.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/commit.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessica Steele is in the front wearing a striped sweater vest. Mrs. Steele and I are next to each other on the back row, directly under the flower arrangement on the wall." >}}
-Jessica Steele is in the front wearing a striped sweater vest. Mrs. Steele and I are next to each other on the back row, directly under the flower arrangement on the wall.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/commit.jpg" caption="Jessica Steele is in the front wearing a striped sweater vest. Mrs. Steele and I are next to each other on the back row, directly under the flower arrangement on the wall." >}}
 
 The gray sweater vest became a regular part of my wardrobe, and the Steele's were added to the number of other fond acquaintances I had made at COMMIT.
 

--- a/content/blog/2009-03-09-our-trip-to-krakow.md
+++ b/content/blog/2009-03-09-our-trip-to-krakow.md
@@ -12,37 +12,23 @@ slug: 2009-03-09-our-trip-to-krakow
 
 To everyone who prayed for our recent trip to Krakow - thank you! It went very well. I was able to get my visa, though not for as long a term as I had planned. There was a misunderstanding with the paperwork, and I ended up with a visa for only six months. However, in September I can apply again and, Lord willing, should be able to get my full five year visa at that time.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5101.jpg" caption="{: .article-image .article-image--has-caption}" alt="We got one of the locals to snap this shot of us standing in front of Krakow's Florian Gate." >}}
-We got one of the locals to snap this shot of us standing in front of Krakow's Florian Gate.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5101.jpg" caption="We got one of the locals to snap this shot of us standing in front of Krakow's Florian Gate." >}}
 
 Kels and I had a wonderful time in Krakow as usual. For us, Krakow is a nice place to relax and take some time off from the daily grind of L'viv. Here are a few pictures from our trip. Thanks again for praying!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5043.jpg" caption="{: .article-image .article-image--has-caption}" alt="Getting to Krakow means about 9 hours on a train. Great time to get some reading done!" >}}
-Getting to Krakow means about 9 hours on a train. Great time to get some reading done!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5043.jpg" caption="Getting to Krakow means about 9 hours on a train. Great time to get some reading done!" >}}
 
 Because the tracks in Ukraine are a different gauge than the rest of Europe, they actually have to change the wheels on the entire train when we get to the border! This process can take up to four hours.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5050.jpg" caption="{: .article-image .article-image--has-caption}" alt="The train is jacked up (with us in it!) so that the wheels can be changed at the border." >}}
-The train is jacked up (with us in it!) so that the wheels can be changed at the border.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5050.jpg" caption="The train is jacked up (with us in it!) so that the wheels can be changed at the border." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5092.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our friends Beata and Serhiy graciously allowed us to stay in their beautiful home while we were in Krakow." >}}
-Our friends Beata and Serhiy graciously allowed us to stay in their beautiful home while we were in Krakow.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5092.jpg" caption="Our friends Beata and Serhiy graciously allowed us to stay in their beautiful home while we were in Krakow." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5073.jpg" caption="{: .article-image .article-image--has-caption}" alt="Of course, we found time to visit our favorite climbing wall in Krakow." >}}
-Of course, we found time to visit our favorite climbing wall in Krakow.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5073.jpg" caption="Of course, we found time to visit our favorite climbing wall in Krakow." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5086.jpg" caption="{: .article-image .article-image--has-caption}" alt="The gym in Krakow is much larger and nicer than the one we have in L'viv." >}}
-The gym in Krakow is much larger and nicer than the one we have in L'viv.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5086.jpg" caption="The gym in Krakow is much larger and nicer than the one we have in L'viv." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5098.jpg" caption="{: .article-image .article-image--has-caption}" alt="Oh, and did we mention that McDonald's in Krakow has sausage-egg-and-cheese biscuits? Glory hallelujah!" >}}
-Oh, and did we mention that McDonald's in Krakow has sausage-egg-and-cheese biscuits? Glory hallelujah!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5098.jpg" caption="Oh, and did we mention that McDonald's in Krakow has sausage-egg-and-cheese biscuits? Glory hallelujah!" >}}
 
 ### ABS Tomorrow
 

--- a/content/blog/2009-03-11-how-to-study-the-bible.md
+++ b/content/blog/2009-03-11-how-to-study-the-bible.md
@@ -13,15 +13,12 @@ slug: 2009-03-11-how-to-study-the-bible
 
 We had our core group of men show up last night for English Club and Audio Bible Study (ABS)! As time has passed, we feel we have really gotten to know this group and that our friendships are steadily growing. 
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5115.jpg" caption="{: .article-image .article-image--has-caption}" alt="Several men joined us last night for English Club and ABS." >}}
-Several men joined us last night for English Club and ABS.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5115.jpg" caption="Several men joined us last night for English Club and ABS." >}}
 
 Each week, the Word of God is preached and they are staying to listen. As we teach the Bible, we feel it is paramount that they understand we are not just another religious group putting forth our own ideas about the Bible, trying to dogmatically convince them of our personal views. Rather, we make every effort to show them that anything we teach comes directly from the Word of God, a source they can easily access for themselves. With some simple studying they can know for themselves exactly what the Bible says and whether we are indeed speaking truth.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5116.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5116.jpg" >}}
 
 Last night, Joshua did a great job of laying out simple steps to studying the Bible and drawing accurate conclusions about what it teaches. We hope that this message will benefit not only those who were present, but many others who will hear the recording of it in the days to come.
 
 **"Every word of God is pure: he is a shield unto them that put their trust in him." Proverbs 30:5**
-{: .article-text--centered}

--- a/content/blog/2009-03-19-pray-everyday-all-the-time-everywhere.md
+++ b/content/blog/2009-03-19-pray-everyday-all-the-time-everywhere.md
@@ -16,22 +16,14 @@ In Ukraine, it is not uncommon to find people who think that prayer must be read
 
 Jessie did a wonderful job of explaining to our Tuesday night group what the Bible says about prayer. He touched on what, where, when, why, and how to pray. We all came away encouraged to "pray everyday, all the time, everywhere."
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_51251.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie was excited about his subject and taught enthusiastically." >}}
-Jessie was excited about his subject and taught enthusiastically.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_51251.jpg" caption="Jessie was excited about his subject and taught enthusiastically." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5124.jpg" caption="{: .article-image .article-image--has-caption}" alt="Bryan (far left) and Denise (far right) are taking an active part in ABS each week." >}}
-Bryan (far left) and Denise (far right) are taking an active part in ABS each week.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5124.jpg" caption="Bryan (far left) and Denise (far right) are taking an active part in ABS each week." >}}
 
 Denise gave me a needed break by planning English Club for the next two weeks. She is offering some fresh perspective and good ideas. It has been great having both her and Bryan join our team.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5123.jpg" caption="{: .article-image .article-image--has-caption}" alt="Marian and Taras are among our most faithful attendees." >}}
-Marian and Taras are among our most faithful attendees.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5123.jpg" caption="Marian and Taras are among our most faithful attendees." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5128.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua and Jessie have known each other for nearly 14 years, and have actively worked together for 8. They make a good team!" >}}
-Joshua and Jessie have known each other for about 13 years and have actively worked together for 8. Spreading the Gospel of Jesus Christ together has been a major part of their friendship.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5128.jpg" caption="Joshua and Jessie have known each other for about 13 years and have actively worked together for 8. Spreading the Gospel of Jesus Christ together has been a major part of their friendship." >}}
 
 We appreciate all the prayers that are going up on behalf of this ministry! Our request is not only that the people attending would come to know Christ as their personal Savior, but also that the CD recordings of the preaching and Bible teaching will reach countless others who we may never even meet.

--- a/content/blog/2009-03-26-snapshots-from-tuesday-night.md
+++ b/content/blog/2009-03-26-snapshots-from-tuesday-night.md
@@ -14,48 +14,26 @@ slug: 2009-03-26-snapshots-from-tuesday-night
 
 A few photos from ABS...
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5132.jpg" caption="{: .article-image .article-image--has-caption}" alt="Marian examines a Bolivian souvenir during English Club. Our theme this week was &quot;Vacations&quot;." >}}
-Marian examines a Bolivian souvenir during English Club. Our theme this week was "Vacations".
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5132.jpg" caption="Marian examines a Bolivian souvenir during English Club. Our theme this week was \"Vacations\"." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5130.jpg" caption="{: .article-image .article-image--has-caption}" alt="Denise tells the group about a trip she took to Africa." >}}
-Denise tells the group about a trip she took to Africa.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5130.jpg" caption="Denise tells the group about a trip she took to Africa." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5135.jpg" caption="{: .article-image .article-image--has-caption}" alt="An engaging English discussion between Jessie and Igor." >}}
-An engaging English discussion between Jessie and Igor.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5135.jpg" caption="An engaging English discussion between Jessie and Igor." >}}
 
- {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5136.jpg" caption="{: .article-image .article-image--has-caption}" alt="&quot;If money were not an issue, what would be your ideal vacation?&quot; (Looks like Denise left has dreamed up a good one!)" >}}
-"If money were not an issue, what would be your ideal vacation?" (Looks like Denise has dreamed up a good one!)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5136.jpg" caption="\"If money were not an issue, what would be your ideal vacation?\" (Looks like Denise has dreamed up a good one!)" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5137.jpg" caption="{: .article-image .article-image--has-caption}" alt="More interesting vacation planning going on...." >}}
-More interesting vacation planning going on….
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5137.jpg" caption="More interesting vacation planning going on…." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5134.jpg" caption="{: .article-image .article-image--has-caption}" alt="I enjoyed talking with two girls who came for the first time this week." >}}
-I enjoyed talking with two girls who came for the first time this week.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5134.jpg" caption="I enjoyed talking with two girls who came for the first time this week." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5138.jpg" caption="{: .article-image .article-image--has-caption}" alt="Getting ready for Bible teaching...." >}}
-Getting ready for Bible teaching….
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5138.jpg" caption="Getting ready for Bible teaching…." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5139.jpg" caption="{: .article-image .article-image--has-caption}" alt="What a great group, and this isn't even everyone!" >}}
-What a great group, and this isn't even everyone!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5139.jpg" caption="What a great group, and this isn't even everyone!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5140.jpg" caption="{: .article-image .article-image--has-caption}" alt="And here's the rest of them." >}}
-Here's the rest of them.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5140.jpg" caption="Here's the rest of them." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5142.jpg" caption="{: .article-image .article-image--has-caption}" alt="Listening as Joshua teaches from the 1st chapter of Romans." >}}
-Listening as Joshua teaches from the 1st chapter of Romans.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5142.jpg" caption="Listening as Joshua teaches from the 1st chapter of Romans." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5141.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua and my good friend, Natalia, came for the first time." >}}
-It was great having our good friend, Natalia, there for the first time.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5141.jpg" caption="It was great having our good friend, Natalia, there for the first time." >}}
 
 Thanks to everyone who is praying for this ministry!

--- a/content/blog/2009-04-24-report-from-tuesday-night.md
+++ b/content/blog/2009-04-24-report-from-tuesday-night.md
@@ -14,26 +14,14 @@ slug: 2009-04-24-report-from-tuesday-night
 
 Each Tuesday evening, we continue to meet together with Ukrainians for English Club and Audio Bible Study. (ABS)  "Audio" refers to the fact that each time Joshua, Jessie, or another missionary preaches from the Word of God, the messages are being recorded in digital format so that multiple Ukrainians can have access to them over time. Although the first half of the evening is a focus on English, the preaching time is always done in Ukrainian so that the nationals can hear the Word of God clearly  in their own language. This ministry continues to grow and we are encouraged by how God has blessed it! New people often visit our group, and others have become regular attendees. Thank you to everyone who is consistently lifting this ministry up in prayer. Please pray with us that it would bear fruit unto salvation, and that people would be "turned from the error of their way" unto Christ, who is THE way.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5849.jpg" caption="{: .article-image .article-image--has-caption}" alt="Some lively English discussion." >}}
-Some lively English discussion.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5849.jpg" caption="Some lively English discussion." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5851.jpg" caption="{: .article-image .article-image--has-caption}" alt="Denise talking with some girls who just began attending recently." >}}
-Denise (far right) talking with some girls who just began attending recently.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5851.jpg" caption="Denise (far right) talking with some girls who just began attending recently." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5852.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie and Marian studying a text from Good and Evil." >}}
-Jessie and Marian studying a text from Good and Evil.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5852.jpg" caption="Jessie and Marian studying a text from Good and Evil." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5853.jpg" caption="{: .article-image .article-image--has-caption}" alt="Reading practice. This is the first time that we have ever had more girls at Bible Study than guys." >}}
-Reading practice. This is the first time that we have ever had more girls at English Club/Bible Study than guys.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5853.jpg" caption="Reading practice. This is the first time that we have ever had more girls at English Club/Bible Study than guys." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5857.jpg" caption="{: .article-image .article-image--has-caption}" alt="They made for a great audience during the preaching from Romans 2." >}}
-They made for a great audience during the preaching from Romans 2.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5857.jpg" caption="They made for a great audience during the preaching from Romans 2." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5859.jpg" caption="{: .article-image .article-image--has-caption}" alt="Ministering to the Lord is a joyful thing!" >}}
-Ministering to the Lord is a joyful thing!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/04/dsc_5859.jpg" caption="Ministering to the Lord is a joyful thing!" >}}

--- a/content/blog/2009-05-16-romans-3-the-closing-arguments.md
+++ b/content/blog/2009-05-16-romans-3-the-closing-arguments.md
@@ -39,4 +39,3 @@ E'er since by faith I saw the stream
 Thy flowing wounds supply,  
 Redeeming love has been my theme  
 And shall be till I die!*
-{: .article-text--centered}

--- a/content/blog/2009-05-21-abs-from-nikkis-point-of-view.md
+++ b/content/blog/2009-05-21-abs-from-nikkis-point-of-view.md
@@ -16,38 +16,22 @@ slug: 2009-05-21-abs-from-nikkis-point-of-view
 
 God is continuing to bless this ministry--we are building good friendships and people are hearing the gospel preached. Please continue to pray that those who are coming would repent and believe in Christ!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6388.jpg" caption="{: .article-image .article-image--has-caption}" alt="Joshua teaching out of Romans." >}}
-Joshua teaching out of Romans.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6388.jpg" caption="Joshua teaching out of Romans." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6326.jpg" caption="{: .article-image .article-image--has-caption}" alt="English Club participants practicing their language skills together." >}}
-English Club participants practicing their language skills together.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6326.jpg" caption="English Club participants practicing their language skills together." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6325.jpg" caption="{: .article-image .article-image--has-caption}" alt="We had a large group that night." >}}
-We had a large group that night.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6325.jpg" caption="We had a large group that night." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6328.jpg" caption="{: .article-image .article-image--has-caption}" alt="Evelina is one of our faithful Bible students. She is often able to come to ABS." >}}
-Evelina is one of our faithful Bible students. She often joins us for ABS.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6328.jpg" caption="Evelina is one of our faithful Bible students. She often joins us for ABS." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6330.jpg" caption="{: .article-image .article-image--has-caption}" alt="Jessie and Joshua laughing over a joke as they get ready to preach." >}}
-Jessie and Joshua laughing over a joke as they get ready to preach.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6330.jpg" caption="Jessie and Joshua laughing over a joke as they get ready to preach." >}}
 
 About once a month or so, we have hosted a game night during our English teaching period. The students seem to really enjoy these evenings, and many of our games are new to them. It makes for a nice change of pace, and also helps them break out of their shell and practice more freely.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5159.jpg" caption="{: .article-image .article-image--has-caption}" alt="Scattergories!" >}}
-Scattergories!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5159.jpg" caption="Scattergories!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5162.jpg" caption="{: .article-image .article-image--has-caption}" alt="Coming up with good answers." >}}
-Looks like this team is coming up with some good answers.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5162.jpg" caption="Looks like this team is coming up with some good answers." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5163.jpg" caption="{: .article-image .article-image--has-caption}" alt="Hurry, time is ticking!" >}}
-Hurry, time is ticking!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5163.jpg" caption="Hurry, time is ticking!" >}}
 
 **"Finally, brethren, pray for us, that the word of the Lord may have free course, and be glorified...." 2 Thessalonians 3:1**

--- a/content/blog/2009-05-26-some-girls-and-some-guys.md
+++ b/content/blog/2009-05-26-some-girls-and-some-guys.md
@@ -14,36 +14,20 @@ It's been a while since we've posted any pictures of Abby and Rebekah. Here's a 
 
 ### The Girls
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6319.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby tries on a new skirt that Baba (her grandma) made for her." >}}
-Abby tries on a new skirt that Baba (her grandma) made for her.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6319.jpg" caption="Abby tries on a new skirt that Baba (her grandma) made for her." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6322.jpg" caption="{: .article-image .article-image--has-caption}" alt="Yeah, mom got new stuff too!" >}}
-Yeah, mom got new stuff too!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6322.jpg" caption="Yeah, mom got new stuff too!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6323.jpg" caption="{: .article-image .article-image--has-caption}" alt="Trying out Abby's new headbands." >}}
-Trying out Abby's new headbands.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6323.jpg" caption="Trying out Abby's new headbands." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5143.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our sweet Rebekah" >}}
-Our sweet Rebekah
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5143.jpg" caption="Our sweet Rebekah" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5157.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abby and Daddy getting ready to go on their first big outing together." >}}
-Abby is starting to tag along on some of Daddy's trips to the mountains!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5157.jpg" caption="Abby is starting to tag along on some of Daddy's trips to the mountains!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5173.jpg" caption="{: .article-image .article-image--has-caption}" alt="Rebekah often toddles back go Daddy's office for a visit." >}}
-Rebekah often toddles back to Daddy's office for a visit.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5173.jpg" caption="Rebekah often toddles back to Daddy's office for a visit." >}}
 
 ### The Guys
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6386.jpg" caption="{: .article-image .article-image--has-caption}" alt="Meet Daniel Courter, our latest recruit, and one of the guys who will be participating in CMO 2009." >}}
-Meet Daniel Courter, our latest recruit, and one of the guys who will be participating in CMO 2009.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6386.jpg" caption="Meet Daniel Courter, our latest recruit, and one of the guys who will be participating in CMO 2009." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6380.jpg" caption="{: .article-image .article-image--has-caption}" alt="Of Macs and Men. Taken at a recent Sunday gathering for food and...fellowship??" >}}
-"Of Macs and Men." Taken at a recent Sunday gathering for food and…fellowship??
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6380.jpg" caption="\"Of Macs and Men.\" Taken at a recent Sunday gathering for food and…fellowship??" >}}

--- a/content/blog/2012-12-21-love-story-part-4.md
+++ b/content/blog/2012-12-21-love-story-part-4.md
@@ -12,9 +12,7 @@ After only three weeks, Danny surprised me by stating that he felt this was of t
 
 I believe there were those at the time who, upon hearing our story, worried that Danny and I were concocting an arranged marriage in which Kelsie had no say. Nothing could be further from the truth. As her father, Danny was merely doing what any good father should do: protecting his daughter from potentially harmful relationships and doing all he could to find for her the man who would become her life-long companion. That said, it was understood from the beginning that Kelsie had veto power. I had proposed a courtship, Danny had approved, but the final decision would be Kelsie’s.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010064_3.jpg" caption="{: .article-image .article-image--has-caption}" alt="Kelsie at the girls' retreat" >}}
-Kelsie at the girls' retreat (bottom row, red blouse)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010064_3.jpg" caption="Kelsie at the girls' retreat (bottom row, red blouse)" >}}
 
 At the time all this was transpiring, Kelsie was away teaching at a girls’ retreat. Her parents made their preparations in her absence, and on the day she returned, Danny suggested the family go on an after-dinner stroll in a local park. As Kelsie’s younger brother entertained himself by tossing stones into a nearby pond, she and her parents chatted.
 

--- a/content/blog/2012-12-28-love-story-part-5.md
+++ b/content/blog/2012-12-28-love-story-part-5.md
@@ -24,12 +24,8 @@ Kelsie’s immediate response was to get alone and pray. She had my letter, the 
 
 As Kelsie prayed, the rest of us held our breaths and waited. Happily, we did not have to wait long. A few hours later I received Kelsie’s response in which she excitedly agreed to begin a relationship!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010014_2.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our moms met and chatted at the girls' retreat before Kelsie knew what was going on." >}}
-Our moms met and chatted at the girls' retreat before Kelsie knew what was going on.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010014_2.jpg" caption="Our moms met and chatted at the girls' retreat before Kelsie knew what was going on." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010013_2.jpg" caption="{: .article-image .article-image--has-caption}" alt="Suddenly, Kelsie was spending a lot more time with her email!" >}}
-Suddenly, Kelsie was spending a lot more time with her email!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2012/12/P1010013_2.jpg" caption="Suddenly, Kelsie was spending a lot more time with her email!" >}}
 
 [Part 6: Mystery Courtship](/blog/2013-01-04-love-story-part-6/)

--- a/content/blog/2013-01-04-love-story-part-6.md
+++ b/content/blog/2013-01-04-love-story-part-6.md
@@ -10,13 +10,9 @@ slug: 2013-01-04-love-story-part-6
 
 As Kelsie and I embarked on what would become a life-long journey together, our relationship was unlike anything I had envisioned. I was still in Thailand and she in Oklahoma. My acquaintance with her family had reached the ripe old age of three weeks, and neither of us had ever seen each other in person. Our budding new friendship sounded more like a success story from an online dating site than a Christian courtship. Yet none involved could deny that God was leading.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/P1010017.jpg" caption="{: .article-image .article-image--has-caption}" alt="Kelsie receives her first bouquet from me while I was still overseas." >}}
-Kelsie receives her first bouquet from me while I was still overseas.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/P1010017.jpg" caption="Kelsie receives her first bouquet from me while I was still overseas." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/P1010020_3.jpg" caption="{: .article-image .article-image--has-caption}" alt="I think she liked them." >}}
-I think she liked them.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/P1010020_3.jpg" caption="I think she liked them." >}}
 
 Let me clarify at this point what exactly we had begun. Neither of us had agreed to marriage. How could we? We knew only the barest facts about each other and were proceeding primarily based on the sincere belief that this was God’s direction.
 

--- a/content/blog/2013-01-11-love-story-part-7.md
+++ b/content/blog/2013-01-11-love-story-part-7.md
@@ -14,23 +14,17 @@ As the days passed, my confidence in our relationship grew steadily. Soon, I dec
 
 Armed with this approval, I purchased a dozen red roses and placed them in the parlor of my Grandmother’s house, where Kelsie had been staying. That afternoon, Kelsie and I entered the parlor together where she immediately saw the flowers. Her face beamed as she noticed the card protruding from the side. Inscribed on it in large letters were the words: “I love you, Princess Kelsie!”
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1124.jpg" caption="{: .article-image .article-image--has-caption}" alt="&quot;I love you, Princess Kelsie!&quot;" >}}
-"I love you, Princess Kelsie!"
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1124.jpg" caption="\"I love you, Princess Kelsie!\"" >}}
 
 A few days later, I asked Kelsie to marry me, and she joyfully agreed. Perhaps no two people on earth were happier that day than we were. After long months of waiting, seeking, praying and trusting God, we knew for certain that each of us had found our life-partner in the other.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1179.jpg" caption="{: .article-image .article-image--has-caption}" alt="She said yes!" >}}
-She said yes!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1179.jpg" caption="She said yes!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_1235.jpg" caption="{: .article-image .article-image--has-caption}" alt="Planning the wedding at the Powells' home in Canada" >}}
-Planning the wedding at the Powells' home in Canada
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_1235.jpg" caption="Planning the wedding at the Powells' home in Canada" >}}
 
 The days and weeks that followed were a delightful blend of travel, meeting family, wedding planning, and of course, spending every possible moment with each other. On September 18, 2004 our young courtship officially ended as we crossed the threshold from singleness into marriage. Less than a month later, we arrived in Ukraine as a missionary couple and began building our new life together.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1129.jpg" caption="{: .article-image}" alt="111_1129" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1129.jpg" alt="111_1129" >}}
 
 ### Ever After
 
@@ -41,18 +35,12 @@ We count ourselves very blessed to have had parents and mentors who urged us to 
 *“Trust in the Lord with all thine heart; and lean not unto thine own understanding. In all thy ways acknowledge him, and he shall direct thy paths.”*
 *(Prov. 3:5-6)*
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/157_5780.jpg" caption="{: .article-image .article-image--has-caption}" alt="From the left: Cindy Powell, Danny Powell, Kelsie, Joshua, Cathy Steele, Mike Steele" >}}
-From the left: Cindy Powell, Danny Powell, Kelsie, Joshua, Cathy Steele, Mike Steele
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/157_5780.jpg" caption="From the left: Cindy Powell, Danny Powell, Kelsie, Joshua, Cathy Steele, Mike Steele" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/160_6056A.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/160_6056A.jpg" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/161_6167.jpg" caption="{: .article-image}" alt="161_6167" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/161_6167.jpg" alt="161_6167" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_1512.jpg" caption="{: .article-image .article-image--has-caption}" alt="Honeymooning in Eureka Springs" >}}
-Honeymooning in Eureka Springs
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_1512.jpg" caption="Honeymooning in Eureka Springs" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_5706-8X10.jpg" caption="{: .article-image .article-image--has-caption}" alt="The honeymoon continues..." >}}
-The honeymoon continues...
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/IMG_5706-8X10.jpg" caption="The honeymoon continues..." >}}

--- a/content/blog/2013-03-14-angels.md
+++ b/content/blog/2013-03-14-angels.md
@@ -10,23 +10,19 @@ slug: 2013-03-14-angels
 
 Tonight our family was involved in a potentially serious car accident. All five of us were coming home in very snowy weather in a taxi. As the driver tried to execute a left turn across traffic, he lost traction in the snow, and we were broadsided by an oncoming vehicle.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.14.46.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our taxi was broadsided by in the middle of a major intersection." >}}
-Our taxi was broadsided by in the middle of a major intersection.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.14.46.jpg" caption="Our taxi was broadsided by in the middle of a major intersection." >}}
 
 As you can see from the image above, the other car hit us just behind the rear passenger door where Kelsie was sitting with Hosanna in her lap. I was in the front passenger seat, and Beka and Abby were in the back with Kelsie.
 
 Our car spun around and came to rest next to the opposite curb. I suffered a very minor head bang on the ceiling, but Kelsie hit her head pretty hard on the window. The kids were  terrified and crying, but otherwise unhurt. As soon as I could do so safely, I got everyone out of the car to check for injuries. It was snowing heavily. After a quick inspection, it appeared that everyone was OK. Kels will no doubt have a nice goose egg to show for the evening, but other than that we are all safe.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.08.47.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.08.47.jpg" >}}
 
 Meanwhile, a nearby tram was stopped because our car was blocking the tracks. In Ukraine, it is illegal to move any vehicle involved in accident until the police have arrived. The tram had emptied of passengers and the driver, seeing that we were standing in the snow with the children, came over and invited us into her warm tram! She was a very nice lady, and the kids had a great time sitting up in the driver's seat.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.16.11.jpg" caption="{: .article-image}" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.16.11.jpg" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.16.00.jpg" caption="{: .article-image .article-image--has-caption}" >}}
-We were blessed by a kind tram driver who took us in out of the cold while we waited for a taxi.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/03/2013-03-14-19.16.00.jpg" caption="We were blessed by a kind tram driver who took us in out of the cold while we waited for a taxi." >}}
 
 After a while, the taxi company sent another car to pick us up and soon we were home. We're a bit shaken up but very grateful for God's protection. Thank you again to all of you who keep our family covered in prayer. It certainly counted tonight.
 

--- a/content/blog/2013-05-25-pillars-genesis-part-1-adam.md
+++ b/content/blog/2013-05-25-pillars-genesis-part-1-adam.md
@@ -19,7 +19,7 @@ Genesis introduces many significant characters, but seven individuals in particu
 
 The Bible is a book of kingdoms, and Adam was earth’s first king. Like most monarchs, Adam’s authority was given him by right of birth. Immediately after his creation, God charged Adam to take dominion over the entire planet.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Adam-and-Eve-1200-1-351x450.jpg" caption="{: .article-image}" alt="Adam and Eve" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Adam-and-Eve-1200-1-351x450.jpg" alt="Adam and Eve" >}}
 
 But Adam was more than our first king. He was also our father. Though he did not fully understand it at the time, his position as head of the human race meant that every decision he made would directly affect his descendants. Sadly, when Adam chose to disobey God, he forfeited his dominion to Satan who became the god of this world. As a result, mankind was plunged into darkness and corporately separated from God’s life-giving presence.
 

--- a/content/blog/2013-06-01-pillars-genesis-part-2-abel.md
+++ b/content/blog/2013-06-01-pillars-genesis-part-2-abel.md
@@ -15,7 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 Abel’s offering of a lamb in Genesis 4 clearly represents the payment God requires to atone for (that is, cover) sin. Only innocent blood possesses the judicial power to effectively remove sin. (See Leviticus 17:11, Hebrews 9:22)
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/06/Abel-366x450.jpg" caption="{: .article-image}" alt="Cain and Abel" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/06/Abel-366x450.jpg" alt="Cain and Abel" >}}
 
 At first glance, many have supposed that Abel’s choice of an offering was based on his profession: he was a shepherd and thus brought a lamb. If that were true, God’s refusal of Cain’s gift would be quite unjust, for Cain, a farmer by trade, brought the best of his harvest. In actuality, God’s rejection of Cain was not based on the quality of his labor, but on the fact that his offering was inappropriate to the task for which it was intended. Fruits and vegetables cannot pay for sin. This operation, known in the Bible as atonement, can only be accomplished by the shedding of innocent blood.
 

--- a/content/blog/2013-06-08-pillars-genesis-part-3-noah.md
+++ b/content/blog/2013-06-08-pillars-genesis-part-3-noah.md
@@ -15,7 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 Noah lived in an era of wickedness so terrible that it caused God to regret His creation of the human race. Yet in the midst of this universal debauchery, Noah was found to be righteous.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Noah-378x450.jpg" caption="{: .article-image}" alt="Noah" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Noah-378x450.jpg" alt="Noah" >}}
 
 As God resolved to destroy humanity in a global flood, He made provision for the salvation of Noah and his family. But this provision was narrow and exact. Noah was required to follow detailed instructions as he constructed a giant ark that would one day become the only habitable place on earth.
 

--- a/content/blog/2013-06-15-pillars-genesis-part-4-abraham.md
+++ b/content/blog/2013-06-15-pillars-genesis-part-4-abraham.md
@@ -15,9 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 Historically, men have sought God’s favor through their works. While this pursuit is theoretically legitimate, it is always found inadequate due to the presence of sin. Although righteous works are indeed pleasing to God, they cannot undo evil works.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Abraham-372x450.jpg" caption="{: .article-image .article-image--has-caption}" alt="Abraham" >}}
-“But without faith it is impossible to please [God]…” (Hebrews 11:6)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Abraham-372x450.jpg" caption="“But without faith it is impossible to please [God]…” (Hebrews 11:6)" >}}
 
 When God promised to give Abraham a son under impossible circumstances, Abraham believed that God would do exactly as He said. As a result of Abraham’s faith, God chose to attribute His own perfect righteousness to Abraham. Abraham’s deliberate belief in God’s promise became the standard by which all men would eventually have opportunity to be reconciled to their Creator. For this reason, the story of Abraham’s faith, as recorded in Genesis 15 and later expounded in Romans 4, represents the most foundational doctrine in all of Scripture. The great significance of Abraham’s faith is found in its result: imputed righteousness.
 

--- a/content/blog/2013-06-22-pillars-genesis-part-5-isaac.md
+++ b/content/blog/2013-06-22-pillars-genesis-part-5-isaac.md
@@ -15,7 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 After repeatedly promising Abraham that he would become a great nation, God fulfilled His word by giving Abraham a miracle son: Isaac. Given this background, one can only imagine the shock Abraham must have experienced when God commanded him to offer Isaac as a sacrifice. Not only was human sacrifice inconsistent with God’s previous commands regarding the sanctity of life, but this new directive seemed a contradiction of His promise to make Abraham the head of a great nation. How could there ever be such a nation if God’s promised child, Isaac, was to die?
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Isaac-349x450.jpg" caption="{: .article-image}" alt="Isaac" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Isaac-349x450.jpg" alt="Isaac" >}}
 
 Happily, faith in God’s direction was a lesson Abraham had learned well. Although overcome with sorrow, he set out immediately to obey. When all was ready and Isaac lay bound on the altar, Abraham lifted the knife to slay his son. At the last moment, God intervened and saved Isaac’s life, saying, *“…Lay not thine hand upon the lad, neither do thou any thing unto him: for now I know that thou fearest God, seeing thou hast not withheld thy son, thine only son from me.” (Genesis 22:12)* The test was over, and Abraham had passed.
 

--- a/content/blog/2013-06-29-pillars-genesis-part-6-jacob.md
+++ b/content/blog/2013-06-29-pillars-genesis-part-6-jacob.md
@@ -15,7 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 Jacob, the third of the great patriarchs, seemed an unlikely candidate to carry on the Abrahamic covenant, and yet his life demonstrated a personal relationship with God and a genuine walk of faith. Many aspects of Jacob’s life parallel that of Christ, but perhaps most significant is his inheritance.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Jacob-366x450.jpg" caption="{: .article-image}" alt="Jacob" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/05/Jacob-366x450.jpg" alt="Jacob" >}}
 
 On the night that Jacob wrestled with God, his name was changed to Israel, which also became the name of the nation God had revealed to Abraham years earlier. Jacob’s sons, who themselves became the heads of twelve tribes, were born into a glorious inheritance. From their lineage sprang a nation without equal on the earth: chosen of God, blessed of God, and known to the world as the people of God.
 

--- a/content/blog/2013-07-06-pillars-genesis-part-7-joseph.md
+++ b/content/blog/2013-07-06-pillars-genesis-part-7-joseph.md
@@ -15,7 +15,7 @@ The following is an excerpt taken from the twentieth and final lesson of *<a tit
 
 Joseph is often acclaimed as the most complete type of Christ found in the Old Testament. Entire charts have been constructed to show the numerous parallels between the life of Joseph and the life of our Savior. Of all Joseph’s qualities, his forgiveness of those who had been his persecutors is among the most Christ-like.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/07/Joseph-372x450.jpg" caption="{: .article-image}" alt="Joseph" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/07/Joseph-372x450.jpg" alt="Joseph" >}}
 
 As governor of Egypt, Joseph held the power to bring down crushing retribution against those who had hated, mocked and betrayed him. Amazingly, the Genesis record gives no indication that this course of action ever entered his mind.
 

--- a/content/blog/2015-09-01-gaining-ground.md
+++ b/content/blog/2015-09-01-gaining-ground.md
@@ -26,7 +26,7 @@ But what are five people among 300,000? Maybe not much in terms of numbers, but 
 
 Year after year, our stats continue to demonstrate that around 40% of all our Bible students enroll via word-of-mouth recommendations. These are people with whom we never had any direct contact who are now reaching out to us with a desire to study the Word of God. And as Paul reminds us in Romans 10:17, *“...faith cometh by hearing, and hearing by the word of God.”*
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/38-20150620_175158.png" caption="{: .article-image}" alt="38-20150620_175158" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/38-20150620_175158.png" alt="38-20150620_175158" >}}
 
 ### New Fronts
 
@@ -36,9 +36,7 @@ For example, James Slice, who served with us last year, has just returned from s
 
 Men from the CMO 2015 team are also moving forward in ministry. Emanuel Schrock has already conducted literature campaigns of his own since returning from Ukraine, and he is currently studying linguistics in preparation for mission work overseas. Adam Hall is getting ready to spend a year in northern Africa with a mission work that’s previously been established there. The Henderson family continues to build their *Bible First* course in Minnesota, and they’ve been involving other believers in outreaches in their community.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/36-CMO2015-Team-Photo.png" caption="{: .article-image .article-image--has-caption}" alt="The CMO 2015 team. From the left: Isaiah, Emanuel, Caleb, Ben, Nathan, Joshua, Joe, and Adam." >}}
-The CMO 2015 team. From the left: Isaiah, Emanuel, Caleb, Ben, Nathan, Joshua, Joe, and Adam.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/36-CMO2015-Team-Photo.png" caption="The CMO 2015 team. From the left: Isaiah, Emanuel, Caleb, Ben, Nathan, Joshua, Joe, and Adam." >}}
 
 As always, your prayer support is greatly needed! Pray not only for our team here in Ukraine, but for these who are entering new fields, proclaiming the Lord to men and women who do not yet know Him.
 
@@ -49,18 +47,10 @@ As always, your prayer support is greatly needed! Pray not only for our team her
 * Pray for the Day family as they prepare to travel to the US for the birth of their third child.
 * Pray our staff here as we deal with the large quantities of mail we are receiving from our Bible students.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/31-IMG_2016.png" caption="{: .article-image .article-image--has-caption}" alt="Nathan Day and Adam (a young man from the east of Ukraine) distribute Good and Evil books in a gypsy village in the Carpathians." >}}
-Nathan Day and Adam (a young man from the east of Ukraine) distribute Good and Evil books in a gypsy village in the Carpathians.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/31-IMG_2016.png" caption="Nathan Day and Adam (a young man from the east of Ukraine) distribute Good and Evil books in a gypsy village in the Carpathians." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/22-IMG_1321.png" caption="{: .article-image .article-image--has-caption}" alt="One of our larger film showings this year in the mountains" >}}
-One of our larger film showings this year in the mountains
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/22-IMG_1321.png" caption="One of our larger film showings this year in the mountains" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/25-CMO-Week-4-128.png" caption="{: .article-image .article-image--has-caption}" alt="Preaching the Gospel after the showing" >}}
-Preaching the Gospel after the showing
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/25-CMO-Week-4-128.png" caption="Preaching the Gospel after the showing" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/54-CMO-Wk-1-Mango-547.png" caption="{: .article-image .article-image--has-caption}" alt="Happy to have a Good and Evil book!" >}}
-Happy to have a Good and Evil book!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/54-CMO-Wk-1-Mango-547.png" caption="Happy to have a Good and Evil book!" >}}

--- a/content/blog/2015-12-28-meet-oleg.md
+++ b/content/blog/2015-12-28-meet-oleg.md
@@ -33,21 +33,15 @@ I’m excited about this new discipleship relationship with Oleg, and I would ap
 
 Here at the Steele household – which some of our Ukrainian friends warmly refer to as “Joshua’s Kingdom of Ladies” – there’s never a dull moment. Our little girls are steadily growing into little ladies, with Abigail in particular taking on more and more responsibility in the home.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/four-kids-on-a-couch.jpg" caption="{: .article-image .article-image--has-caption}" alt="From the left: Rebekah, Kathryn, Abigail, Hosanna. It’s hard to believe that Kathryn is nearly a year old!" >}}
-From the left: Rebekah, Kathryn, Abigail, Hosanna. It’s hard to believe that Kathryn is nearly a year old!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/four-kids-on-a-couch.jpg" caption="From the left: Rebekah, Kathryn, Abigail, Hosanna. It’s hard to believe that Kathryn is nearly a year old!" >}}
 
 Kelsie has crafted an excellent school program, and each morning finds the children happily (most of the time) seated at their desks, working through their assignments. In the afternoon, Abby and Rebekah have a few add-on subjects, such as typing lessons and a Bible class with Dad on Fridays.
 
 It’s hard to believe that Kathryn is nearly a year old! As I write this newsletter, she is just beginning to walk on her own. Her smiles bring no end of joy and laughter to our family!
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/bowling-girls.jpg" caption="{: .article-image .article-image--has-caption}" alt="On Thanksgiving, we all had a “ball” at the bowling alley!" >}}
-On Thanksgiving, we all had a “ball” at the bowling alley!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/bowling-girls.jpg" caption="On Thanksgiving, we all had a “ball” at the bowling alley!" >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/beka-abby-hands.jpg" caption="{: .article-image .article-image--has-caption}" alt="Our little girls are quickly becoming little ladies. :)" >}}
-Our little girls are quickly becoming little ladies. :)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/beka-abby-hands.jpg" caption="Our little girls are quickly becoming little ladies. :)" >}}
 
 ### Bible First
 
@@ -59,7 +53,7 @@ Trevor Brown and I are also continuing our programming efforts, working diligent
 
 Registration for next year’s Carpathian Mountain Outreach project is now open! CMO 2016 will begin on June 20, and the deadline for submitting applications is April 1. We’ve also put together a brand new CMO web site! Check out all the latest details at <a href="http://cmoproject.org/">www.cmoproject.org</a>. As always, we appreciate your prayers for this ministry, and for the young men who are even now making preparations to come.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" caption="{: .article-image}" alt="cmo-logo-full" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" alt="cmo-logo-full" >}}
 
 ### How You Can Pray
 

--- a/content/blog/2016-04-18-parenting-seminar.md
+++ b/content/blog/2016-04-18-parenting-seminar.md
@@ -34,17 +34,11 @@ Kelsie and I spent many hours on the couch, huddled around the laptop, typing ou
 
 Finally the day came. Speaking tag-team, in Ukrainian, for nearly seven hours turned about to be both exhausting and very rewarding. I believe God used the seminar to bless these families, and we pray that as a result, many Ukrainian children we will grow up to walk with Jesus.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/IMG_6940-e1460954875136.jpg" caption="{: .article-image .article-image--has-caption}" alt="It’s a great encouragement to see young families train up their children to follow the Lord." >}}
-It’s a great encouragement to see young families train up their children to follow the Lord.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/IMG_6940-e1460954875136.jpg" caption="It’s a great encouragement to see young families train up their children to follow the Lord." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/1934696_494868230702991_8116875278078929514_n.jpg" caption="{: .article-image .article-image--has-caption}" alt="Kelsie and I took turns speaking as we progressed through six sessions of material." >}}
-Kelsie and I took turns speaking as we progressed through six sessions of material.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/1934696_494868230702991_8116875278078929514_n.jpg" caption="Kelsie and I took turns speaking as we progressed through six sessions of material." >}}
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/IMG_6876.jpg" caption="{: .article-image .article-image--has-caption}" alt="The seminar lasted for the better part of a Saturday. It was exhausting but fun!" >}}
-The seminar lasted for the better part of a Saturday. It was exhausting but fun!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/IMG_6876.jpg" caption="The seminar lasted for the better part of a Saturday. It was exhausting but fun!" >}}
 
 ### CMO 2016
 
@@ -52,7 +46,7 @@ Summer is approaching once again, and with it our annual project: Carpathian Mou
 
 As always, there is much preparation to be done. In particular, we will be printing tens of thousands of tracts. There is housing to arrange, and there are film showings to schedule. Please pray that God would open doors before us as we labor, and that as a result of our efforts, multitudes would come to repentance in Christ.
 
-{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" caption="{: .article-image}" alt="cmo-logo-full" >}}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" alt="cmo-logo-full" >}}
 
 ### Bible First
 

--- a/content/blog/2017-03-29-meet-david-noble.md
+++ b/content/blog/2017-03-29-meet-david-noble.md
@@ -37,8 +37,7 @@ The name **Noble** is a reference to the Bereans, of whom Paul said in Acts 17:1
 
 It is our prayer for our son that even in his youth he will come to know and love the *heart of God* as he immerses himself in the study of the *Word of God*.
 
-![David Noble](//d21yo20tm8bmc2.cloudfront.net/2017/03/david-blanket-1024x575.jpg)
-{: .article-image}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/03/david-blanket-1024x575.jpg" alt="David Noble" >}}
 
 ## Good and Evil Update
 
@@ -48,8 +47,7 @@ Meanwhile, we have been in touch with the same printer who did Good and Evil las
 
 Please continue to pray for this project. Good and Evil has proven itself an effective ministry tool in Ukraine, and we're excited to make this new translation available in color. Much work remains, but God is moving and we're encouraged!
 
-![Good and Evil](//d21yo20tm8bmc2.cloudfront.net/2016/09/english-good-and-evil-bogo-special-1-240x450.jpg)
-{: .article-image}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/09/english-good-and-evil-bogo-special-1-240x450.jpg" alt="Good and Evil" >}}
 
 ## How You Can Pray
 

--- a/content/blog/2017-05-24-spring-family-photos.md
+++ b/content/blog/2017-05-24-spring-family-photos.md
@@ -15,10 +15,7 @@ Spring is here! And that means family photos. :) Our little David Noble is now 4
 
 The weather these days in L'viv has been gorgeous. Spring has undoubtedly sprung, and the greenery is everywhere. Last week, we planned a picnic at a large park here in the city called [Stryis'kyi Park](https://goo.gl/maps/VtZdwLKBaaw). Despite its location, once you enter the park you would never guess that you're in a city.
 
-[![Picnic in the park](https://d21yo20tm8bmc2.cloudfront.net/2017/picnic-and-photos-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/picnic-and-photos-2000w.jpg)
-{: .article-image .article-image--has-caption}
-What could be more fun that a picnic in the park on a sunny day? :)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/picnic-and-photos-2000w.jpg" caption="What could be more fun that a picnic in the park on a sunny day? :)" >}}
 
 In addition to the lovely weather, we were also blessed to have Bohdana with us. (She's the young lady who comes to our home a few times a week to help Kelsie.) During the photo shoot, she stood behind the camera and kept the attention of the little ones. You can thank her for the cheery smiles!
 
@@ -27,44 +24,21 @@ We hope you enjoy the pictures. God has blessed our family with five precious ch
 ---
 
 *Click on any photo to enlarge it.*
-{: .article-text--centered}
 
-[![Abigail Hope](https://d21yo20tm8bmc2.cloudfront.net/2017/abigail-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/abigail-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Abigail Hope, 11 yrs.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/abigail-2017-2000w.jpg" caption="Abigail Hope, 11 yrs." >}}
 
-[![Rebekah Praise](https://d21yo20tm8bmc2.cloudfront.net/2017/rebekah-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rebekah-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Rebekah Praise, 9 yrs.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rebekah-2017-2000w.jpg" caption="Rebekah Praise, 9 yrs." >}}
 
-[![Hosanna Joy](https://d21yo20tm8bmc2.cloudfront.net/2017/hosanna-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/hosanna-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Hosanna Joy, 6 yrs.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/hosanna-2017-2000w.jpg" caption="Hosanna Joy, 6 yrs." >}}
 
-[![Kathryn 1](https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn1-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn1-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Kathryn Grace, 2yrs.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn1-2017-2000w.jpg" caption="Kathryn Grace, 2yrs." >}}
 
-[![Abby and David](https://d21yo20tm8bmc2.cloudfront.net/2017/abby-david-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/abby-david-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Abby and David
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/abby-david-2000w.jpg" caption="Abby and David" >}}
 
-[![Hosanna, Rebekah, Abigail](https://d21yo20tm8bmc2.cloudfront.net/2017/3-eldest-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/3-eldest-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Hosanna, Rebekah, Abigail
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/3-eldest-2017-2000w.jpg" caption="Hosanna, Rebekah, Abigail" >}}
 
-[![Kathryn 2](https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn2-2017-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn2-2017-2000w.jpg)
-{: .article-image .article-image--has-caption}
-This little girl loves to pick flowers!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/kathryn2-2017-2000w.jpg" caption="This little girl loves to pick flowers!" >}}
 
 **Lo, children are an heritage of the LORD:  
 and the fruit of the womb is his reward.  
 (Psalms 127:3)**
-{: .article-text--centered}

--- a/content/blog/2017-06-13-bible-first-kids.md
+++ b/content/blog/2017-06-13-bible-first-kids.md
@@ -20,24 +20,15 @@ On April 8, 2017, our eldest daughter [Abigail was baptized](https://youtu.be/uK
 
 I agreed and our first class was held on the Sunday after Easter. I brought a short message for the church during which I introduced *Bible First*, giving an overview of the course and explaining our goals to the parents. I then invited all the older kids up on the stage and gave them three challenges on which to focus as we started our new class: 1. Set aside childish things (1 Cor. 13:11), 2. Build a Godly reputation (Prov. 20:11), and 3. Seek the Lord in their youth (Eccl. 12:1). This done, we prayed and exited the main auditorium together.
 
-[![The class receives three challenges in front of the congregation on our first day.](https://d21yo20tm8bmc2.cloudfront.net/2017/challenge-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/challenge-1440w.jpg)
-{: .article-image .article-image--has-caption}
-The class receives three challenges in front of the congregation on our first day.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/challenge-1440w.jpg" caption="The class receives three challenges in front of the congregation on our first day." >}}
 
 I was glad that Pastor Vladyslav was joining me to help lead the class. Most of my Bible teaching experience has been with adults, and I confess I was bit nervous with the idea of committing to lead a weekly kids' class. That first day, however, laid my fears to rest. We got right down to business, reading through a good portion of Lesson 1. I also introduced the kids to "sword drills", wherein everyone practices finding various passages in their Bibles as quickly as possible. Whoever finds the passage first reads it aloud. He then comes to the front and leads the next drill.
 
-[![Danylo Medyakovsky (16) takes a turn leading the class in sword drills.](https://d21yo20tm8bmc2.cloudfront.net/2017/sword-drills-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/sword-drills-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Danylo Medyakovsky (16) takes a turn leading the class in sword drills.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/sword-drills-2000w.jpg" caption="Danylo Medyakovsky (16) takes a turn leading the class in sword drills." >}}
 
 In addition to reading through *Bible First* lessons in class, I’ve also started taking the group into the main service about once a month. Our church has two messages each Sunday: a shorter "intro" message and a main message. Our class will sometimes sit in for the intro message, and all the kids take notes. We then move downstairs to our classroom and discuss what was taught.
 
-[![The kids takes notes while listening to a message in the main service.](https://d21yo20tm8bmc2.cloudfront.net/2017/taking-notes-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/taking-notes-2000w.jpg)
-{: .article-image .article-image--has-caption}
-The kids takes notes while listening to a message in the main service.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/taking-notes-2000w.jpg" caption="The kids takes notes while listening to a message in the main service." >}}
 
 On several occasions, God has opened the door for me to have one-on-one conversations with various kids. These have proven to be good opportunities to get better acquainted and to encourage them to make wise decisions.
 
@@ -52,8 +43,7 @@ We’ve now finished Lesson 1 of *Bible First*, and we’re about halfway throug
 
 Have you wondered whether or not *Bible First* could help you teach your kids about the Lord? Give it a try! While some of the material is definitely advanced, an attentive teacher or parent can easily fill in the gaps. I think you’ll find, as we have, that reading through *Bible First* with your children will prompt much needed conversations about the Lord. What an exciting privilege to introduce these young ones to Christ!
 
-[Learn more about Bible First](https://getbiblefirst.com/){: .button}
-{: .article-button}
+{{< button href="https://getbiblefirst.com/" text="Learn more about Bible First" external=true >}}
 
 ### Good and Evil Update
 

--- a/content/blog/2017-06-29-lviv-rope-course.md
+++ b/content/blog/2017-06-29-lviv-rope-course.md
@@ -17,50 +17,23 @@ Last Sunday, I took all the kids from our [Bible First class](http://OFReport.co
 
 Please keep praying for our class. We're approaching the end of [Lesson 2](https://getbiblefirst.com/lessons/lesson2/) in Bible First. The kids are learning a lot, and I'm very grateful for the opportunity we have to study this material together.
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-09-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-09-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Anya Medyakovska and her brother Danylo get suited up with a harness and helmet.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-09-2000w.jpg" caption="Anya Medyakovska and her brother Danylo get suited up with a harness and helmet." >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-07-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-07-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Anya and Maria
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-07-2000w.jpg" caption="Anya and Maria" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-08-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-08-2000h.jpg)
-{: .article-image .article-image--has-caption}
-Matthew and Mark
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-08-2000h.jpg" caption="Matthew and Mark" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Also joining us was Ralph Villeneuve from Quebec, Canada. He's serving with ETO this summer as an intern. More about Ralph in a future blog post. :)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-2000w.jpg" caption="Also joining us was Ralph Villeneuve from Quebec, Canada. He's serving with ETO this summer as an intern. More about Ralph in a future blog post. :)" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-06-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-06-2000h.jpg)
-{: .article-image .article-image--has-caption}
-Mark is ready to go!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-06-2000h.jpg" caption="Mark is ready to go!" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-03-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-03-2000w.jpg)
-{: .article-image .article-image--has-caption}
-It may look easy, but this course makes you work for every step!
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-03-2000w.jpg" caption="It may look easy, but this course makes you work for every step!" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-05-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-05-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Pastor Vladyslav stabilizes the steps as Stas works his way across.
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-05-2000w.jpg" caption="Pastor Vladyslav stabilizes the steps as Stas works his way across." >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-02-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-02-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Crossing to the finish
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-02-2000w.jpg" caption="Crossing to the finish" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-10-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-10-2000w.jpg)
-{: .article-image .article-image--has-caption}
-Here's one for the refrigerator! Please remember to pray for our Bible First Kids in L'viv. Clockwise from the back row: Timothy, Joshua, Lisa, Danylo, Pastor Vladyslav, Anya, Maria, Anya, Akim, Anya, Mark, Stas, Matthew, Tolik. Yeah, we have a lot of Anya's in our group! ;)
-{: .caption-text .article-image__caption}
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-10-2000w.jpg" caption="Here's one for the refrigerator! Please remember to pray for our Bible First Kids in L'viv. Clockwise from the back row: Timothy, Joshua, Lisa, Danylo, Pastor Vladyslav, Anya, Maria, Anya, Akim, Anya, Mark, Stas, Matthew, Tolik. Yeah, we have a lot of Anya's in our group! ;)" >}}
 
 ### The Grand Finale
 

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -175,7 +175,7 @@ links to the relevant PRD document for full requirements.
 - [x] Vue components converted to Hugo shortcodes
 - [x] Duplicate tag consolidated (`good-and-evil`)
 - [x] Validation pass: no remaining `<article-` patterns
-- [ ] Legacy WordPress articles reviewed and fixed
+- [~] Legacy WordPress articles reviewed and fixed
 - [x] Static pages created
 - [ ] Data files migrated (`authors.json`, `archives.json`)
 

--- a/scripts/strip_legacy_ials.rb
+++ b/scripts/strip_legacy_ials.rb
@@ -49,7 +49,12 @@ NO_CAPTION_IAL  = "{: .article-image}"
 CAPTION_IAL     = "{: .caption-text .article-image__caption}"
 CENTER_IAL      = "{: .article-text--centered}"
 
-# Quote + escape a value for a Hugo shortcode parameter, matching migrate.rb.
+# A figure caption= that absorbed an article-image IAL instead of real text.
+BOGUS_CAPTION_ATTR = /caption="(\{:[^"]*)"/
+
+# Quote + escape a value for a Hugo shortcode parameter. Keep in sync with
+# Migrate.quote — the Go interpreted-string escaping must be identical so swept
+# captions match freshly-migrated ones.
 def quote(value)
   escaped = value.to_s.gsub("\\") { "\\\\" }.gsub('"') { '\\"' }
   %("#{escaped}")
@@ -65,11 +70,15 @@ end
 # ![alt](url). Protocol-relative URLs are normalized to https, matching
 # migrate.rb. Returns nil for anything that is not a lone image line.
 def parse_md_image(line)
-  if (m = line.match(%r{\A\[!\[([^\]]*)\]\([^)]*\)\]\(([^)]*)\)\z}))
-    [m[1], m[2].sub(%r{\A//}, "https://")]
-  elsif (m = line.match(%r{\A!\[([^\]]*)\]\(([^)]*)\)\z}))
-    [m[1], m[2].sub(%r{\A//}, "https://")]
-  end
+  alt, url =
+    if (m = line.match(%r{\A\[!\[([^\]]*)\]\([^)]*\)\]\(([^)]*)\)\z}))
+      [m[1], m[2]]
+    elsif (m = line.match(%r{\A!\[([^\]]*)\]\(([^)]*)\)\z}))
+      [m[1], m[2]]
+    end
+  return unless url
+
+  [alt, url.sub(%r{\A//}, "https://")]
 end
 
 def strip_file(path)
@@ -85,22 +94,23 @@ def strip_file(path)
     # Rule A / B: figure shortcode that absorbed an IAL into caption=. A handful
     # of figure lines carry stray leading whitespace from the source; matching
     # the lstripped line normalizes the indent away on rewrite.
-    if stripped.start_with?("{{< figure ") && stripped =~ /caption="(\{:[^"]*)"/
-      ial = Regexp.last_match(1)
+    if stripped.start_with?("{{< figure ") && (m = stripped.match(BOGUS_CAPTION_ATTR))
+      ial = m[1]
 
       if ial.include?("--has-caption") && caption_line?(lines[i + 1]) &&
          lines[i + 2]&.strip == CAPTION_IAL
         # Rule A: promote the displaced caption, drop alt + the two stray lines.
         real = lines[i + 1].rstrip
-        rebuilt = stripped.sub(/caption="\{:[^"]*"/, "caption=#{quote(real)}")
+        rebuilt = stripped.sub(BOGUS_CAPTION_ATTR, "caption=#{quote(real)}")
                           .sub(/ alt="(?:[^"\\]|\\.)*"/, "")
         out << rebuilt
         i += 3
         changed = true
         next
       else
-        # Rule B: no real caption — just drop the bogus caption= attribute.
-        out << stripped.sub(/ caption="\{:[^"]*"/, "")
+        # Rule B: no real caption — drop the bogus attribute (and its leading
+        # space, so the figure line doesn't keep a double space).
+        out << stripped.sub(/ #{BOGUS_CAPTION_ATTR}/, "")
         i += 1
         changed = true
         next
@@ -110,11 +120,11 @@ def strip_file(path)
     # Rule E: un-converted markdown image (linked or bare) + standalone
     # article-image IAL.
     parsed = parse_md_image(stripped)
-    if parsed &&
-       (lines[i + 1]&.strip == HAS_CAPTION_IAL || lines[i + 1]&.strip == NO_CAPTION_IAL)
+    nxt    = lines[i + 1]&.strip
+    if parsed && (nxt == HAS_CAPTION_IAL || nxt == NO_CAPTION_IAL)
       alt, src = parsed
 
-      if lines[i + 1].strip == HAS_CAPTION_IAL && caption_line?(lines[i + 2]) &&
+      if nxt == HAS_CAPTION_IAL && caption_line?(lines[i + 2]) &&
          lines[i + 3]&.strip == CAPTION_IAL
         # Has a real caption — promote it and drop the placeholder alt.
         real = lines[i + 2].rstrip

--- a/scripts/strip_legacy_ials.rb
+++ b/scripts/strip_legacy_ials.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# One-off content sweep for issue #129: strip the leftover kramdown/Middleman
+# inline attribute lists (IALs) that the migration carried in raw, and restore
+# the real image captions that were displaced in the process.
+#
+# Runs against the committed #136 baseline in content/blog/. Idempotent: once a
+# file is clean none of the patterns match, so re-running is a no-op. The
+# migration's skip-if-exists guard then preserves these hand-edits.
+#
+# Four IAL shapes are handled (counts reconcile exactly against the audit):
+#
+#   A. Figure shortcode whose caption= absorbed a "has-caption" IAL; the real
+#      caption sits on the next line, trailed by a caption IAL:
+#        {{< figure src="…" caption="{: .article-image .article-image--has-caption}" alt="X" >}}
+#        The real caption text.
+#        {: .caption-text .article-image__caption}
+#      -> caption set to the real text; alt dropped (the shortcode falls back to
+#         caption); the displaced text line and trailing IAL removed.
+#
+#   B. Figure shortcode whose caption= absorbed a plain "{: .article-image}" IAL
+#      and that had no real caption at all:
+#        {{< figure src="…" caption="{: .article-image}" alt="X" >}}
+#      -> the bogus caption= attribute is removed; alt is kept.
+#
+#   E. A markdown linked-image that survived migration un-converted, followed by
+#      a standalone article-image IAL (and optionally a caption + caption IAL):
+#        [![Description](…thumb)](…full)
+#        {: .article-image .article-image--has-caption}
+#        The real caption text.
+#        {: .caption-text .article-image__caption}
+#      -> rewritten to {{< figure src="<full>" caption="<real text>" >}} so it
+#         renders with the same Cloudinary/lightbox treatment as every other
+#         figure. The placeholder alt is dropped.
+#
+#   D. A centering IAL attached to a verse / note:
+#        …text…
+#        {: .article-text--centered}
+#      -> the IAL line is removed (the text remains as a normal paragraph).
+#
+# The "{: .article-button}" / inline "{: .button}" one-off (Rule F) is a single
+# hand-edit in 2017-06-13-bible-first-kids.md, not handled here.
+
+BLOG_DIR = File.expand_path("../content/blog", __dir__)
+
+HAS_CAPTION_IAL = "{: .article-image .article-image--has-caption}"
+NO_CAPTION_IAL  = "{: .article-image}"
+CAPTION_IAL     = "{: .caption-text .article-image__caption}"
+CENTER_IAL      = "{: .article-text--centered}"
+
+# Quote + escape a value for a Hugo shortcode parameter, matching migrate.rb.
+def quote(value)
+  escaped = value.to_s.gsub("\\") { "\\\\" }.gsub('"') { '\\"' }
+  %("#{escaped}")
+end
+
+# A non-blank line that is not itself an IAL — i.e. a real caption.
+def caption_line?(line)
+  line && !line.strip.empty? && !line.strip.start_with?("{:")
+end
+
+# Parse a markdown image line into [alt, src]. Handles the linked form
+# [![alt](thumb)](full) — full-size target wins as src — and the bare form
+# ![alt](url). Protocol-relative URLs are normalized to https, matching
+# migrate.rb. Returns nil for anything that is not a lone image line.
+def parse_md_image(line)
+  if (m = line.match(%r{\A\[!\[([^\]]*)\]\([^)]*\)\]\(([^)]*)\)\z}))
+    [m[1], m[2].sub(%r{\A//}, "https://")]
+  elsif (m = line.match(%r{\A!\[([^\]]*)\]\(([^)]*)\)\z}))
+    [m[1], m[2].sub(%r{\A//}, "https://")]
+  end
+end
+
+def strip_file(path)
+  lines   = File.read(path).split("\n", -1)
+  out     = []
+  changed = false
+  i       = 0
+
+  while i < lines.length
+    line    = lines[i]
+    stripped = line.lstrip
+
+    # Rule A / B: figure shortcode that absorbed an IAL into caption=. A handful
+    # of figure lines carry stray leading whitespace from the source; matching
+    # the lstripped line normalizes the indent away on rewrite.
+    if stripped.start_with?("{{< figure ") && stripped =~ /caption="(\{:[^"]*)"/
+      ial = Regexp.last_match(1)
+
+      if ial.include?("--has-caption") && caption_line?(lines[i + 1]) &&
+         lines[i + 2]&.strip == CAPTION_IAL
+        # Rule A: promote the displaced caption, drop alt + the two stray lines.
+        real = lines[i + 1].rstrip
+        rebuilt = stripped.sub(/caption="\{:[^"]*"/, "caption=#{quote(real)}")
+                          .sub(/ alt="(?:[^"\\]|\\.)*"/, "")
+        out << rebuilt
+        i += 3
+        changed = true
+        next
+      else
+        # Rule B: no real caption — just drop the bogus caption= attribute.
+        out << stripped.sub(/ caption="\{:[^"]*"/, "")
+        i += 1
+        changed = true
+        next
+      end
+    end
+
+    # Rule E: un-converted markdown image (linked or bare) + standalone
+    # article-image IAL.
+    parsed = parse_md_image(stripped)
+    if parsed &&
+       (lines[i + 1]&.strip == HAS_CAPTION_IAL || lines[i + 1]&.strip == NO_CAPTION_IAL)
+      alt, src = parsed
+
+      if lines[i + 1].strip == HAS_CAPTION_IAL && caption_line?(lines[i + 2]) &&
+         lines[i + 3]&.strip == CAPTION_IAL
+        # Has a real caption — promote it and drop the placeholder alt.
+        real = lines[i + 2].rstrip
+        out << "{{< figure src=#{quote(src)} caption=#{quote(real)} >}}"
+        i += 4
+      else
+        # No caption — keep the alt when it carries real text.
+        parts = ["src=#{quote(src)}"]
+        parts << "alt=#{quote(alt)}" unless alt.strip.empty?
+        out << "{{< figure #{parts.join(' ')} >}}"
+        i += 2
+      end
+      changed = true
+      next
+    end
+
+    # Rule D: drop a standalone centering IAL.
+    if line.strip == CENTER_IAL
+      i += 1
+      changed = true
+      next
+    end
+
+    out << line
+    i += 1
+  end
+
+  return false unless changed
+
+  File.write(path, out.join("\n"))
+  true
+end
+
+edited = Dir.glob(File.join(BLOG_DIR, "*.md")).sort.select { |path| strip_file(path) }
+puts "Stripped legacy IALs from #{edited.length} files:"
+edited.each { |path| puts "  #{File.basename(path)}" }


### PR DESCRIPTION
## Summary

- Strips every leftover kramdown/Middleman **inline attribute list (IAL)** from the migrated blog articles and restores the real image captions that the migration displaced.
- Fixes a visible rendering bug: figures whose `caption=` had absorbed `{: .article-image .article-image--has-caption}` were rendering that literal text as the caption, with the real caption stranded below as a stray paragraph + another literal `{: .caption-text …}` line.
- Delivers **slice 1 of the multi-PR #129** (the kramdown-IAL acceptance criterion). The issue stays open for the remaining slices.

## Changes

A committed, idempotent sweep (`scripts/strip_legacy_ials.rb`) clears all IALs across 46 files, plus one hand edit. Five legacy variants handled:

| Rule | Case | Treatment |
|------|------|-----------|
| A | figure absorbed a `--has-caption` IAL | promote the body-line caption (authoritative — often a better, distinct version of the `alt`), drop the now-redundant `alt` |
| B | figure absorbed a plain `{: .article-image}` IAL, no caption | drop the bogus `caption=`, keep `alt` |
| E | un-converted markdown images (linked + bare) left with standalone IALs | rewrite to `{{< figure >}}` (full-size src, `//` → `https://`) for Cloudinary/lightbox parity |
| D | `{: .article-text--centered}` on verses/notes | strip the IAL, keep the text (re-centering deferred — a presentation concern) |
| F | lone button IAL (`bible-first-kids`) | convert to the `button` shortcode (external link) |

- `scripts/strip_legacy_ials.rb` — the sweep tool (committed for an auditable, re-runnable transform, like `migrate.rb`).
- 46 `content/blog/*.md` files — the sweep's output (+214 / −612).
- `docs/prd/ROADMAP.md` — marked "Legacy WordPress articles reviewed and fixed" as in progress (`[~]`).

## Testing

- [x] `hugo --gc --minify` builds clean (289 pages, no errors/warnings)
- [x] Zero IALs remain in content; **no IAL text leaks into any built page**
- [x] Escaped-quote captions render correctly (smartypants → curly quotes); Abraham's Hebrews verse verbatim
- [x] Rule E figures render via Cloudinary fetch with normalized `https://` src
- [x] Spot-checked across eras: 2009 (WordPress-origin), 2013 (Pillars), 2017 (Middleman: rope-course, david-noble, button)
- [x] Script is idempotent (2nd run edits 0 files); refactored script reproduces the sweep byte-for-byte
- [x] **Re-runnable guard:** a non-force `migrate.rb` re-run skips all 223 files — content byte-identical, hand-edits preserved

## Notes

- **Fix-in-content, not in `migrate.rb`.** The migration issues (#126/#127) are closed and the re-runnable guard explicitly frames the deliverable as hand-edits protected by skip-if-exists. The committed sweep keeps the transform auditable/reproducible without re-opening the migration.
- **The body-line is authoritative over `alt`.** In many figures the real caption differs meaningfully from the migration-derived `alt` (e.g. `&quot;` entities vs real quotes, a typo'd "Denise left has" vs "Denise has", "kelsie" vs a full sentence), so the sweep pulls captions from the body line.

**Part of #129** — this PR does the kramdown-IAL slice only. HTML-entity decoding, the residual raw-HTML review, and the alt/caption spot pass follow in separate PRs, so #129 intentionally stays open (no closing keyword).
