### PR TITLE
fix(single): cap cover hero height so article text stays visible on large screens

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -21,10 +21,16 @@
           data-gallery="article"
           {{- with $.Params.caption }} data-description="{{ partial "caption-plain.html" . }}"{{ end }}
         >
+          {{- /* Fixed heights (not min-h): on an <img>, min-height is only a floor,
+                 so w-full lets the image grow to its intrinsic aspect-ratio height
+                 and overflow the viewport on large/wide screens, hiding the caption
+                 and title. The original used a background <div> whose height equalled
+                 its min-height; a fixed height + object-cover reproduces that cap so
+                 text below the hero always stays in view (#160). */ -}}
           <img
             src="{{ $hero }}"
             alt="{{ $.Title }}"
-            class="block w-full object-cover min-h-[250px] sm:min-h-[450px] md:min-h-[500px] lg:min-h-[600px] xl:min-h-[75vh]"
+            class="block w-full object-cover h-[250px] sm:h-[450px] md:h-[500px] lg:h-[600px] xl:h-[75vh]"
             loading="eager"
           >
         </a>


### PR DESCRIPTION
## Summary

On single blog posts, the cover hero overflowed the viewport on large/wide screens, hiding the caption and title below the fold (sometimes filling the entire screen) — a regression from the original Nuxt site, which capped the hero at ~75vh so text always signalled "scroll to read."

## Root cause

The original hero (`_slug.vue`) is a background-image `<div>` with `min-h-…`; an empty div's height equals its `min-height`, so the hero was always capped and `bg-cover` cropped the photo. Hugo switched to a real `<img>` (for GLightbox, #110/#111) but kept `min-h-…`. On an `<img>`, `min-height` is only a floor — with `w-full` and no cap, the image grows to its intrinsic aspect-ratio height. Measured: **1117px (89vh)** on a 2000×1250 viewport, with the `<h1>` at `top: 1365px`, below the fold.

## Fix

One template change in `layouts/blog/single.html` — hero `<img>` from `min-h-[…]` to fixed `h-[…]` per breakpoint, keeping `object-cover`:

```diff
- class="block w-full object-cover min-h-[250px] sm:min-h-[450px] md:min-h-[500px] lg:min-h-[600px] xl:min-h-[75vh]"
+ class="block w-full object-cover h-[250px] sm:h-[450px] md:h-[500px] lg:h-[600px] xl:h-[75vh]"
```

A fixed-height box + `object-cover` reproduces the original's capped `bg-cover` behaviour: the box is a fixed height and the photo crops to fill it.

## Verification

Measured the rendered hero across breakpoints on the live build:

| Breakpoint | Viewport | Hero height | Result |
|---|---|---|---|
| base | 500×844 | 250px | capped ✅ |
| sm | 700×900 | 450px | capped ✅ |
| md | 768×1024 | 500px | capped ✅ |
| lg | 1200×800 | 600px | capped ✅ |
| xl | 1440×900 | 675px (75vh) | capped ✅ |
| xl (large) | 2000×1250 | 938px (75vh) | caption + title in view ✅ |
| xl (huge) | 2560×1267 | 950px (75vh) | caption + title in view ✅ |

`object-cover` crops without distortion at every step; no regression to the no-cover path. `hugo --gc --minify` clean (289 pages).

Closes #160. Relates to #135 (cover display) and #120 (hero restoration).
