### PR TITLE
feat(404): add custom error page with site chrome and CTAs

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,29 @@
+{{ define "main" }}
+  {{/* Custom 404. Inherits the header/footer chrome from baseof.html via the
+       "main" block. Deliberately NOT the standard page-shell header — the big
+       "Page not found" reads as an error state, not a content page. Matches the
+       page-shell vertical rhythm (py-24 sm:py-32) and the site's design tokens
+       (font-header, text-ink, brand-blue buttons) for visual consistency. */}}
+  <section class="px-6 py-24 text-center sm:py-32 lg:px-8">
+    <div class="mx-auto max-w-2xl">
+      <p class="font-header text-base font-semibold text-blue-700">404</p>
+      <h1 class="mt-4 font-header text-5xl font-bold leading-tight tracking-tight text-pretty text-ink sm:text-6xl">
+        Page not found
+      </h1>
+      <p class="mt-6 text-lg text-pretty text-gray-600 sm:text-xl">
+        Sorry, we couldn’t find that page. It may have moved, or the link you
+        followed may be out of date.
+      </p>
+      <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
+        <a href="{{ .Site.Home.RelPermalink }}"
+           class="inline-flex items-center px-6 py-3 text-base {{ partial "button-classes.html" (dict "variant" "filled") }}">
+          Back home
+        </a>
+        <a href="{{ "/blog/" | relURL }}"
+           class="inline-flex items-center px-6 py-3 text-base {{ partial "button-classes.html" (dict "variant" "outline") }}">
+          Browse the blog
+        </a>
+      </div>
+    </div>
+  </section>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds a custom `layouts/404.html` so unknown paths render an on-brand error page instead of Netlify's generic 404 — a real gap given the migration's redirect-map risk (#150 §2): a missed old URL lands here.
- Inherits the site header/footer via the `{{ define "main" }}` block on `baseof.html`, and reuses existing design tokens (page-shell vertical rhythm, `font-header`/`text-ink`, the shared `button-classes` partial) so it matches the rest of the site.
- Provides clear recovery navigation: a filled **Back home** CTA and an outline **Browse the blog** CTA.

## Changes

- `layouts/404.html` (new) — centered error hero: "404" eyebrow, "Page not found" heading, brief copy, and the two CTAs.

## Testing

- [x] `hugo --gc --minify` builds clean; `public/404.html` is produced with full header/footer chrome.
- [x] Rendered `<title>` is `404 Page not found | …`; robots `index,follow`; CTAs resolve to `/` and `/blog/`.
- [x] Visual check via `hugo server` at 1280×900 — on-brand render; unmatched paths return this page (404 status).
- [ ] Netlify deploy-preview confirmation that `404.html` is served for unknown paths — **this PR's preview is where that gets confirmed.**

## Notes

- Hugo's 404 template supports base templates, so the page automatically picks up head / header / footer / analytics via `baseof.html`. Confirmed against current Hugo docs (Context7) before implementing.
- No `netlify.toml` change needed — Netlify serves `public/404.html` for unmatched routes with zero config.
- Epic #150 §6 "404 page exists and is helpful" flips on merge + deploy.

Closes #167

https://claude.ai/code/session_01Sfv3qMEnRhGdno1C4esQ4E
