### PR TITLE
docs(prd): descope authors.json from migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ hugo new content blog/YYYY-MM-DD-slug-title.md
 
 - Blog articles live in `content/blog/` with YAML frontmatter
 - Static pages (`family.md`, `ministry.md`, etc.) live in `content/` root
-- Data files (`authors.json`, `archives.json`) in `data/`
+- Data files (`archives.json`) in `data/`
 - Tag taxonomy is the only taxonomy (`[taxonomies] tag = "tags"`)
 
 ### Article Frontmatter Schema

--- a/docs/prd/03-site-structure.md
+++ b/docs/prd/03-site-structure.md
@@ -27,7 +27,6 @@ ofreport.com/
 │   ├── subscribe.md             # Newsletter signup page
 │   └── thank-you.md             # Contact form success page
 ├── data/
-│   ├── authors.json             # Author information
 │   └── archives.json            # PDF archive listing by year
 ├── docs/
 │   └── tailwind_plus/           # Tailwind Plus reference snippets (gitignored)

--- a/docs/prd/CHANGELOG.md
+++ b/docs/prd/CHANGELOG.md
@@ -34,6 +34,14 @@ Each entry records one deviation or decision:
 
 ## Entries
 
+### 2026-06-22 — `docs/prd/03-site-structure.md`, `docs/prd/appendix.md`, `docs/prd/ROADMAP.md`, `CLAUDE.md`
+
+**What changed:** Descoped `authors.json` from the migration. The PRD listed it as a data file to migrate (`appendix.md` envisioned author name/bio/avatar accessed via `site.Data.authors`), but it is not being brought over to the Hugo site. `archives.json` migration is unaffected (done, byte-identical to the Nuxt source).
+
+**Why:** The data file's original purpose was to render each byline as a live link to that author's homepage/profile. The blog has three authors — Joshua and Kelsie Steele (the site owners) and Raphaël Villeneuve (a single guest post years ago, who has no link). Self-linking the owners' bylines to `/contact` is redundant, and the richer author-profile capability the PRD imagined (bio/avatar blocks) is premature abstraction for this author set. Nothing in the Hugo build reads the file: the byline renders from the frontmatter `author` string (`.Params.author`) as plain text in `single.html` / `article-card.html`, with no `site.Data.authors` lookup anywhere, and the file was never copied into `data/`. So this is a clean descope, not a removal of working functionality — an authors data file is trivial to add back if the author base ever grows.
+
+**Category:** Pivot
+
 ### 2026-06-22 — `layouts/partials/cloudinary-url.html`, `content/blog/2012-11-04-today-fly.md`
 
 **What changed:** Graceful-display pass for no-cover / small-image legacy articles (issue #135). Verification found the requirement was already met by the templates, which faithfully ported the original Nuxt site's `v-if="cover"` guards: the single-article hero and preview-card image both omit cleanly when `cover` is absent (no broken hero, no 404), OG/Twitter fall back to `params.ogImage`, and the RSS `<enclosure>` is omitted. The documented no-cover fallback is therefore **omit** (parity with the original), not a neutral default header. Two hardening changes applied: (1) the display Cloudinary presets (`featured`, `regular`, `hero`) switched from `c_scale` to `c_limit` so an intrinsically small image is never upscaled; (2) the one broken relative-path cover (`2012-11-04-today-fly`) repointed to its CloudFront URL so it loads via Cloudinary fetch.

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -177,7 +177,7 @@ links to the relevant PRD document for full requirements.
 - [x] Validation pass: no remaining `<article-` patterns
 - [x] Legacy WordPress articles reviewed and fixed (#129 content, #135 display, #160 hero cap)
 - [x] Static pages created
-- [ ] Data files migrated (`authors.json`, `archives.json`)
+- [x] Data files migrated (`archives.json`; `authors.json` descoped — see CHANGELOG 2026-06-22)
 
 **Key learning:** Migration scripting, validation, content testing
 

--- a/docs/prd/appendix.md
+++ b/docs/prd/appendix.md
@@ -22,10 +22,10 @@
 
 ## Existing Data Files
 
-These files from the current site should be migrated to the Hugo `data/`
-directory:
+This file from the current site is migrated to the Hugo `data/` directory:
 
-| File            | Purpose                        | Hugo Usage                                 |
-| --------------- | ------------------------------ | ------------------------------------------ |
-| `authors.json`  | Author name, bio, avatar       | Data file accessed via `site.Data.authors` |
-| `archives.json` | PDF newsletter archive by year | Data file for `/archives/` page template   |
+| File            | Purpose                        | Hugo Usage                               |
+| --------------- | ------------------------------ | ---------------------------------------- |
+| `archives.json` | PDF newsletter archive by year | Data file for `/archives/` page template |
+
+> `authors.json` was **descoped** (see `CHANGELOG.md`, 2026-06-22) — the byline renders from the frontmatter `author` string, not a data file.


### PR DESCRIPTION
## Summary

- Descopes `authors.json` from the migration — it is not being brought over to the Hugo site.
- Records the decision as a PRD deviation (`CHANGELOG.md`) and updates every PRD/CLAUDE reference so the docs stop implying the file will be migrated.
- `archives.json` migration is unaffected (already done, byte-identical to the Nuxt source).

## Why

The data file's original purpose was to render each byline as a live link to that author's homepage/profile. The blog has three authors — Joshua and Kelsie Steele (the site owners) and Raphaël Villeneuve (one guest post years ago, no link). Self-linking the owners' bylines to `/contact` is redundant, and the richer author-profile capability the PRD imagined (name/bio/avatar via `site.Data.authors`) is premature abstraction for this author set.

Confirmed it's a **clean descope, not a removal of working functionality**: nothing in the Hugo build reads the file. The byline renders from the frontmatter `author` string (`.Params.author`) as plain text in `single.html` / `article-card.html`, there's no `site.Data.authors` lookup anywhere, the migration script doesn't touch it, and the file was never copied into `data/`. An authors data file is trivial to add back if the author base ever grows.

## Changes

- `docs/prd/CHANGELOG.md` — new deviation entry (Pivot), 2026-06-22.
- `docs/prd/03-site-structure.md` — drop `authors.json` from the `data/` tree.
- `docs/prd/appendix.md` — remove the `authors.json` table row; add a descope note.
- `docs/prd/ROADMAP.md` — mark the data-files item done (`archives.json` migrated; `authors.json` descoped).
- `CLAUDE.md` — architecture note now lists only `archives.json`.

## Testing

- [x] `npm run lint:md` — 0 errors.
- [x] Doc-only; no template/build impact (no code reads the file).

Relates to #150 §1 (data-files content gate) — no closing keyword; the epic stays open.

https://claude.ai/code/session_01Sfv3qMEnRhGdno1C4esQ4E
