### PR TITLE
chore: verify launch integrations on deploy preview

### DIFF
--- a/docs/integrations-check.md
+++ b/docs/integrations-check.md
@@ -1,7 +1,7 @@
 # Integrations Verification
 
 **Issue:** #179 (launch-readiness epic #150 §4)
-**Last run:** 2026-06-23 — RSS feed ✅ validated; Mailchimp / Netlify Forms / Umami pending (see status).
+**Last run:** 2026-06-23 — RSS ✅ PASS (incl. Mailchimp render, #180/#181); Netlify Forms detection ✅ (HTML evidence); Mailchimp signup submit + Netlify dashboard round-trip pending Joshua; Umami deferred to cutover.
 
 A pre-cutover gate for the site's four external integrations. Like the URL-parity (`docs/url-parity/`) and link-check (`docs/link-check.md`) gates, it proves each integration rather than assuming it. **Only two integrations can be fully verified before cutover** — the other two are production-only by design and are confirmed on cutover day (#150 §7 steps 6–7). This doc records the evidence and keeps that boundary explicit.
 
@@ -9,9 +9,9 @@ A pre-cutover gate for the site's four external integrations. Like the URL-parit
 
 | Integration | When verifiable | Status |
 | --- | --- | --- |
-| **RSS feed** (Phase 9) | Now (preview) | ✅ **PASS** — well-formed, 10 items, all cover enclosures resolve |
+| **RSS feed** (Phase 9) | Now (preview) | ✅ **PASS** — well-formed, 10 items + `content:encoded`, all 20 image URLs resolve; Mailchimp render confirmed (#180/#181) |
 | **Mailchimp signup forms** (Phase 12) | Now (preview) | ⬜ Pending account-side submit |
-| **Netlify Forms** detection + honeypot (Phase 11) | Now (preview, partial) | ⬜ Pending dashboard check |
+| **Netlify Forms** detection + honeypot (Phase 11) | Now (preview, partial) | 🟡 **Detection confirmed** (HTML evidence); submission + honeypot pending dashboard |
 | **Umami analytics** (Phase 14) | Cutover only | ⬜ Deferred — production-gated by design (#150 §7) |
 
 Preview base for all "now" checks: `https://ofreport-dev.netlify.app`
@@ -20,36 +20,53 @@ Preview base for all "now" checks: `https://ofreport-dev.netlify.app`
 
 ## 1. RSS feed → Mailchimp ✅ PASS (2026-06-23)
 
-The feed is the input to Mailchimp's RSS-to-email campaigns, so the URL must be stable and the markup must render. URL parity (#173) already proved `/feed.xml` returns `200` and is a valid feed; this is the structural + content validation.
+The feed is the input to Mailchimp's RSS-to-email campaigns, so the URL must be stable and the markup must render undistorted in email. URL parity (#173) already proved `/feed.xml` returns `200` and is a valid feed; this is the structural + content validation, including the Mailchimp-hardening fixes shipped in #181 (evidence in #180).
 
 ### How to re-run
 
 ```bash
-curl -s https://ofreport-dev.netlify.app/feed.xml -o /tmp/feed.xml
-xmllint --noout /tmp/feed.xml && echo "well-formed"
-# probe every cover enclosure resolves:
-grep -oE 'enclosure url="[^"]+"' /tmp/feed.xml | sed -E 's/enclosure url="([^"]+)"/\1/' \
-  | while read u; do echo "$(curl -s -o /dev/null -w '%{http_code}' -I "$u")  $u"; done
+cd "$(mktemp -d)" && curl -s https://ofreport-dev.netlify.app/feed.xml -o feed.xml
+xmllint --noout feed.xml && echo "well-formed"
+
+# noon-UTC dates (the #181 off-by-one fix — every pubDate must end "12:00:00 +0000"):
+grep -oE '<pubDate>[^<]+</pubDate>' feed.xml | head -3
+
+# enclosure types track the real extension (not all jpeg — the #181 fix):
+grep -oE '<enclosure[^>]+>' feed.xml | sed -E 's/.*type="([^"]+)".*/\1/' | sort | uniq -c
+
+# every image URL (enclosures + content:encoded <img>) resolves 200:
+python3 - <<'PY'
+import re, subprocess
+xml = open('feed.xml').read()
+urls = list(dict.fromkeys(re.findall(r'<enclosure[^>]*url="([^"]+)"', xml)
+                          + re.findall(r'<img[^>]*src="([^"]+)"', xml)))
+bad = [u for u in urls if subprocess.run(["curl","-s","-o","/dev/null","-w","%{http_code}","-I",u],
+        capture_output=True, text=True).stdout.strip() != "200"]
+print(f"{len(urls)} image URLs — " + ("ALL 200" if not bad else f"{len(bad)} FAILED: {bad}"))
+PY
 ```
 
 ### Findings
 
-- **Well-formed** (`xmllint --noout` clean). RSS 2.0 with `atom:` and `dc:` namespaces declared.
+- **Well-formed** (`xmllint --noout` clean). RSS 2.0 with `atom:`, `dc:`, **and `content:`** namespaces declared — the `content` namespace was added in #181 for the `<content:encoded>` blocks.
 - **Channel** carries `title`, `link`, `description`, `generator`, `language` (`en-US`), `copyright`, `lastBuildDate`, and an `atom:link` self-reference.
 - **Self-reference is launch-ready:** even on the preview build, `<atom:link href="https://ofreport.com/feed.xml" …>` and channel `<link>` point at the **production** domain — so Mailchimp continuity is preserved (the feed URL Mailchimp polls never changes across cutover). This is the single most important RSS fact for the migration.
-- **10 items** (explicit `[services.rss] limit = 10` in `hugo.toml`), newest → oldest:
-  - `Wed, 27 May 2026` → `Mon, 24 Feb 2025`
-- **Each item** has `title`, `link` (absolute, production permalink), `pubDate` (RFC-822), `dc:creator`, `guid` (= permalink), a **curated excerpt** `description` (the excerpt model from CHANGELOG 2026-06-06, not full HTML), and a cover `<enclosure>`.
-- **All 10 cover enclosures resolve `200`** (the `rss` Cloudinary preset, `w_560` — a different transform than the cover probe's `hero`; both resolve, consistent with Cloudinary's all-or-nothing derivative behavior).
+- **10 items** (explicit `[services.rss] limit = 10` in `hugo.toml`), newest → oldest: `Wed, 27 May 2026` → `Mon, 24 Feb 2025`.
+- **Dates emit at noon UTC** (`… 12:00:00 +0000`) on both `pubDate` and `lastBuildDate` — the #181 fix for the publish-date-off-by-one wart, so the displayed date never crosses a day boundary when rendered anywhere in the Americas.
+- **Each item** has `title`, `link` (absolute, production permalink), `pubDate` (RFC-822), `dc:creator`, `guid` (= permalink), a plain-text **curated excerpt** `description` (the excerpt model from CHANGELOG 2026-06-06, kept clean for RSS readers), a `<content:encoded>` CDATA block, and a cover `<enclosure>`.
+- **`<content:encoded>` carries an email-safe cover `<img>`** sized by width only (`width="600"` + inline `style="…width:100%;max-width:600px;height:auto;border:0"`) at the 1200×630 (1.91:1) `c_fill` social preset — the width-with-auto-height pattern that can't distort in email clients — followed by the excerpt. This is the block the Mailchimp campaign points at for the email body (`*|RSSITEM:CONTENT_FULL|*`).
+- **Enclosure `type` tracks the real extension** — 8 `image/jpeg`, 2 `image/png` (no longer hardcoded to jpeg; the #181 fix). Enclosure retained for podcast-style readers.
+- **All 20 image URLs resolve `200`** — 10 enclosure covers (`rss` preset, `w_560`) + 10 `content:encoded` covers (1200×630 `c_fill`).
 
-### Minor / cosmetic (not blockers)
+### Mailchimp render — confirmed (Joshua, #180)
 
-- `enclosure` emits `length="0"` (`layouts/_default/rss.xml:53`) — Hugo can't know the remote Cloudinary byte size. Universally tolerated by readers and Mailchimp; the RSS spec wants real bytes but this is the standard Hugo-remote-image compromise.
-- `enclosure` emits `type="image/jpeg"` for every item, but several covers are `.png` (and `f_auto` actually delivers webp/avif). The `type` is an advisory hint, so this is harmless — but it's inaccurate. **Possible tiny future fix:** derive the type from the source extension, or drop the attribute. Low priority; out of scope for this gate.
+A real Mailchimp RSS-to-email **test campaign** was sent account-side: the **cover image rendered undistorted** and the **displayed publish date matched the actual post date**. This closes the two legacy warts (stretched cover, off-by-one date) at the source. Full evidence in #180; the live, fixed feed is `https://ofreport-dev.netlify.app/feed.xml`.
 
-### Account-side confirm (Joshua) — optional but recommended
+> **Cutover note:** the production Mailchimp RSS campaign must repoint at `https://ofreport.com/feed.xml` and use `*|RSSITEM:CONTENT_FULL|*` (not `*|RSSITEM:CONTENT|*`, which drops the cover) in the RSS Items block. Tracked in #150 §8 (post-launch).
 
-- [ ] Open `https://ofreport-dev.netlify.app/feed.xml` in a feed reader (or the [W3C Feed Validator](https://validator.w3.org/feed/)) and confirm titles, excerpts, dates, and a cover image render as expected.
+### Minor / cosmetic (not a blocker)
+
+- `enclosure` emits `length="0"` (`layouts/_default/rss.xml`) — Hugo can't know the remote Cloudinary byte size. Universally tolerated by readers and Mailchimp; the RSS spec wants real bytes, but this is the standard Hugo-remote-image compromise.
 
 ---
 
@@ -73,19 +90,47 @@ The embedded forms POST directly to `OFReport.us6.list-manage.com` (`layouts/par
 
 ---
 
-## 3. Netlify Forms (contact) ⬜ Pending — partial pre-cutover
+## 3. Netlify Forms (contact) 🟡 Detection confirmed — submission/honeypot pending
 
 The contact form (`layouts/partials/contact-form.html`) is auto-detected by Netlify on build. **Detection + honeypot are testable on the preview; notification routing is production-only** — the live Nuxt site uses an AWS Lambda (not Netlify Forms), so routing must be set up fresh on the production site at cutover (#150 §7 step 6). The Lambda retires with the Nuxt site; nothing to migrate.
 
 Form: `https://ofreport-dev.netlify.app/contact/`
 
+### Detection confirmed at the HTML level (Claude, 2026-06-23)
+
+Netlify's form-detection post-processor leaves a **distinctive fingerprint** in the served HTML, so detection is verifiable without the dashboard. When Netlify finds `data-netlify="true"` at deploy time, it registers the form and **consumes** the build-directive attributes (`data-netlify`, `netlify-honeypot`), re-serializing only that form (single-quoted, alphabetized attributes) while keeping the runtime fields it needs at POST time.
+
+Three serializers make this unambiguous:
+
+| Form | Served `<form>` tag style | Meaning |
+| --- | --- | --- |
+| Hugo's minifier (local `hugo --minify`) | `<form name=contact … data-netlify=true netlify-honeypot=bot-field …>` | source HTML before Netlify sees it |
+| Deployed **Mailchimp** form (no `data-netlify`) | `<form id=mc-embedded-subscribe-form … >` — unquoted, Hugo style, untouched | Netlify ignored it (correct) |
+| Deployed **contact** form | `<form action='/thank-you/' class='…' method='POST' name='contact'>` — single-quoted, alphabetized, **`data-netlify` gone** | Netlify detected + processed it ✅ |
+
+The runtime fields survive the rewrite, confirming the form is wired to capture: `<input type=hidden name=form-name value=contact>` (associates the POST with the "contact" form) and `<input name=bot-field …>` (the honeypot trap). The `netlify-honeypot="bot-field"` directive is consumed — Netlify now knows which field is the honeypot.
+
+#### How to re-run
+
+```bash
+curl -s https://ofreport-dev.netlify.app/contact/ -o /tmp/contact.html
+# data-netlify is CONSUMED on a successful detect — its absence is the pass signal:
+grep -q 'data-netlify' /tmp/contact.html \
+  && echo "still present → NOT detected ❌" \
+  || echo "consumed by Netlify → detected ✅"
+# the runtime fields Netlify needs must remain:
+grep -oE "name=['\"]?(form-name|bot-field)" /tmp/contact.html | sort -u
+```
+
 ### Account-side confirm (Joshua) — on the `ofreport-dev` site
 
-- [ ] Confirm the form appears under the site's **Forms** tab (auto-detected on the latest build).
-- [ ] Submit the contact form; confirm the submission is captured.
-- [ ] Confirm the honeypot field rejects an obvious bot submission (does not appear as a real submission).
+Detection is already evidenced above; these confirm the round-trip in the dashboard.
 
-> _Evidence (fill in after testing): form name detected, submission captured Y/N, honeypot behavior._
+- [ ] Confirm a form named **`contact`** appears under the site's **Forms** tab (Netlify dashboard → `ofreport-dev` → Forms).
+- [ ] Submit the contact form at `/contact/`; confirm the submission appears under that form.
+- [ ] Submit again with the hidden **`bot-field`** populated (e.g. via devtools) and confirm Netlify drops it as spam (does not appear as a real submission).
+
+> _Evidence (fill in after testing): form appears in Forms tab Y/N, submission captured Y/N, honeypot-filled submit rejected Y/N._
 
 ### Deferred to cutover (#150 §7 step 6–7)
 

--- a/docs/integrations-check.md
+++ b/docs/integrations-check.md
@@ -104,7 +104,7 @@ Three serializers make this unambiguous:
 
 The runtime fields survive the rewrite, confirming the form is wired to capture: `<input type=hidden name=form-name value=contact>` (associates the POST with the "contact" form) and `<input name=bot-field …>` (the honeypot trap). The `netlify-honeypot="bot-field"` directive is consumed — Netlify now knows which field is the honeypot.
 
-#### How to re-run
+#### How to re-run the detection check
 
 ```bash
 curl -s https://ofreport-dev.netlify.app/contact/ -o /tmp/contact.html
@@ -128,7 +128,7 @@ grep -oE "name=['\"]?(form-name|bot-field)" /tmp/contact.html | sort -u
 
 The contact form carries a hidden `subject` field (`layouts/partials/contact-form.html`) so the notification email's subject is versioned in the template and identical across preview/production. A form-supplied `subject` **takes precedence** over the dashboard's "Custom email subject line" field — so leave that UI field blank and the form value wins. Only the predefined vars `%{formName}`, `%{siteName}`, `%{submissionId}` interpolate in the subject; submitted fields (name/email) cannot, so it stays static.
 
-### Deferred to cutover (#150 §7 step 6–7)
+### Deferred to cutover — notification routing (#150 §7 step 6–7)
 
 - [ ] Set up the email notification on the **production** Netlify site (the new site starts with no Forms config; the `subject` line carries over automatically via the form field).
 - [ ] After cutover, submit the contact form on `ofreport.com` and confirm routing + spam handling.
@@ -141,7 +141,7 @@ The `analytics.html` partial is **double-gated on `hugo.IsProduction` + a config
 
 `[params.umami]` in `hugo.toml` is intentionally blank today.
 
-### Deferred to cutover (#150 §7 step 6–7)
+### Deferred to cutover — Umami credentials (#150 §7 step 6–7)
 
 - [ ] Populate live `scriptUrl` + `websiteId` (reuses the existing OFReport.com website ID `34d2cfa4-e623-418a-936d-670c9d163ead`, so the dashboard record continues unbroken).
 - [ ] Confirm events fire on `ofreport.com` in production **only**, and never on the preview.

--- a/docs/integrations-check.md
+++ b/docs/integrations-check.md
@@ -119,8 +119,10 @@ grep -oE "name=['\"]?(form-name|bot-field)" /tmp/contact.html | sort -u
 ### Account-side confirm (Joshua) — on the `ofreport-dev` site
 
 - [x] A form named **`contact`** appears under the site's **Forms** tab (Netlify dashboard → `ofreport-dev` → Forms) — confirmed 2026-06-23, matching the HTML evidence above.
-- [ ] Submit the contact form at `/contact/`; confirm the submission appears under that form.
-- [ ] Submit again with the hidden **`bot-field`** populated (e.g. via devtools) and confirm Netlify drops it as spam (does not appear as a real submission).
+- [x] **Two submissions staged 2026-06-23** (driven via browser; both reached `/thank-you/`):
+  - **Clean** — `Claude — #179 clean test` / `ofr179-clean@example.com`, honeypot empty → **should appear** under the `contact` form.
+  - **Honeypot** — `Claude — #179 honeypot test` / `ofr179-bot@example.com`, `bot-field` populated → **should be dropped** (absent from verified submissions; the redirect to `/thank-you/` is expected — Netlify accepts silently so as not to tip off bots).
+- [ ] _Joshua's final eyeball:_ confirm the clean submit is captured and the honeypot submit is absent (or filed under Spam), then delete the two test rows.
 
 ### Notification subject — set in the form, not the dashboard
 

--- a/docs/integrations-check.md
+++ b/docs/integrations-check.md
@@ -1,7 +1,7 @@
 # Integrations Verification
 
 **Issue:** #179 (launch-readiness epic #150 §4)
-**Last run:** 2026-06-23 — RSS ✅ PASS (incl. Mailchimp render, #180/#181); Netlify Forms detection ✅ (HTML evidence); Mailchimp signup submit + Netlify dashboard round-trip pending Joshua; Umami deferred to cutover.
+**Last run:** 2026-06-23 — RSS ✅ PASS (incl. Mailchimp render, #180/#181); Mailchimp signup ✅ PASS (3 placements, Joshua); Netlify Forms ✅ detected (HTML + dashboard), notification subject + honeypot-reject in progress; Umami deferred to cutover.
 
 A pre-cutover gate for the site's four external integrations. Like the URL-parity (`docs/url-parity/`) and link-check (`docs/link-check.md`) gates, it proves each integration rather than assuming it. **Only two integrations can be fully verified before cutover** — the other two are production-only by design and are confirmed on cutover day (#150 §7 steps 6–7). This doc records the evidence and keeps that boundary explicit.
 
@@ -10,8 +10,8 @@ A pre-cutover gate for the site's four external integrations. Like the URL-parit
 | Integration | When verifiable | Status |
 | --- | --- | --- |
 | **RSS feed** (Phase 9) | Now (preview) | ✅ **PASS** — well-formed, 10 items + `content:encoded`, all 20 image URLs resolve; Mailchimp render confirmed (#180/#181) |
-| **Mailchimp signup forms** (Phase 12) | Now (preview) | ⬜ Pending account-side submit |
-| **Netlify Forms** detection + honeypot (Phase 11) | Now (preview, partial) | 🟡 **Detection confirmed** (HTML evidence); submission + honeypot pending dashboard |
+| **Mailchimp signup forms** (Phase 12) | Now (preview) | ✅ **PASS** — all 3 placements submit to Mailchimp (Joshua) |
+| **Netlify Forms** detection + honeypot (Phase 11) | Now (preview, partial) | ✅ **Detected** (HTML + dashboard); notification subject + honeypot-reject in progress |
 | **Umami analytics** (Phase 14) | Cutover only | ⬜ Deferred — production-gated by design (#150 §7) |
 
 Preview base for all "now" checks: `https://ofreport-dev.netlify.app`
@@ -70,23 +70,17 @@ A real Mailchimp RSS-to-email **test campaign** was sent account-side: the **cov
 
 ---
 
-## 2. Mailchimp signup forms ⬜ Pending
+## 2. Mailchimp signup forms ✅ PASS (Joshua, 2026-06-23)
 
-The embedded forms POST directly to `OFReport.us6.list-manage.com` (`layouts/partials/mailchimp-form.html`) — **independent of the Hugo/Netlify environment**, so a preview submit exercises the real production path. Three placements to verify:
+The embedded forms POST directly to `OFReport.us6.list-manage.com` (`layouts/partials/mailchimp-form.html`) — **independent of the Hugo/Netlify environment**, so a preview submit exercises the real production path. All three placements were exercised:
 
-| Placement | Where |
-| --- | --- |
-| Homepage | `https://ofreport-dev.netlify.app/` |
-| Article footer | any article, e.g. `https://ofreport-dev.netlify.app/blog/2026-05-27-teaching-serving-standing/` |
-| Subscribe page | `https://ofreport-dev.netlify.app/subscribe/` |
+| Placement | Where | Result |
+| --- | --- | --- |
+| Homepage | `https://ofreport-dev.netlify.app/` | ✅ routes to Mailchimp signup |
+| Article footer (every post) | e.g. `https://ofreport-dev.netlify.app/blog/2026-05-27-teaching-serving-standing/` | ✅ routes to Mailchimp signup |
+| Subscribe page | `https://ofreport-dev.netlify.app/subscribe/` | ✅ routes to Mailchimp signup |
 
-### Account-side confirm (Joshua)
-
-- [ ] Submit a real test address from **each** of the three placements.
-- [ ] Confirm each submission lands in the Mailchimp audience (and the double-opt-in email arrives, if enabled).
-- [ ] Note any styling/UX issues with the inline success/error states.
-
-> _Evidence (fill in after testing): which placements tested, test address used, audience confirmation._
+**Evidence (Joshua):** confirmed the signup submits cleanly from all three placements — each reaches the Mailchimp signup/confirmation with no errors. Because the form POSTs straight to `list-manage.com`, this path is identical on the live domain; no cutover re-test needed.
 
 ---
 
@@ -124,17 +118,17 @@ grep -oE "name=['\"]?(form-name|bot-field)" /tmp/contact.html | sort -u
 
 ### Account-side confirm (Joshua) — on the `ofreport-dev` site
 
-Detection is already evidenced above; these confirm the round-trip in the dashboard.
-
-- [ ] Confirm a form named **`contact`** appears under the site's **Forms** tab (Netlify dashboard → `ofreport-dev` → Forms).
+- [x] A form named **`contact`** appears under the site's **Forms** tab (Netlify dashboard → `ofreport-dev` → Forms) — confirmed 2026-06-23, matching the HTML evidence above.
 - [ ] Submit the contact form at `/contact/`; confirm the submission appears under that form.
 - [ ] Submit again with the hidden **`bot-field`** populated (e.g. via devtools) and confirm Netlify drops it as spam (does not appear as a real submission).
 
-> _Evidence (fill in after testing): form appears in Forms tab Y/N, submission captured Y/N, honeypot-filled submit rejected Y/N._
+### Notification subject — set in the form, not the dashboard
+
+The contact form carries a hidden `subject` field (`layouts/partials/contact-form.html`) so the notification email's subject is versioned in the template and identical across preview/production. A form-supplied `subject` **takes precedence** over the dashboard's "Custom email subject line" field — so leave that UI field blank and the form value wins. Only the predefined vars `%{formName}`, `%{siteName}`, `%{submissionId}` interpolate in the subject; submitted fields (name/email) cannot, so it stays static.
 
 ### Deferred to cutover (#150 §7 step 6–7)
 
-- [ ] Set up notification routing on the **production** Netlify site (new — this site has no Forms config today).
+- [ ] Set up the email notification on the **production** Netlify site (the new site starts with no Forms config; the `subject` line carries over automatically via the form field).
 - [ ] After cutover, submit the contact form on `ofreport.com` and confirm routing + spam handling.
 
 ---

--- a/docs/integrations-check.md
+++ b/docs/integrations-check.md
@@ -1,0 +1,114 @@
+# Integrations Verification
+
+**Issue:** #179 (launch-readiness epic #150 §4)
+**Last run:** 2026-06-23 — RSS feed ✅ validated; Mailchimp / Netlify Forms / Umami pending (see status).
+
+A pre-cutover gate for the site's four external integrations. Like the URL-parity (`docs/url-parity/`) and link-check (`docs/link-check.md`) gates, it proves each integration rather than assuming it. **Only two integrations can be fully verified before cutover** — the other two are production-only by design and are confirmed on cutover day (#150 §7 steps 6–7). This doc records the evidence and keeps that boundary explicit.
+
+## Status at a glance
+
+| Integration | When verifiable | Status |
+| --- | --- | --- |
+| **RSS feed** (Phase 9) | Now (preview) | ✅ **PASS** — well-formed, 10 items, all cover enclosures resolve |
+| **Mailchimp signup forms** (Phase 12) | Now (preview) | ⬜ Pending account-side submit |
+| **Netlify Forms** detection + honeypot (Phase 11) | Now (preview, partial) | ⬜ Pending dashboard check |
+| **Umami analytics** (Phase 14) | Cutover only | ⬜ Deferred — production-gated by design (#150 §7) |
+
+Preview base for all "now" checks: `https://ofreport-dev.netlify.app`
+
+---
+
+## 1. RSS feed → Mailchimp ✅ PASS (2026-06-23)
+
+The feed is the input to Mailchimp's RSS-to-email campaigns, so the URL must be stable and the markup must render. URL parity (#173) already proved `/feed.xml` returns `200` and is a valid feed; this is the structural + content validation.
+
+### How to re-run
+
+```bash
+curl -s https://ofreport-dev.netlify.app/feed.xml -o /tmp/feed.xml
+xmllint --noout /tmp/feed.xml && echo "well-formed"
+# probe every cover enclosure resolves:
+grep -oE 'enclosure url="[^"]+"' /tmp/feed.xml | sed -E 's/enclosure url="([^"]+)"/\1/' \
+  | while read u; do echo "$(curl -s -o /dev/null -w '%{http_code}' -I "$u")  $u"; done
+```
+
+### Findings
+
+- **Well-formed** (`xmllint --noout` clean). RSS 2.0 with `atom:` and `dc:` namespaces declared.
+- **Channel** carries `title`, `link`, `description`, `generator`, `language` (`en-US`), `copyright`, `lastBuildDate`, and an `atom:link` self-reference.
+- **Self-reference is launch-ready:** even on the preview build, `<atom:link href="https://ofreport.com/feed.xml" …>` and channel `<link>` point at the **production** domain — so Mailchimp continuity is preserved (the feed URL Mailchimp polls never changes across cutover). This is the single most important RSS fact for the migration.
+- **10 items** (explicit `[services.rss] limit = 10` in `hugo.toml`), newest → oldest:
+  - `Wed, 27 May 2026` → `Mon, 24 Feb 2025`
+- **Each item** has `title`, `link` (absolute, production permalink), `pubDate` (RFC-822), `dc:creator`, `guid` (= permalink), a **curated excerpt** `description` (the excerpt model from CHANGELOG 2026-06-06, not full HTML), and a cover `<enclosure>`.
+- **All 10 cover enclosures resolve `200`** (the `rss` Cloudinary preset, `w_560` — a different transform than the cover probe's `hero`; both resolve, consistent with Cloudinary's all-or-nothing derivative behavior).
+
+### Minor / cosmetic (not blockers)
+
+- `enclosure` emits `length="0"` (`layouts/_default/rss.xml:53`) — Hugo can't know the remote Cloudinary byte size. Universally tolerated by readers and Mailchimp; the RSS spec wants real bytes but this is the standard Hugo-remote-image compromise.
+- `enclosure` emits `type="image/jpeg"` for every item, but several covers are `.png` (and `f_auto` actually delivers webp/avif). The `type` is an advisory hint, so this is harmless — but it's inaccurate. **Possible tiny future fix:** derive the type from the source extension, or drop the attribute. Low priority; out of scope for this gate.
+
+### Account-side confirm (Joshua) — optional but recommended
+
+- [ ] Open `https://ofreport-dev.netlify.app/feed.xml` in a feed reader (or the [W3C Feed Validator](https://validator.w3.org/feed/)) and confirm titles, excerpts, dates, and a cover image render as expected.
+
+---
+
+## 2. Mailchimp signup forms ⬜ Pending
+
+The embedded forms POST directly to `OFReport.us6.list-manage.com` (`layouts/partials/mailchimp-form.html`) — **independent of the Hugo/Netlify environment**, so a preview submit exercises the real production path. Three placements to verify:
+
+| Placement | Where |
+| --- | --- |
+| Homepage | `https://ofreport-dev.netlify.app/` |
+| Article footer | any article, e.g. `https://ofreport-dev.netlify.app/blog/2026-05-27-teaching-serving-standing/` |
+| Subscribe page | `https://ofreport-dev.netlify.app/subscribe/` |
+
+### Account-side confirm (Joshua)
+
+- [ ] Submit a real test address from **each** of the three placements.
+- [ ] Confirm each submission lands in the Mailchimp audience (and the double-opt-in email arrives, if enabled).
+- [ ] Note any styling/UX issues with the inline success/error states.
+
+> _Evidence (fill in after testing): which placements tested, test address used, audience confirmation._
+
+---
+
+## 3. Netlify Forms (contact) ⬜ Pending — partial pre-cutover
+
+The contact form (`layouts/partials/contact-form.html`) is auto-detected by Netlify on build. **Detection + honeypot are testable on the preview; notification routing is production-only** — the live Nuxt site uses an AWS Lambda (not Netlify Forms), so routing must be set up fresh on the production site at cutover (#150 §7 step 6). The Lambda retires with the Nuxt site; nothing to migrate.
+
+Form: `https://ofreport-dev.netlify.app/contact/`
+
+### Account-side confirm (Joshua) — on the `ofreport-dev` site
+
+- [ ] Confirm the form appears under the site's **Forms** tab (auto-detected on the latest build).
+- [ ] Submit the contact form; confirm the submission is captured.
+- [ ] Confirm the honeypot field rejects an obvious bot submission (does not appear as a real submission).
+
+> _Evidence (fill in after testing): form name detected, submission captured Y/N, honeypot behavior._
+
+### Deferred to cutover (#150 §7 step 6–7)
+
+- [ ] Set up notification routing on the **production** Netlify site (new — this site has no Forms config today).
+- [ ] After cutover, submit the contact form on `ofreport.com` and confirm routing + spam handling.
+
+---
+
+## 4. Umami analytics ⬜ Deferred — production only
+
+The `analytics.html` partial is **double-gated on `hugo.IsProduction` + a configured `scriptUrl`/`websiteId`**, and `data-domains="ofreport.com"` scopes tracking to the canonical host. It emits **nothing** on previews by design, so it cannot be verified before cutover — and that's the correct, safe behavior (a stray `*.netlify.app` load can never pollute the dashboard).
+
+`[params.umami]` in `hugo.toml` is intentionally blank today.
+
+### Deferred to cutover (#150 §7 step 6–7)
+
+- [ ] Populate live `scriptUrl` + `websiteId` (reuses the existing OFReport.com website ID `34d2cfa4-e623-418a-936d-670c9d163ead`, so the dashboard record continues unbroken).
+- [ ] Confirm events fire on `ofreport.com` in production **only**, and never on the preview.
+
+> **Optional pre-stage:** the config can be filled in ahead of cutover since the partial stays inert until production — this just needs the Umami instance `scriptUrl`. Leaving blank per the documented plan is also fine.
+
+---
+
+## Cross-check: nothing dropped
+
+The two cutover-only integrations (Umami firing, Netlify Forms notification routing) and the live Mailchimp RSS campaign send (#150 §8 post-launch) remain tracked in epic #150. This doc closes the **preview-verifiable** bucket of §4; it does not close §4 outright.

--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -30,6 +30,14 @@
   {{- /* Netlify matches the POST to the "contact" form via this hidden field. */ -}}
   <input type="hidden" name="form-name" value="contact" />
 
+  {{- /* Netlify uses a field named "subject" as the notification email's
+         subject line, and a form-supplied value takes precedence over the
+         dashboard setting — so the subject lives in version control here, not
+         in per-site UI config. Only the predefined vars %{formName},
+         %{siteName}, %{submissionId} interpolate; submitted fields (name,
+         email) cannot, so this stays static. */ -}}
+  <input type="hidden" name="subject" value="New contact form message — OFReport.com" />
+
   {{- /* Honeypot — hidden from real visitors; bots that fill it are dropped by
          Netlify. Do not remove. */ -}}
   <p class="hidden" aria-hidden="true">


### PR DESCRIPTION
## Summary

Closes the **preview-verifiable** bucket of the Integrations gate (epic #150 §4) and captures the evidence in a re-runnable `docs/integrations-check.md`, mirroring the URL-parity (#173) and link-check (#168) gates. Two of the four integrations are fully verifiable before cutover; the other two are production-only by design and stay tracked in #150 §7.

## What's verified (on `ofreport-dev.netlify.app`)

| Integration | Result |
| --- | --- |
| **RSS feed → Mailchimp** | ✅ PASS — well-formed, 10 items + `content:encoded`, `content` namespace, noon-UTC dates, accurate enclosure types, all 20 image URLs `200`. Mailchimp render confirmed in #180/#181. |
| **Mailchimp signup forms** | ✅ PASS — submits cleanly from all three placements (homepage, article footer, `/subscribe/`). |
| **Netlify Forms (contact)** | ✅ Detected — confirmed at the HTML level *and* in the dashboard; two test submissions staged (clean + honeypot). |
| **Umami analytics** | ⬜ Deferred — production-gated by design; stays in #150 §7. |

## Notable finding — Netlify Forms detection is provable from the HTML alone

Three serializers make detection verifiable without the dashboard:

- Hugo's minifier emits `data-netlify=true` (unquoted, source order).
- The deployed **Mailchimp** form is served that way untouched (no `data-netlify` → Netlify ignores it).
- The deployed **contact** form is re-serialized (single-quoted, alphabetized) with `data-netlify`/`netlify-honeypot` **consumed** — Netlify's detection fingerprint. The runtime `form-name` + `bot-field` inputs survive, proving the form is wired to capture.

A re-runnable assertion for this is in the doc.

## Also in this PR

- **`feat(contact)`**: a hidden `subject` field on the contact form, so the Netlify notification subject is versioned in the template. A form-supplied subject takes precedence over the dashboard's "Custom email subject line" field and carries to the production site automatically at cutover. Surfaced while verifying Netlify Forms. _Takes effect on `ofreport-dev` only after this merges and the site redeploys._

## Remaining — one manual eyeball

Two contact-form submissions were staged in the `ofreport-dev` Netlify Forms dashboard:

- ✅ `Claude — #179 clean test` (`ofr179-clean@example.com`) should be **captured**.
- 🚫 `Claude — #179 honeypot test` (`ofr179-bot@example.com`) should be **dropped** (absent / filed as spam).

Confirm + delete the two test rows, and the §4 preview bucket is fully green. Cutover-only items (Umami firing, Netlify notification routing, live Mailchimp RSS campaign) remain tracked in #150 §7–§8.

## Build

`hugo --gc --minify` passes; the `subject` field renders in the built `/contact/`.

Closes #179
