### PR TITLE
chore(umami): pre-stage live analytics credentials for cutover

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -49,8 +49,8 @@ enableRobotsTXT = true
   #   scriptUrl = "https://lens.euroteamoutreach.org/script.js"
   #   websiteId = "34d2cfa4-e623-418a-936d-670c9d163ead"
   [params.umami]
-    scriptUrl = ""
-    websiteId = ""
+    scriptUrl = "https://lens.euroteamoutreach.org/script.js"
+    websiteId = "34d2cfa4-e623-418a-936d-670c9d163ead"
 
 # Build stats for Tailwind CSS purging
 [build]


### PR DESCRIPTION
Pre-stages the live Umami `scriptUrl` + `websiteId` in `hugo.toml` (§6/§7 step 6 of #150), so analytics is launch-ready.

**Safety verified locally:**
- Production build → emits `<script defer src=…/script.js data-website-id=… data-domains=ofreport.com>` (the partial's double gate + `data-domains` safeguard).
- Preview build → emits **nothing** (`hugo.IsProduction` is false on deploy-previews/branch builds).

Once on main, `ofreport-dev`'s production-env build will load the script, but `data-domains="ofreport.com"` prevents it recording any dev traffic (and the dev site is deleted at cutover). Relates to #150 §6; no behavior change until the Hugo site becomes production at cutover.