### PR TITLE
docs: refresh README post-launch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joshua Steele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/69a46dc9-827c-4b08-8b75-0164feb31dce/deploy-status)](https://app.netlify.com/projects/ofreport/deploys)
 
-A missionary family blog by Joshua and Kelsie Steele, documenting 17 years of ministry work in Ukraine. The site was rebuilt from Nuxt.js 2 to [Hugo](https://gohugo.io/) in 2026 and is live at **[ofreport.com](https://ofreport.com)**.
+A missionary family blog by Joshua and Kelsie Steele, documenting 25 years of ministry work in Ukraine. The site was rebuilt from Nuxt.js 2 to [Hugo](https://gohugo.io/) in 2026 and is live at **[ofreport.com](https://ofreport.com)**.
 
 > [!NOTE]
 > Looking for the previous version? The original **Nuxt.js 2** site lives in [joshukraine/ofreport.com-nuxt](https://github.com/joshukraine/ofreport.com-nuxt) (archived, read-only).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ The Hugo rebuild is **complete** — OFReport.com went live on the new codebase 
 
 The source code in this repository is licensed under the [MIT License](LICENSE).
 
-Site **content** — blog articles, photographs, and other written material — is Copyright © 2001–2026 Joshua and Kelsie Steele. All rights reserved, and may not be reused without permission.
+Site **content** — blog articles, photographs, and other written material — is copyright © 2001–2026 Joshua and Kelsie Steele. All rights reserved, and may not be reused without permission.
 
 [screenshot]: https://res.cloudinary.com/dnkvsijzu/image/upload/bo_1px_solid_rgb:e2e8f0,c_scale,f_auto,q_auto,w_1000/v1782237895/screenshots/ofreport.com-hugo-2026_vtr69j.png

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
+![OFReport.com][screenshot]
+
 # OFReport.com (Hugo Rebuild)
 
-A missionary family blog by Joshua and Kelsie Steele, documenting 17 years of
-ministry work in Ukraine. This is a ground-up rebuild from Nuxt.js 2 to
-[Hugo](https://gohugo.io/).
+[![Netlify Status](https://api.netlify.com/api/v1/badges/69a46dc9-827c-4b08-8b75-0164feb31dce/deploy-status)](https://app.netlify.com/projects/ofreport/deploys)
 
-The site includes 223 blog articles (2008-2026), 5 static pages, and 26 tags.
+A missionary family blog by Joshua and Kelsie Steele, documenting 17 years of ministry work in Ukraine. The site was rebuilt from Nuxt.js 2 to [Hugo](https://gohugo.io/) in 2026 and is live at **[ofreport.com](https://ofreport.com)**.
 
 > [!NOTE]
-> Looking for the previous version? The original **Nuxt.js 2** site lives in
-> [joshukraine/ofreport.com-nuxt](https://github.com/joshukraine/ofreport.com-nuxt)
-> (archived, read-only).
+> Looking for the previous version? The original **Nuxt.js 2** site lives in [joshukraine/ofreport.com-nuxt](https://github.com/joshukraine/ofreport.com-nuxt) (archived, read-only).
 
 ## Tech Stack
 
 - **Hugo** - Static site generator with Go templates
 - **Tailwind CSS v4** - Utility-first CSS via Hugo's built-in `css.TailwindCSS`
 - **Alpine.js** - Lightweight JS for mobile menu and dropdowns
+- **GLightbox** - Lightbox for article images
 - **Cloudinary** - Image hosting and transformation (no local images)
+- **Mailchimp** - Newsletter signup (inline forms)
+- **Umami** - Cookieless, privacy-focused analytics
 - **Netlify** - Hosting, forms, and deployment
 
 ## Getting Started
@@ -32,8 +33,7 @@ hugo server -D
 hugo --gc --minify
 ```
 
-Requires [Hugo](https://gohugo.io/installation/) (extended edition) and
-[Node.js](https://nodejs.org/) 22 LTS.
+Requires [Hugo](https://gohugo.io/installation/) (extended edition) and [Node.js](https://nodejs.org/) 20 or newer (production builds run on Node 22).
 
 ## Project Structure
 
@@ -47,12 +47,27 @@ data/             # Structured data files (authors, archives)
 docs/             # PRD and project documentation
 ```
 
+## Documentation
+
+Project documentation lives in [`docs/`](docs/):
+
+- **[Product requirements (PRD)](docs/prd/)** — full requirements and phase-by-phase build history (start with [`00-overview.md`](docs/prd/00-overview.md); [`ROADMAP.md`](docs/prd/ROADMAP.md) tracks the build phases)
+- **Quality & launch checks** — repeatable verification procedures:
+  - [Lighthouse audit](docs/lighthouse-check.md) — performance & accessibility
+  - [Link check](docs/link-check.md) — broken-link sweep
+  - [OG / social card check](docs/og-check.md) — Open Graph / social preview verification
+  - [Integrations check](docs/integrations-check.md) — third-party launch integrations
+- **[URL parity audit](docs/url-parity/report.md)** — Nuxt → Hugo redirect and URL verification
+- **[Hugo learning notes](docs/hugo-learning/)** — annotated notes captured during the build
+
 ## Status
 
 The Hugo rebuild is **complete** — OFReport.com went live on the new codebase in June 2026.
 
-Full requirements and the phase-by-phase build history are in the [`docs/prd/`](docs/prd/) directory (start with [`00-overview.md`](docs/prd/00-overview.md); see [`ROADMAP.md`](docs/prd/ROADMAP.md) for build phases).
-
 ## License
 
-Content is copyright Joshua and Kelsie Steele. All rights reserved.
+The source code in this repository is licensed under the [MIT License](LICENSE).
+
+Site **content** — blog articles, photographs, and other written material — is Copyright © 2003–2026 Joshua and Kelsie Steele. All rights reserved, and may not be reused without permission.
+
+[screenshot]: https://res.cloudinary.com/dnkvsijzu/image/upload/bo_1px_solid_rgb:e2e8f0,c_scale,f_auto,q_auto,w_1000/v1782237895/screenshots/ofreport.com-hugo-2026_vtr69j.png

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ The Hugo rebuild is **complete** — OFReport.com went live on the new codebase 
 
 The source code in this repository is licensed under the [MIT License](LICENSE).
 
-Site **content** — blog articles, photographs, and other written material — is Copyright © 2003–2026 Joshua and Kelsie Steele. All rights reserved, and may not be reused without permission.
+Site **content** — blog articles, photographs, and other written material — is Copyright © 2001–2026 Joshua and Kelsie Steele. All rights reserved, and may not be reused without permission.
 
 [screenshot]: https://res.cloudinary.com/dnkvsijzu/image/upload/bo_1px_solid_rgb:e2e8f0,c_scale,f_auto,q_auto,w_1000/v1782237895/screenshots/ofreport.com-hugo-2026_vtr69j.png


### PR DESCRIPTION
## Summary

Post-launch refresh of the root `README.md`, plus a new MIT `LICENSE` file. The README had not had a substantive update since early in the project; this brings it in line with the shipped, live Hugo site.

Closes #188.

## Changes

**README**

- **Screenshot** at the top (Cloudinary-hosted, with the same border + scaling transform the old site used — serves ~80 KB instead of the 4.35 MB original)
- **Netlify deploy-status badge** and a **live-site link** to [ofreport.com](https://ofreport.com)
- Removed the **article/page/tag counts** (would go stale quickly)
- **Node requirement** broadened to "20 or newer (production builds run on Node 22)"
- **Tech Stack** completed — added GLightbox, Mailchimp, Umami
- New **Documentation** section indexing the PRD and the launch-check utilities (Lighthouse, Link, OG, Integrations), the URL-parity audit, and the Hugo learning notes; **Status** trimmed to a one-line launch note
- **License** section now documents the split (MIT for source code, content reserved) with a real `©` symbol
- **Unwrapped hard-wrapped prose** to a single line per paragraph (matches the no-hard-wrap convention; `MD013` is disabled in `.markdownlint-cli2.yaml`)

**LICENSE**

- New MIT `LICENSE` for the source code (`© 2026 Joshua Steele`), mirroring the old Nuxt repo. Site content (blog prose, photos) remains all-rights-reserved, as stated in the README.

## Notes

- `markdownlint-cli2` passes with 0 errors.
- The Netlify badge ID matches the old site's, confirming the cutover repointed the same Netlify project to the Hugo repo.
- Please review the README **rendered on GitHub** before merging.
