### PR TITLE
fix(a11y): nav links meet WCAG AA contrast (slate-500)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,8 @@
       {{ end }}
     </a>
 
-    {{/* Desktop navigation — Lato (font-header), 20px, semibold, light cool-gray,
+    {{/* Desktop navigation — Lato (font-header), 20px, semibold, cool-gray
+         (slate-500 — ≥4.5:1 on white for WCAG AA; slate-400 was only 2.6:1),
          with the original's slide-in blue underline on hover / current page. */}}
     <nav class="hidden lg:flex lg:items-center lg:gap-x-8" aria-label="Main navigation">
       {{ $currentPage := . }}
@@ -22,7 +23,7 @@
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     text-blue-700
                   {{ else }}
-                    text-slate-400 hover:text-blue-600
+                    text-slate-500 hover:text-blue-600
                   {{ end }}">
           {{ .Name }}
         </a>
@@ -65,7 +66,7 @@
                   {{ if $currentPage.IsMenuCurrent "main" . }}
                     bg-blue-50 text-blue-900
                   {{ else }}
-                    text-slate-400 hover:bg-gray-50 hover:text-blue-900
+                    text-slate-500 hover:bg-gray-50 hover:text-blue-900
                   {{ end }}">
           {{ .Name }}
         </a>


### PR DESCRIPTION
## Summary

Fixes the **header nav-link** half of #164 — the WCAG AA color-contrast failure on the site-wide navigation. (The tag-pill half was already resolved by #184.)

Closes #164.

## Problem

The default (non-current) nav links rendered `text-slate-400` (#90a1b9) on the white header — **2.63:1**, below AA's 4.5:1 for normal text (the links are 20px / weight 600, which axe-core treats as normal, not large). This affects **every page** at desktop widths, in both the desktop nav and the mobile menu.

## Fix

Darken the resting nav state `slate-400` → **`slate-500`** (computed **4.76:1** on white) in both `header.html` nav blocks, keeping the existing blue hover and current-page (`blue-700`) states. `slate-500` clears AA while staying closest to the intended light cool-gray; `slate-600` (7.6:1) was darker than the design wants.

## Why #184's "Accessibility 100" missed this

#184 ran Lighthouse `--form-factor=mobile`, where the desktop nav is `hidden lg:flex` (`display:none`) and the mobile menu is collapsed (`x-show`), so axe-core never evaluated these links. The failure was real but masked by the audit viewport.

**Follow-up:** future Lighthouse gates should also run `--preset=desktop` so the nav is exercised.

## Verification

- `hugo --gc --minify` builds clean (290 pages).
- The CSS the built HTML references emits `.text-slate-500{color:var(--color-slate-500)}`, and the built nav markup uses `text-slate-500`.
- Contrast via the WCAG formula: `slate-500` = **4.76:1** (PASS), `slate-400` = 2.63:1 (FAIL).

Pure CSS/class change — no content edits, no change to the hover affordances.
