### PR TITLE
fix(a11y): normalize legacy section headings to start at h2

### DIFF
--- a/content/blog/2008-10-11-whatever-happened-to-september.md
+++ b/content/blog/2008-10-11-whatever-happened-to-september.md
@@ -19,7 +19,7 @@ With the end of the project, the Steeles have been enjoying a few quieter days.
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_dsc_3377-1.jpg" caption="We love having Daddy home more often!" >}}
 
-### 4th Anniversary!!
+## 4th Anniversary!!
 
 Joshua and I took a 6 day get away trip to Krakow, Poland, over our anniversary!
 
@@ -41,7 +41,7 @@ On the night of our anniversary, we ate at a very quaint traditional Polish rest
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/11/steele_anniversary_trip_055.jpg" caption="Best friends and lovers" >}}
 
-### Happy 3rd Birthday, Abigail!
+## Happy 3rd Birthday, Abigail!
 
 We had a blast doing fun things together on Abigail’s birthday. We opened presents all throughout the day, playing with each one. We even saved some until the following morning! It’s hard to believe our little girl is already three.
 

--- a/content/blog/2008-12-19-its-beginning-to-look-a-lot-like-christmas.md
+++ b/content/blog/2008-12-19-its-beginning-to-look-a-lot-like-christmas.md
@@ -22,7 +22,7 @@ Our family is getting things ready for the holidays!
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2008/12/dsc_3781.jpg" caption="Taking your own picture with a Nikon D40 is not that easy. (The girls were sleeping; otherwise, they would've made better photo material. =) )" >}}
 
-### Ministry Update
+## Ministry Update
 
 Our good friend and missionary here in Ukraine, Denise Hutchison, helps us tremendously by keeping up our Correspondence Bible Course of over 300 students. She and Nathan Day are responsible for grading lessons, sending out letters to students, addressing envelopes, and much more that goes into maintaining this course. Denise is going to be leaving for the U.S. this weekend, and Nathan is also in the U.S. visiting family. This means that the whole responsibility of the course will be on our shoulders and the Beal's over the next month or so! Our ministry obligations are already mushrooming, so we would appreciate your prayers for us as we take on this additional job.
 

--- a/content/blog/2009-01-15-keeping-busy.md
+++ b/content/blog/2009-01-15-keeping-busy.md
@@ -21,13 +21,13 @@ There is a great spirit about this group and we are grateful for the freedom the
 
 A special thanks to all of you who are specifically praying for this ministry! We believe that God is at work through your prayers. *"The sacrifice of the wicked is an abomination to the Lord: <strong>but the prayer of the upright is his delight</strong>."*
 
-### CBC Course
+## CBC Course
 
 With Nathan and Denise in the U.S. right now, Joshua and I have had the oversight of the Correspondence Bible Course. We are working each morning on grading and sending lessons, and answering letters we receive from students with questions about the Bible. Last week we had roughly 35 pieces of mail in our P.O. box, waiting to be graded and sent back out! It is so thrilling to see people who are consistently studying God's Word and growing in understanding.
 
 We are currently finishing the writing process for Lesson 13 (Sodom and Gomorrah), with 14, 15, and 16 on tab to be finished by the end of January. Writing each lesson can be a very time consuming affair, including research, drafting, editing, translating, correcting, and formatting, so please pray for us to make good progress. The finished course for the OT is slated to have around 33-34 lessons, with the book of John being the finale.
 
-### New Blog Feature (from Josh ;) )
+## New Blog Feature (from Josh ;) )
 
 You may have noticed that on the side bar of our blog there is a new section called Josh's Twitter Feed. [Twitter](http://twitter.com/) is a free online service used to communicate and stay connected through the exchange of short text messages. These messages can be posted via the Twitter web site, or even through one's mobile telephone, and are then immediately displayed on our blog. We find Twitter useful for those times when we'd like to post a quick note or update, but don't have time to put together an entire blog post.
 

--- a/content/blog/2009-01-27-this-week-in-lviv.md
+++ b/content/blog/2009-01-27-this-week-in-lviv.md
@@ -13,7 +13,7 @@ slug: 2009-01-27-this-week-in-lviv
 
 With the arrival of a new team member, preparations for this summer's outreach, the ongoing development and upkeep of our correspondence Bible course (CBC), and two growing little girls, our family is keeping pretty busy these days! Here's a quick news update to fill you in on the latest. 
 
-### Bryan Shufelt
+## Bryan Shufelt
 
 When Bryan got here on January 16, he hit the ground running. For the time being, he has been living at our ministry center and has busied himself by handling some of the paperwork related to our correspondence course. This includes things like putting together "starter packets" for new students in the course, and packaging up full versions of Good and Evil for mailing. I recently gave Bryan the crash course on how we track our CBC students using a web-based application called CBC Admin. While much of the course management requires a knowledge of Ukrainian (such as answering letters or grading lessons) there are several things that Bryan can assist us with right away. And what a blessing that will be!
 
@@ -23,13 +23,13 @@ Yesterday, Bryan had his first language lesson with Veronica. They will be meeti
 
 We would also appreciate your prayers for Bryan regarding a roommate. Originally, we had planned for him to share an apartment with a Ukrainian man from our church. We made an agreement to this effect months in advance. Unfortunately, this man decided to back out at the last minute. While finding alternate housing for Bryan will not be hard, it would be best if he could share an apartment with a native Ukrainian. Nathan and I both had the opportunity of learning Ukrainian while living with a native speaker, and we know from experience what a profound effect this can have on one's ability to achieve fluency. Please pray that we will be able to locate a responsible, single, Ukrainian believer who would be willing to share an apartment with Bryan.
 
-### Audio Bible Study (ABS)
+## Audio Bible Study (ABS)
 
 ABS day is upon us once again. If you are interested in praying for ABS, it takes place every Tuesday at 11:00am CST. Many of you have written to us pledging your prayer support each week, and we are very grateful for your faithful intercession. We are excited to see how God is already answering those prayers. As I write this post, ABS is about 8 hours away. We'll try to post again tomorrow and let you know how it went. Thanks again for praying!
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/01/abs-jan13-20093.jpg" caption="Standing (from left to right): Jessie, Evelina, Kelsie, Taras, Roman. Sitting: Joshua, Bohdan, Marian, Roman, Anya." >}}
 
-### Family News
+## Family News
 
 With each passing day, I become more and more aware of what a blessing it is to have a family. Our two daughters are growing cuter all the time (at least we think so!) and they are the delight of our lives. Rebekah started crawling a few weeks ago, and now she's pulling up on everything she sees. Abigail can't seem to put down her books. She is constantly asking us to read to her, and she knows large potions of several books by heart. Kelsie has already started her on phonics training.
 

--- a/content/blog/2009-02-04-snapshots-from-abs.md
+++ b/content/blog/2009-02-04-snapshots-from-abs.md
@@ -31,7 +31,7 @@ We had a great turn out for English Club and Audio Bible Study (ABS) last night!
 
 Please continue to pray that the Word of God would be powerful in transforming the lives of these individuals and bringing them to faith in Christ!
 
-### Correspondence Bible Course
+## Correspondence Bible Course
 
 In other news, Bryan has been getting involved right away in helping with the Correspondence Bible Course. The areas he is able to cover have been a tremendous help to Joshua and I in keeping up with the course.
 

--- a/content/blog/2009-02-12-the-bible-or-the-church.md
+++ b/content/blog/2009-02-12-the-bible-or-the-church.md
@@ -28,6 +28,6 @@ While this is a difficult choice for many, I believe that Marian has a sincere d
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/02/dsc_4863.jpg" caption="Jessie (right) chats with Taras (left) during English Club." >}}
 
-### A NOTE OF CLARIFICATION
+## A NOTE OF CLARIFICATION
 
 The Bible teaches that the true Church is the body of Jesus Christ, consisting of all born-again believers. (Col. 1:18, 24; I Cor. 12:27) As such, Christ's Church is much higher than any denomination or religious system operating on Earth. While the New Testament certainly calls for believers to assemble themselves in a local church structure, we believe that <span style="text-decoration: underline;">the Bible nonetheless remains our final authority in every area</span>. No person or organization - whether or not they refer to themselves as a "church" - has the authority to teach doctrines which contradict the written Word of God.

--- a/content/blog/2009-03-02-our-love-story.md
+++ b/content/blog/2009-03-02-our-love-story.md
@@ -17,7 +17,7 @@ Joshua and I have often expressed how much we wished we had written our love sto
 
 **Psalm 118: 23 "This is the LORD's doing; it is marvelous in our eyes."**
 
-### PART ONE
+## PART ONE
 
 "Thank you so much!" I crooned as I pulled a cute gray sweater vest from the gift bag. "Mrs. Steele, it was so nice having you on the team this week. I really enjoyed meeting you. And Jessica, it was great getting to know you too!"
 

--- a/content/blog/2009-03-09-our-trip-to-krakow.md
+++ b/content/blog/2009-03-09-our-trip-to-krakow.md
@@ -30,6 +30,6 @@ Because the tracks in Ukraine are a different gauge than the rest of Europe, the
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/03/dsc_5098.jpg" caption="Oh, and did we mention that McDonald's in Krakow has sausage-egg-and-cheese biscuits? Glory hallelujah!" >}}
 
-### ABS Tomorrow
+## ABS Tomorrow
 
 We skipped one week of ABS while we were in Poland, but will be resuming tomorrow evening. We would appreciate your prayers as usual: Tuesday @ 12:00pm CST. Thank you!

--- a/content/blog/2009-05-26-some-girls-and-some-guys.md
+++ b/content/blog/2009-05-26-some-girls-and-some-guys.md
@@ -12,7 +12,7 @@ slug: 2009-05-26-some-girls-and-some-guys
 
 It's been a while since we've posted any pictures of Abby and Rebekah. Here's a sampling of some family shots.
 
-### The Girls
+## The Girls
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6319.jpg" caption="Abby tries on a new skirt that Baba (her grandma) made for her." >}}
 
@@ -26,7 +26,7 @@ It's been a while since we've posted any pictures of Abby and Rebekah. Here's a 
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_5173.jpg" caption="Rebekah often toddles back to Daddy's office for a visit." >}}
 
-### The Guys
+## The Guys
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2009/05/dsc_6386.jpg" caption="Meet Daniel Courter, our latest recruit, and one of the guys who will be participating in CMO 2009." >}}
 

--- a/content/blog/2010-04-30-were-back.md
+++ b/content/blog/2010-04-30-were-back.md
@@ -17,6 +17,6 @@ I'd also like to express our sincere gratefulness to our friends and family on t
 
 Here in L'viv, we're still in the process of unpacking and reorganizing, but are making progress. I'm moving my office over to our ministry center, which will free up an extra room in our house. This will probably end up being the baby's room/guest room. Once we get our feet under us, we'll be sending out the next issue of Overseas Field Report with more ministry details. In the meantime, we appreciate your continued prayers for us as we gear up for a full summer of ministry.
 
-### VISA UPDATE
+## VISA UPDATE
 
 For those of you who have kept up with the visa saga, know that our troubles in that arena are far from over. The day we got in from the States, I went with a small group of Americans to meet with a representative of the US Consulate from Kyiv. We discussed with him our concerns and some of the problems we have experienced with registration. He was able to give us quite a bit of information which I believe will be helpful in solving the problems we face. There are still several unknowns, but in a nutshell it appears we will no longer be able to use the Type-K (cultural) visas that we've all had in the past. Please continue to pray that the Lord would give us wisdom as we search for lasting solutions to these immigration issues.

--- a/content/blog/2012-05-09-sad-turn-events.md
+++ b/content/blog/2012-05-09-sad-turn-events.md
@@ -10,7 +10,7 @@ slug: 2012-05-09-sad-turn-events
 
 The following is copied from an email which I sent out yesterday to a small group of family and friends. We appreciate your prayers for our family during this time.
 
-### Email, May 8, 2012
+## Email, May 8, 2012
 
 Today Kelsie and I went for a routine ultrasound to our clinic here in L'viv, hoping to find out the gender of our baby. Instead, we were shocked to learn that the baby has cystic hygroma (also known as lymphatic malformation), a severe genetic disorder which, depending on the cause, is often fatal. In our case, it is probable that this condition resulted from chromosomal abnormalities which were in motion from the start of the pregnancy.
 

--- a/content/blog/2012-07-03-patient-faith.md
+++ b/content/blog/2012-07-03-patient-faith.md
@@ -12,7 +12,7 @@ On Sunday morning, June 3, I preached a message called Patient Faith at our home
 
 You can listen to the message using the audio player below, or download it by right-clicking the download link and selecting "Save as...".
 
-### Patient Faith (51 minutes)
+## Patient Faith (51 minutes)
 
 <audio width="300" height="32" controls="controls">
 <source src="https://d21yo20tm8bmc2.cloudfront.net/audio/Patient-Faith.mp3" type="audio/mpeg" />

--- a/content/blog/2012-11-30-love-story-part-1.md
+++ b/content/blog/2012-11-30-love-story-part-1.md
@@ -16,7 +16,7 @@ The book is due to come out in January, but we'd like to give you a preview of o
 
 And now, without further ado...
 
-### Part 1 – Three Strikes and You’re Out?
+## Part 1 – Three Strikes and You’re Out?
 
 As the year 2003 was drawing to a close, I had reached the grim conclusion that God probably did not want me to be married any time soon. I was 24, and while my life heretofore had seen many successes, romance had not been among them. Onlookers, perhaps, suspected that I just was not trying hard enough, but this was far from true.
 

--- a/content/blog/2013-01-11-love-story-part-7.md
+++ b/content/blog/2013-01-11-love-story-part-7.md
@@ -26,7 +26,7 @@ The days and weeks that followed were a delightful blend of travel, meeting fami
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2013/01/111_1129.jpg" alt="111_1129" >}}
 
-### Ever After
+## Ever After
 
 At the time of this writing, Kelsie and I have been married for over 8 years, and the Lord has blessed us with three precious children who are the joy of our lives. While married life has certainly presented its challenges, we have faced them together: not as competitors, but as friends. In fact, the phrase, “You’re my best friend,” is one used often in our home.
 

--- a/content/blog/2013-05-25-pillars-genesis-part-1-adam.md
+++ b/content/blog/2013-05-25-pillars-genesis-part-1-adam.md
@@ -11,11 +11,11 @@ slug: 2013-05-25-pillars-genesis-part-1-adam
 
 The following text is taken from the twentieth and final lesson of [*Bible First*](http://www.getbiblefirst.com/). As promised in a previous issue of our newsletter, we'll be publishing *The Seven Pillars of Genesis* as a series of blog posts over the next few weeks.
 
-### The Seven Pillars of Genesis
+## The Seven Pillars of Genesis
 
 Genesis introduces many significant characters, but seven individuals in particular clearly illustrate the Gospel message in story form. These men–Adam, Abel, Noah, Abraham, Isaac, Jacob and Joseph–are Genesis’ Seven Pillars. Their stories constitute the bulk of the Genesis narrative, each one presenting a different aspect of the Gospel and revealing God’s plan for the salvation of the world.
 
-### Adam’s Dominion
+## Adam’s Dominion
 
 The Bible is a book of kingdoms, and Adam was earth’s first king. Like most monarchs, Adam’s authority was given him by right of birth. Immediately after his creation, God charged Adam to take dominion over the entire planet.
 
@@ -25,11 +25,11 @@ But Adam was more than our first king. He was also our father. Though he did not
 
 Like Adam, Christ also came as King on the earth. He too received His authority by right of birth, and stood at the head of a new family. As such, Christ commanded the same power of influence over His descendants that Adam did. But unlike Adam, Christ understood His position fully, and He chose to obey God in righteousness, succeeding where Adam had failed. His complete triumph over sin and death brought about the rebirth of multitudes into a new family whose children enjoy freedom from the bondage of the old kingdom. The Scriptures aptly refer to Christ as the Second Adam, *“And so it is written, <span style="text-decoration: underline;">The first man Adam</span> was made a living soul; <span style="text-decoration: underline;">the last Adam</span> was made a quickening spirit. …The <span style="text-decoration: underline;">first man</span> is of the earth, earthy: the <span style="text-decoration: underline;">second man</span> is the Lord from heaven.” (1 Corinthians 15:45, 47)*
 
-### Adam’s Dominion in Genesis
+## Adam’s Dominion in Genesis
 
 *“And God said, Let us make man in our image, after our likeness: and <span style="text-decoration: underline;">let them have dominion</span> over the fish of the sea, and over the fowl of the air, and over the cattle, and over all the earth, and over every creeping thing that creepeth upon the earth. So God created man in his own image, in the image of God created he him; male and female created he them. And God blessed them, and God said unto them, Be fruitful, and multiply, and replenish the earth, and subdue it: <span style="text-decoration: underline;">and have dominion</span> over the fish of the sea, and over the fowl of the air, and <span style="text-decoration: underline;">over every living thing that moveth upon the earth</span>.” (Genesis 1:26–28)*
 
-### Adam and Christ Contrasted in the New Testament
+## Adam and Christ Contrasted in the New Testament
 
 *“For since by man came death, by man came also the resurrection of the dead. For as <span style="text-decoration: underline;">in Adam all die</span>, even so <span style="text-decoration: underline;">in Christ shall all be made alive</span>.” (1 Corinthians 15:21-22)*
 

--- a/content/blog/2013-06-01-pillars-genesis-part-2-abel.md
+++ b/content/blog/2013-06-01-pillars-genesis-part-2-abel.md
@@ -11,7 +11,7 @@ slug: 2013-06-01-pillars-genesis-part-2-abel
 
 The following is an excerpt taken from the twentieth and final lesson of *[Bible First](http://www.getbiblefirst.com)*.
 
-### Abel’s Atonement
+## Abel’s Atonement
 
 Abel’s offering of a lamb in Genesis 4 clearly represents the payment God requires to atone for (that is, cover) sin. Only innocent blood possesses the judicial power to effectively remove sin. (See Leviticus 17:11, Hebrews 9:22)
 
@@ -23,11 +23,11 @@ The Biblical account of Cain and Abel does not explain where they learned of the
 
 However, the blood of animals could only provide a temporary covering for sin. (Hebrews 10:1-4) Abel’s lamb, while acceptable to God at that time, represents a mere shadow of God’s ultimate solution for the redemption of mankind. Thousands of years after Abel’s cruel death at the hands of Cain, Jesus was announced by John the Baptist as, *“…the Lamb of God, which taketh away the sin of the world.” (John 1:29)* Like Abel, Christ was also murdered by wicked men who spilled His divine blood as they scourged and crucified Him. But in contrast to Abel, Christ’s blood did not cry out for vengeance. (Genesis 4:10, Hebrews 12:24) Though it appeared a tragedy, the death of Christ was a triumph, a voluntary sacrifice that provided the atonement needed to cover our sin.
 
-### Abel’s Atonement in Genesis
+## Abel’s Atonement in Genesis
 
 *“And Abel, he also brought of the firstlings of his flock and of the fat thereof. And the LORD had respect unto Abel and to his offering:” (Genesis 4:4)*
 
-### Other Key Passages on Blood Atonement
+## Other Key Passages on Blood Atonement
 
 *“For the life of the flesh is in the blood: and I have given it to you upon the altar to make an atonement for your souls: for <span style="text-decoration: underline;">it is the blood that maketh an atonement for the soul</span>.” (Leviticus 17:11)*
 

--- a/content/blog/2013-06-08-pillars-genesis-part-3-noah.md
+++ b/content/blog/2013-06-08-pillars-genesis-part-3-noah.md
@@ -11,7 +11,7 @@ slug: 2013-06-08-pillars-genesis-part-3-noah
 
 The following is an excerpt taken from the twentieth and final lesson of *[Bible First](http://www.getbiblefirst.com)*.
 
-### Noah’s Position
+## Noah’s Position
 
 Noah lived in an era of wickedness so terrible that it caused God to regret His creation of the human race. Yet in the midst of this universal debauchery, Noah was found to be righteous.
 
@@ -27,13 +27,13 @@ Noah initially found grace in the sight of God because he chose to walk righteou
 
 The ark is an Old Testament illustration of Jesus Christ. As in the days of Noah, God has seen fit to provide a means for the salvation of anyone who will receive it. Jesus is our ark, and all who enter in will be delivered from the coming flood of God’s righteous wrath. Christ Himself declares in John 10:9, *“I am the door: by me if any man enter in, he shall be saved…”*
 
-### Noah’s Position IN the Ark
+## Noah’s Position IN the Ark
 
 *“And the LORD said unto Noah, Come thou and all thy house <span style="text-decoration: underline;">into the ark</span>; for thee have I seen righteous before me in this generation.” (Genesis 7:1)*
 
 *“By faith Noah, being warned of God of things not seen as yet, moved with fear, prepared an ark to the saving of his house; by the which he condemned the world, and became heir of the righteousness which is by faith.” (Hebrews 11:7)*
 
-### The Bible Speaks of our Position IN Christ
+## The Bible Speaks of our Position IN Christ
 
 *“For as <span style="text-decoration: underline;">in Adam</span> all die, even so <span style="text-decoration: underline;">in Christ</span> shall all be made alive.” (1 Corinthians 15:22)*
 

--- a/content/blog/2013-06-15-pillars-genesis-part-4-abraham.md
+++ b/content/blog/2013-06-15-pillars-genesis-part-4-abraham.md
@@ -11,7 +11,7 @@ slug: 2013-06-15-pillars-genesis-part-4-abraham
 
 The following is an excerpt taken from the twentieth and final lesson of *[Bible First](http://www.getbiblefirst.com)*.
 
-### Abraham’s Faith
+## Abraham’s Faith
 
 Historically, men have sought God’s favor through their works. While this pursuit is theoretically legitimate, it is always found inadequate due to the presence of sin. Although righteous works are indeed pleasing to God, they cannot undo evil works.
 
@@ -25,11 +25,11 @@ With Abraham, God revealed a completely new kind of moral standing, a righteousn
 
 Proverbs 11:4 presents a simple and solemn warning for all who seek deliverance from God’s coming judgment: “Riches profit not in the day of wrath: But righteousness delivereth from death.” To this we have a joyous response, for the righteousness we cannot attain by works is freely given by faith! *“But now the righteousness of God without the law is manifested, being witnessed by the law and the prophets; <span style="text-decoration: underline;">Even the righteousness of God which is by faith</span> of Jesus Christ unto all and upon all them that believe: for there is no difference:” (Romans 3:21–22)*
 
-### Abraham’s Faith in Genesis
+## Abraham’s Faith in Genesis
 
 *“And [the Lord] brought him forth abroad, and said, Look now toward heaven, and tell the stars, if thou be able to number them: and he said unto him, So shall thy seed be. And <span style="text-decoration: underline;">[Abraham] believed in the LORD</span>; and he <span style="text-decoration: underline;">counted it to him for righteousness</span>.” (Genesis 15:5–6)*
 
-### Righteousness Imputed by Faith in the New Testament
+## Righteousness Imputed by Faith in the New Testament
 
 *“For what saith the scripture? <span style="text-decoration: underline;">Abraham believed God, and it was counted unto him for righteousness</span>. Now to him that worketh is the reward not reckoned of grace, but of debt. But to him that <span style="text-decoration: underline;">worketh not</span>, but <span style="text-decoration: underline;">believeth on him</span> that justifieth the ungodly, <span style="text-decoration: underline;">his faith is counted for righteousness</span>.” (Romans 4:3–5)*
 

--- a/content/blog/2013-06-22-pillars-genesis-part-5-isaac.md
+++ b/content/blog/2013-06-22-pillars-genesis-part-5-isaac.md
@@ -11,7 +11,7 @@ slug: 2013-06-22-pillars-genesis-part-5-isaac
 
 The following is an excerpt taken from the twentieth and final lesson of *[Bible First](http://www.getbiblefirst.com)*.
 
-### Isaac’s Substitution
+## Isaac’s Substitution
 
 After repeatedly promising Abraham that he would become a great nation, God fulfilled His word by giving Abraham a miracle son: Isaac. Given this background, one can only imagine the shock Abraham must have experienced when God commanded him to offer Isaac as a sacrifice. Not only was human sacrifice inconsistent with God’s previous commands regarding the sanctity of life, but this new directive seemed a contradiction of His promise to make Abraham the head of a great nation. How could there ever be such a nation if God’s promised child, Isaac, was to die?
 
@@ -25,11 +25,11 @@ Similar to Isaac’s plight, all of humanity was once in jeopardy because of sin
 
 Substitution was God’s master plan to save His family from condemnation. By offering His only begotten Son to be executed in our place, God could remain just, and at the same time justify the ungodly. *“...That he might be just, and the justifier of him which believeth on Jesus.” (Romans 3:26)* Christ took our place on the cross in order to purchase for us a place in the family of God.
 
-### Isaac’s Substitution in Genesis
+## Isaac’s Substitution in Genesis
 
 *“And Abraham lifted up his eyes, and looked, and behold behind him a ram caught in a thicket by his horns: and Abraham went and took the ram, and offered him up for a burnt offering <span style="text-decoration: underline;">in the stead of his son</span>.” (Genesis 22:13)*
 
-### Christ as Our Substitute in the New Testament
+## Christ as Our Substitute in the New Testament
 
 *“For when we were yet without strength, in due time <span style="text-decoration: underline;">Christ died for the ungodly</span>. For scarcely for a righteous man will one die: yet peradventure for a good man some would even dare to die. But God commendeth his love toward us, in that, <span style="text-decoration: underline;">while we were yet sinners, Christ died for us</span>.” (Romans 5:6–8)*
 

--- a/content/blog/2013-06-29-pillars-genesis-part-6-jacob.md
+++ b/content/blog/2013-06-29-pillars-genesis-part-6-jacob.md
@@ -11,7 +11,7 @@ slug: 2013-06-29-pillars-genesis-part-6-jacob
 
 The following is an excerpt taken from the twentieth and final lesson of *[Bible First](http://www.getbiblefirst.com)*.
 
-### Jacob’s Inheritance
+## Jacob’s Inheritance
 
 Jacob, the third of the great patriarchs, seemed an unlikely candidate to carry on the Abrahamic covenant, and yet his life demonstrated a personal relationship with God and a genuine walk of faith. Many aspects of Jacob’s life parallel that of Christ, but perhaps most significant is his inheritance.
 
@@ -21,11 +21,11 @@ On the night that Jacob wrestled with God, his name was changed to Israel, which
 
 The Scriptures reveal that Christ also received a great inheritance from His Father, and became heir to a kingdom. All who believe on His name are made citizens of this kingdom, and are born again into the family of God, receiving what the Apostle Peter calls *“an inheritance incorruptible, and undefiled, and that fadeth not away, reserved in heaven for you.” (1 Peter 1:4)* Speaking of believers, Peter further expounds our great inheritance in Christ: *“But ye are a chosen generation, a royal priesthood, an holy nation, a peculiar people; that ye should shew forth the praises of him who hath called you out of darkness into his marvellous light:” (1 Peter 2:9)*
 
-### Jacob’s Inheritance in Genesis
+## Jacob’s Inheritance in Genesis
 
 *“And he dreamed, and behold a ladder set up on the earth, and the top of it reached to heaven: and behold the angels of God ascending and descending on it. And, behold, the LORD stood above it, and said, I am the LORD God of Abraham thy father, and the God of Isaac: <span style="text-decoration: underline;">the land whereon thou liest, to thee will I give it, and to thy seed</span>; And thy seed shall be as the dust of the earth, and thou shalt spread abroad to the west, and to the east, and to the north, and to the south: <span style="text-decoration: underline;">and in thee and in thy seed shall all the families of the earth be blessed.</span>” (Genesis 28:12–14)*
 
-### Our Inheritance in Christ
+## Our Inheritance in Christ
 
 *“How much more shall the blood of Christ, who through the eternal Spirit offered himself without spot to God, purge your conscience from dead works to serve the living God? And for this cause he is the mediator of the new testament, that by means of death, for the redemption of the transgressions that were under the first testament, <span style="text-decoration: underline;">they which are called might receive the promise of eternal inheritance.</span>” (Hebrews 9:14–15)*
 

--- a/content/blog/2014-01-25-position-ukraine.md
+++ b/content/blog/2014-01-25-position-ukraine.md
@@ -17,13 +17,13 @@ There are quite a few foreign missionaries (Americans, Canadians, Czech, and oth
 
 Over the past few days, several options have been discussed. We have tried our best to peer a little ways into the future and discern how we should respond. Should we stay put? Should we leave? Whether we stay or leave, what preparations should we make? For my part, I feel that I have found reasonable answers to those questions based on the facts available. But before I share our plan, let’s take a quick look at the current state of things in L’viv.
 
-### The Status in L’viv
+## The Status in L’viv
 
 For my entire adult life, I have made my home in [L’viv](http://en.wikipedia.org/wiki/Lviv), a medium-size city in western Ukraine with a population comparable to my Texas hometown of Fort Worth. As of this writing, the bulk of the violence is occurring in Kyiv, Ukraine’s capital city, which is located a little more than 300 miles east of us. For now, things in L’viv are mostly calm. Yes, it is true that protesters have taken over the Oblast Administration building (as they have in many other oblasts across the country), and have forced the governor to resign, but happily, the city continues to operate mostly normally.
 
 Yesterday, I was in downtown L’viv for an hour or so running errands, and except for the peaceful gathering of protesters in the main square (our “maydan”) there were no signs that anything was amiss. Public transportation is functioning normally, traffic is horrendous as usual, shops are open for business, and people are going about their daily lives as best they can. There are no riot police on the streets. Furthermore, all major utilities and other services have continued without interruption. We have light, gas, water, heat, cell phone service, and internet access. Nothing has been turned off, and to my knowledge, the rumors of internet censorship have proven false. For now, at least, L’viv is very much a safe place to be.
 
-### Cause for Concern?
+## Cause for Concern?
 
 Given my description of peaceful L’viv, you might be tempted to think that we are not concerned about current events. Nothing could be further from the truth. We are not panicking, and we are grateful that our city is still safe, but the violence in Kyiv, the new anti-protest laws passed recently by the government, the lack of unity amongst opposition leaders, and the scores of people who are suffering the loss of life and limb, all provide ample justification for the use of the term *crisis*.
 
@@ -31,7 +31,7 @@ While the reality of the conflict is clear, the wisest course of action is perha
 
 If all that seems like a cloud of complexity, that’s because it is. War–if that is indeed what we are facing–is never simple. But despite all this, we are not without direction.
 
-### Our Plan
+## Our Plan
 
 God has blessed us with a wonderful team here on the mission field, and for the most part we try to do things together. The current crisis is no exception. All three of the men who lead [Euro Team Outreach](http://www.euroteamoutreach.org)–myself, Nathan Day, and Jessie Beal–have discussed the situation and decided on a course of action for our team. This is our outlook in a nutshell:
 
@@ -40,7 +40,7 @@ God has blessed us with a wonderful team here on the mission field, and for the 
 * If we do decide to leave, Poland is the likely destination, though there are others as well. Ukraine borders five US-friendly countries on its western side. Poland, the closest of the five, is less than two hours by car from L’viv.
 * We are praying and trusting that the Lord will guide and protect us now as He always has. We are persuaded that those who fear God need not fear anyone else.
 
-### Conclusion
+## Conclusion
 
 To date, none of the foreign missionaries we know in L’viv have made the decision to leave Ukraine. We’re all still here, and we’re all praying that this situation will be resolved peacefully. Our ministries are moving forward, and our families are continuing with daily life.
 

--- a/content/blog/2014-07-17-overcome-evil-with-good.md
+++ b/content/blog/2014-07-17-overcome-evil-with-good.md
@@ -36,15 +36,15 @@ Please don’t stop praying for our team as we minister. God knows every heart i
 
 If you’d like to keep up with CMO 2014 as the project progresses, be sure to subscribe to the ETO eReport at [www.euroteamoutreach.org](http://www.euroteamoutreach.org).
 
-### New *Bible First* Lessons
+## New *Bible First* Lessons
 
 We’ve recently released Volumes 3 and 4 of our *Bible First* course in English. These two volumes add an additional seven lessons to those already available. As our local *Bible First* course in Ukraine continues to grow, we are excited to see more people using the English version of these materials in their own ministries. To learn more about how you can use *Bible First* to reach the lost in your own ministry, please visit our web site: [www.getbiblefirst.com](http://www.getbiblefirst.com).
 
-### Baby Update
+## Baby Update
 
 As you likely know already, we are excitedly anticipating the arrival of our fourth child in late December of this year! After much prayer and consideration, we’ve decided to have the baby in the U.S. For that reason, our family will be coming back to Texas in mid-October to prepare for the birth. Please pray for safety and health as we travel.
 
-### How You Can Pray
+## How You Can Pray
 
 * Pray for open doors to preach Christ in the Carpathians and throughout Ukraine.
 * Praise God for the many new responses we are receiving as a result of literature campaigns!

--- a/content/blog/2014-11-03-smoky-mountain-shindig.md
+++ b/content/blog/2014-11-03-smoky-mountain-shindig.md
@@ -30,7 +30,7 @@ NGJ also set up an exhibit hall where vendors could sell various products and se
 
 If you’d like to learn more about the Shindig, be sure to visit [www.nogreaterjoy.org/shindig](http://www.nogreaterjoy.org/shindig). All the sessions were recorded on video and I believe they will be made available soon.
 
-### Missionary to Egypt
+## Missionary to Egypt
 
 This year, we had just one CMO guy who joined us from the US. His name is James Slice, and he is now preparing to go as a full-time missionary to Egypt. Even before coming to Ukraine, James had his eye on Egypt, and has spent more than a year studying Arabic.
 
@@ -41,13 +41,13 @@ We ministered side-by-side with James for two months in Ukraine, and I can say w
 If you would be interested in supporting James financially or simply want to know more about his work, you can contact him via e-mail at
 [james.alvin260@gmail.com](mailto:james.alvin260@gmail.com).
 
-### Family Update
+## Family Update
 
 Following a busy month of travel and speaking engagements in September, we’ve been enjoying some rest and fellowship with our extended family. Right now we’re staying with Kelsie’s parents, the Powells, and in early December we’ll be heading back to Fort Worth where we’ll spend some time with my parents and prepare for the birth.
 
 Our fourth daughter is due to be born on December 19th, though past experience suggests that she’s more likely to come in the form of a Christmas gift. Either way, we’re thrilled to be receiving yet another little one from the Lord. Please pray with us for strength, health and safety for Kelsie and the baby.
 
-### How You Can Pray
+## How You Can Pray
 
 * Pray for a strong team for CMO 2015. Details are available now at [www.CMOproject.org](http://www.CMOproject.org).
 * Praise God for over 50 Ukrainian graduates from our Bible First program!

--- a/content/blog/2015-02-09-welcome-kathryn-grace.md
+++ b/content/blog/2015-02-09-welcome-kathryn-grace.md
@@ -24,7 +24,7 @@ In just a few days, our family will be flying back to Ukraine to continue our mi
 
 (HINT: More baby photos at the end of this post!)
 
-### CMO 2015
+## CMO 2015
 
 This year’s CMO project is on track to begin June 15th. As I mentioned above, the military conflict in Ukraine has caused many to give greater consideration to the things of eternity, and we believe that we are facing a special door of opportunity to sow the seed of the Gospel on fertile ground. We’re praying that God will raise up a strong team of young men to help us preach Christ in Ukraine this summer!
 
@@ -32,7 +32,7 @@ This year’s CMO project is on track to begin June 15th. As I mentioned above, 
 
 The deadline to [register for CMO 2015 is May 1](https://cmoproject.org/), so if you or someone you know is interested in coming, please contact us right away! And of course, please continue to lift up our team in prayer as we make preparations for the summer.
 
-### *Bible First* Update
+## *Bible First* Update
 
 Our list of *Bible First* graduates in Ukraine continues to grow, with the majority professing faith in Christ and expressing interest in receiving more of our materials in the future. One of our next major objectives is to make *Bible First* available online, and to this end we’ve begun developing a web-based application that will allow anyone world-wide to begin and manage their own *Bible First* course. This application will open the door to allowing our Ukrainian graduates to begin their own indigenous ministries, reaching their fellow Ukrainians using the same materials that brought them to Christ.
 
@@ -40,7 +40,7 @@ Our list of *Bible First* graduates in Ukraine continues to grow, with the major
 
 In late January, we were very blessed to have Trevor Brown, a software developer from Florida, visit us in Texas for an entire week. Trevor and I spent many hours writing code to get the *Bible First* app on its feet, and while there is still much to do, we made a great start! Trevor will continue to work with us remotely as we develop this software.
 
-### How You Can Pray
+## How You Can Pray
 
 * Pray for our family as we depart for Ukraine on February 16th.
 * Praise the Lord for His protection and provision surrounding Kathryn’s birth!

--- a/content/blog/2015-04-27-when-god-provides.md
+++ b/content/blog/2015-04-27-when-god-provides.md
@@ -24,19 +24,19 @@ Yet nothing is impossible with God. As we have experienced time and again, God l
 
 So without further ado, here’s the blow-by-blow of how God blessed us with a new home that fits our needs better than we could have hoped.
 
-### Monday, February 23
+## Monday, February 23
 
 We’d been in Ukraine all of three days. That morning I had a meeting with our attorney to discuss the upcoming renewal of our residency permits. As we were finishing up, I mentioned to him that we would like to begin searching for a new apartment. His daughter, Victoria, is a realtor and he promised to pass along my request. As I returned home to continue unpacking from our trip, I had no idea how quickly things were about to move.
 
 That very afternoon, I received a call from Victoria. She had gotten the message from her father, and now she wanted to know more details about what we were looking for. Location? Number of rooms? Cost? I gave her some general criteria, but emphasized that we were willing to be flexible. We haven’t been apartment hunting for ourselves in several years, and I wasn’t sure what we’d find on the market.
 
-### Tuesday, February 24
+## Tuesday, February 24
 
 To my surprise, Victoria called and said she had found a large apartment right in our region that was for rent. When could we come and see it?
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/04/2015-02-26-15.22.22.jpg" caption="The building where our new apartment is located." >}}
 
-### Wednesday, February 25
+## Wednesday, February 25
 
 At the agreed upon time, Kelsie and I went to the address Victoria had provided us. It was only about a five-minute drive from Tychyny, and almost across the street from the apartment that ETO rents as our “Ministry Center”!
 
@@ -50,11 +50,11 @@ Since the Ministry Center was just a couple of blocks away, Kelsie and I walked 
 
 Needless to say, we called Victoria back with a positive answer.
 
-### Thursday, February 26
+## Thursday, February 26
 
 At 2pm, we sat down and signed a one-year lease for an apartment well over twice the size of our previous one. We had been in Ukraine for six days.
 
-### Let the “Remont” Begin!
+## Let the “Remont” Begin!
 
 The Ukrainian language has a wonderful little word that translates “remodeling job”: remont. Even the Americans here use the word remont in everyday speech, partly because it’s short and easy to say, and partly because it seems everyone is either doing a remont or needs to do one.
 
@@ -66,7 +66,7 @@ This brings up another amazing (at least to us) part of this story: all of this 
 
 As the painting progressed, we began slowly ferrying our belongings over in Jessie’s van, which he graciously allowed us to use throughout this time.
 
-### Moving Day
+## Moving Day
 
 Finally, the remont was finished and it was time to move. We packed everything in advance, wrapped all our furniture in plastic film, and steeled ourselves (no pun intended) for what promised to be a whopper of a work day.
 
@@ -80,7 +80,7 @@ A few days before the move, two young guys came over, glanced briefly around the
 
 On the day of the move, they arrived at 8am sharp. They worked all day long, helped by me and two other guys from our team. When they finally carried the last of our belongings into the new house, it was past midnight. Exhausted, they told us that it was by far the largest job they’d ever had.
 
-### Taste and See
+## Taste and See
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/04/2015-02-26-15.20.14.jpg" caption="2015-02-26 15.20.14" >}}
 
@@ -96,7 +96,7 @@ In the weeks leading up to our move, our family had been memorizing Psalm 34. Th
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/04/IMG_6471.jpg" caption="Space for dad to have his office at home!" >}}
 
-### An 8-man CMO Team
+## An 8-man CMO Team
 
 The roster for CMO this year is filling up quickly! As of this writing, we have six men confirmed to come for the project. Adam, Isaiah, Ben, Joe, Caleb and Emmanuel will be joining Nathan and I in mid-June for six weeks of literature campaigns, film showings, mountain travel and hands-on missionary training.
 
@@ -104,7 +104,7 @@ This will be our 9th CMO project, and while we’ve covered lots of ground in ye
 
 So that you can be more informed as you pray, we would like to encourage you to visit our web site ([www.euroteamoutreach.org](http://www.euroteamoutreach.org)) and subscribe to our email newsletter. During the off-season, we send emails infrequently, but during the summer there will be updates nearly every week, written by various team members.
 
-### How You Can Pray
+## How You Can Pray
 
 * Praise the Lord for His provision of a larger apartment for our family!
 * Pray for Adam, Isaiah, Ben, Joe, Caleb and Emmanuel as they travel to Ukraine in June.

--- a/content/blog/2015-09-01-gaining-ground.md
+++ b/content/blog/2015-09-01-gaining-ground.md
@@ -28,7 +28,7 @@ Year after year, our stats continue to demonstrate that around 40% of all our Bi
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/09/38-20150620_175158.png" alt="38-20150620_175158" >}}
 
-### New Fronts
+## New Fronts
 
 In addition to the growth we are seeing in Ukraine, there is another type of multiplication that we are equally excited about. The men who come to CMO each summer are going on to establish their own ministries in the US and even in other countries.
 
@@ -40,7 +40,7 @@ Men from the CMO 2015 team are also moving forward in ministry. Emanuel Schrock 
 
 As always, your prayer support is greatly needed! Pray not only for our team here in Ukraine, but for these who are entering new fields, proclaiming the Lord to men and women who do not yet know Him.
 
-### How You Can Pray
+## How You Can Pray
 
 * Praise the Lord for new ground gained this summer in the advancement of the Gospel!
 * Pray for the CMO men as they continue their ministries in the US and around the world.

--- a/content/blog/2015-12-28-meet-oleg.md
+++ b/content/blog/2015-12-28-meet-oleg.md
@@ -29,7 +29,7 @@ Oleg has also begun some limited involvement in our Bible First ministry. For ex
 
 I’m excited about this new discipleship relationship with Oleg, and I would appreciate your prayers for us as we move forward. In particular, pray that God would open clear doors for Oleg and others like him to become involved in the Bible First ministry.
 
-### Family Update
+## Family Update
 
 Here at the Steele household – which some of our Ukrainian friends warmly refer to as “Joshua’s Kingdom of Ladies” – there’s never a dull moment. Our little girls are steadily growing into little ladies, with Abigail in particular taking on more and more responsibility in the home.
 
@@ -43,19 +43,19 @@ It’s hard to believe that Kathryn is nearly a year old! As I write this newsle
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/beka-abby-hands.jpg" caption="Our little girls are quickly becoming little ladies. :)" >}}
 
-### Bible First
+## Bible First
 
 We are excited to report that God is continuing to bless the impact of Bible First in Ukraine! In particular, our prison ministry is growing. In fact, since CMO ended this past summer, we’ve been enrolling an average of one new student almost every day!
 
 Trevor Brown and I are also continuing our programming efforts, working diligently to bring Bible First to the web. We feel that making the course available in electronic format will open many new doors to reaching the lost for Christ.
 
-### Next Summer...
+## Next Summer...
 
 Registration for next year’s Carpathian Mountain Outreach project is now open! CMO 2016 will begin on June 20, and the deadline for submitting applications is April 1. We’ve also put together a brand new CMO web site! Check out all the latest details at [www.cmoproject.org](http://cmoproject.org/). As always, we appreciate your prayers for this ministry, and for the young men who are even now making preparations to come.
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" alt="cmo-logo-full" >}}
 
-### How You Can Pray
+## How You Can Pray
 
 * Praise the Lord for Ukrainians who are hearing the Gospel as they study the Scriptures with Bible First
 * Pray for a strong team for CMO 2016.

--- a/content/blog/2016-04-18-parenting-seminar.md
+++ b/content/blog/2016-04-18-parenting-seminar.md
@@ -40,7 +40,7 @@ Finally the day came. Speaking tag-team, in Ukrainian, for nearly seven hours tu
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2016/04/IMG_6876.jpg" caption="The seminar lasted for the better part of a Saturday. It was exhausting but fun!" >}}
 
-### CMO 2016
+## CMO 2016
 
 Summer is approaching once again, and with it our annual project: Carpathian Mountain Outreach. This year it looks like five young men will be joining us from the States as we spread the Gospel here in western Ukraine.
 
@@ -48,7 +48,7 @@ As always, there is much preparation to be done. In particular, we will be print
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2015/12/cmo-logo-full.png" alt="cmo-logo-full" >}}
 
-### Bible First
+## Bible First
 
 God continues to bless the impact of our Bible First course both here in Ukraine and elsewhere. Enrollment for our Ukrainian course is now over 700 students, and with CMO approaching, that number is likely to increase significantly.
 
@@ -60,7 +60,7 @@ Additionally, the Lord has provided some extra assistance with the Bible First w
 
 <h3 style="text-align: center;"><a href="http://nogreaterjoy.org/shop/bible-first-complete-set">Purchase Bible First</a></h3>
 
-### How You Can Pray
+## How You Can Pray
 
 * Pray that much fruit would come as a result of the parenting seminar. Pray that God would open doors for us to do more seminars in the future.
 * Pray that God would bless CMO 2 016, and that as a result many would hear the Gospel.

--- a/content/blog/2016-09-22-platform-rising.md
+++ b/content/blog/2016-09-22-platform-rising.md
@@ -23,7 +23,7 @@ As I began my language-learning journey, I became something of a fanatic. I imme
 
 As I further developed my ministry, I ran into an unexpected frustration. Despite my ability to speak, there were surprisingly few who wanted to listen.
 
-### Audience First
+## Audience First
 
 If you’ve watched our [Bible First training videos](http://getbiblefirst.com/training/#video-start), then you are familiar with a concept we teach called “Audience First”. The basic idea is that in order to be effective in communicating a message, you first need to establish a hearing with your target audience. In social media, this is often referred to as “building a platform.”
 
@@ -31,7 +31,7 @@ Our world today is filled with voices competing for their turn at the mic. Every
 
 In this report, I’d like to share with you how God is blessing our platform in Ukraine and around the world.
 
-### Good and Evil: Round 2
+## Good and Evil: Round 2
 
 Several years ago, we translated Good and Evil into Ukrainian. We began handing out the books at film showings, and offering free copies on our web site. Back then, things were pretty quiet. But in recent months, we have seen traffic increase dramatically such that we are now sending out 50-70 books per month!
 
@@ -41,7 +41,7 @@ Just before CMO began this summer, someone posted a link to our web site on a Uk
 
 At this pace, our supply of books is fast running out, and soon it will be gone. God is clearly blessing this outreach, and for this reason, we’ve begun work on “Round 2” of our Good and Evil ministry. We are working on a completely new translation of Good and Evil and we’ll be using the latest color artwork from NGJ. If God provides the funds, we hope to do a new printing in Ukrainian next year.
 
-### Bible First Translations
+## Bible First Translations
 
 Since No Greater Joy began distributing Bible First books in English, we’ve seen demand for them grow tremendously! One area that is particularly exciting is the translation of Bible First into other languages. Right now, we have Spanish and French translations in progress. There is also a possibility that a Russian translation may begin soon.
 
@@ -51,13 +51,13 @@ Meanwhile, our Bible First ministry in Ukraine is thriving as well. We continue 
 
 In the United States, a growing number of people are using Bible First to great effect in prisons. Just a few days ago, I received an email from a brother named Steve who says, “I use the Bible First course in the prison that I minister at full time in Alabama and the inmates LOVE the course and are constantly asking me if there are more courses by Bible First.”
 
-### A Cup Overflowing
+## A Cup Overflowing
 
 As we look towards the fall season, our ministry cup is overflowing! Our message is the same as it’s been for years, but now it seems that God is allowing it to reach even more people. In addition to the two projects I’ve mentioned above, I am continuing my weekly Bible study with Oleg, and I also have regular opportunities to preach in our church here in L’viv.
 
 Abigail, Rebekah, and Hosanna are all progressing well in school. Kelsie is a star homeschool mommy and keeps all of us on our toes! Little Kathryn is the sunshine in our lives, toddling all over the house and making new “discoveries” every day.
 
-### It’s a Boy!
+## It’s a Boy!
 
 In case you missed our blog post in June, we’d like to share some exciting news! Kelsie is in her 25th week of pregnancy. And now, after four girls, God has given us our first boy! We are thrilled and grateful for His gift of life, and we’re ready to embark on this new adventure. The girls in particular are excited that they will finally have a little brother. :)
 
@@ -65,7 +65,7 @@ In case you missed our blog post in June, we’d like to share some exciting new
 
 Aside from the usual fatigue, Kelsie is doing well. Based on the latest ultrasound data, our projected due date is January 5, 2017. Please keep Kelsie and our new baby in your prayers!
 
-### How You Can Pray
+## How You Can Pray
 
 * Praise God for the new doors He is opening in ministry. Pray that we will continue to be diligent stewards of the platform He has given.
 * Pray for those who heard the Gospel during CMO 2016.

--- a/content/blog/2016-12-31-translators.md
+++ b/content/blog/2016-12-31-translators.md
@@ -24,7 +24,7 @@ Because we are English speakers ministering the Gospel amongst Ukrainians, trans
 
 Now, as Bible First spreads far beyond the borders of Ukraine, the need for translation work has again come to the forefront. We’re very encouraged about the progress being made, and in this report I’d like to share an update on three specific language groups.
 
-### Ukrainian
+## Ukrainian
 
 Back in the mid-2000’s, the very first language group to receive a translation of Bible First was Ukrainian. Later, we implemented significant improvements to our English lessons, but many of these were never incorporated back into the earlier Ukrainian lessons.
 
@@ -33,14 +33,14 @@ This fall, we hired Anatoliy Zhylaviy, a Ukrainian translator and philologist fr
 ![Anatoliy Zhylavyi](https://d21yo20tm8bmc2.cloudfront.net/2016/12/DSC_1007a-295x300.jpg)
 Anatoliy Zhylavyi
 
-### French
+## French
 
 Meet Catherine Leavitt - a French national who has spent more than two decades living in Oregon. Catherine contacted us several months ago with a desire to translate Bible First into French. She’s been working diligently on the project and is making good progress. Her father, a French linguist who still lives in France, is assisting her as well. We are very grateful to their family, and we’re looking forward to making Bible First available as a ministry tool for believers in France!
 
 ![Catherine Leavitt](https://d21yo20tm8bmc2.cloudfront.net/2016/12/IMG_3244-400x300.jpg)
 Catherin Leavitt
 
-### Spanish
+## Spanish
 
 Several months ago, we received an email from a lady named Maria Sanchez. Maria uses Bible First in prison ministry, and because many of the inmates only speak Spanish, she asked if Bible First was available in that language. Upon learning that it was not, she asked for permission to translate it herself. Kelsie is also a Spanish speaker (she formerly translated for Voice of the Martyrs), and after reviewing a sample of Maria’s work, we gave her the green light.
 
@@ -49,7 +49,7 @@ Over the past several months, Maria has kept us on our toes as she has sent emai
 ![Maria Sanchez](https://d21yo20tm8bmc2.cloudfront.net/2016/12/mail_image_preview-400x300.png)
 Maria Sanchez
 
-### The Language of the Web
+## The Language of the Web
 
 As our Ukrainian, French and Spanish translators work to make Bible First available to those respective language groups, another effort is moving forward to make sure that these translations will enjoy the far-reaching scope of the World Wide Web. For some time now, we have been building a web-based application that will serve as a digital platform for Bible First. This app will allow churches and missionaries to reach people with Bible First over electronic media.
 
@@ -57,13 +57,13 @@ As of this writing, we estimate that Bible First Online is about 70% complete. T
 
 We’ll be writing more about this project in future updates, but for now, please pray for our development team as we build this app. We are particularly grateful for programmers Trevor Brown and Andy Buck who are assisting us.
 
-### Almost Baby Time!
+## Almost Baby Time!
 
 Oh, and there’s one more thing: it’s almost baby time! Kelsie is due to deliver our first son in early January. Please pray for our family–and Kelsie in particular–as we prepare to welcome our new little boy!
 
 ![Steele Kids](https://d21yo20tm8bmc2.cloudfront.net/2016/12/steele-girls-338x450.jpg)
 
-### How You Can Pray
+## How You Can Pray
 
 * Praise God for the work being done to translate Bible First into various languages.
 * Pray for Anatoliy, Catherine, and Maria as they translate. We are very grateful for their diligence and commitment to this ministry!

--- a/content/blog/2017-06-13-bible-first-kids.md
+++ b/content/blog/2017-06-13-bible-first-kids.md
@@ -45,17 +45,17 @@ Have you wondered whether or not *Bible First* could help you teach your kids ab
 
 {{< button href="https://getbiblefirst.com/" text="Learn more about Bible First" external=true >}}
 
-### Good and Evil Update
+## Good and Evil Update
 
 The translation of Good and Evil into Ukrainian continues to progress well. Anatoli has now completed two chapters, and Sasha (our designer in Kyiv) has done the initial layout work for both. Chapter three is moving forward! Please keep praying with us about this project. We hope to be ready to print by the fall as we need to have the new books ready for next year’s summer outreach.
 
-### The Russian is Coming!
+## The Russian is Coming!
 
 We are very pleased to announce that we now have a Russian translation of *Bible First* underway! Missionary Pat LaBarbera (sent out of same church as Jessie Beal) has been spearheading this effort. So far, nine lessons have been completed! There is a great demand even amongst our existing Ukrainian students for Russian-language materials, and we are looking forward to the completion of this translation.
 
 Please continue to pray for the various translation efforts. We now have four languages in progress: Ukrainian (revision), Spanish, French, and Russian.
 
-### How You Can Pray
+## How You Can Pray
 
 - Praise the Lord for the fruit we are seeing with our new Bible First Kids class at church!
 - Pray that Good and Evil in Ukrainian would be completed soon, and that we would be able to print this fall.

--- a/content/blog/2017-06-29-lviv-rope-course.md
+++ b/content/blog/2017-06-29-lviv-rope-course.md
@@ -35,7 +35,7 @@ Please keep praying for our class. We're approaching the end of [Lesson 2](https
 
 {{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-10-2000w.jpg" caption="Here's one for the refrigerator! Please remember to pray for our Bible First Kids in L'viv. Clockwise from the back row: Timothy, Joshua, Lisa, Danylo, Pastor Vladyslav, Anya, Maria, Anya, Akim, Anya, Mark, Stas, Matthew, Tolik. Yeah, we have a lot of Anya's in our group! ;)" >}}
 
-### The Grand Finale
+## The Grand Finale
 
 At the end of the rope course, everyone faced a mini rock-climbing wall followed by a zip line. Check out these videos of a few of our brave climbers!
 

--- a/content/blog/2017-08-12-a-chance-to-give-back.md
+++ b/content/blog/2017-08-12-a-chance-to-give-back.md
@@ -72,7 +72,7 @@ This cute little guy was fascinated with Joshua's camera!
 [![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/kelsie-katelin-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kelsie-katelin-2000w.jpg)
 This was the second mommy talk that Kelsie and Katelin have done together, and, Lord willing, it won't be their last!
 
-### How You Can Pray
+## How You Can Pray
 
 * Pray for the ladies who attended the seminar.
 * Praise God for great progress with our *Good and Evil* translation! More details in a future update...

--- a/content/blog/2018-03-19-two-robes.md
+++ b/content/blog/2018-03-19-two-robes.md
@@ -41,7 +41,7 @@ The room was silent as every eye remained fixed on the two children at the front
 Now then we are ambassadors for Christ, as though God did beseech you by us: we pray you in Christ's stead, be ye reconciled to God. For he hath made him to be sin for us, who knew no sin; that we might be made the righteousness of God in him. (2 Corinthians 5:20-21)
 {{< /callout >}}
 
-### Curious to hear some Ukrainian preaching?
+## Curious to hear some Ukrainian preaching?
 
 The clip below is from the Two Robes message. I'm reading a portion of Luke 2, and then asking the audience to quote in unison the phrase, "Glory to God in the highest, and on earth peace, good will toward men."
 

--- a/content/blog/2022-02-13-are-we-safe.md
+++ b/content/blog/2022-02-13-are-we-safe.md
@@ -40,7 +40,7 @@ work.
 
 <div id="buzzsprout-player-10223750"></div><script src="https://www.buzzsprout.com/1953515/10223750-are-we-safe.js?container_id=buzzsprout-player-10223750&player=small" type="text/javascript" charset="utf-8"></script>
 
-### Reference
+## Reference
 
 - [Message to US Citizens: Ukraine Land Border (ua.usembassy.gov)](https://ua.usembassy.gov/message-to-us-citizens-ukraine-land-border/)
 - [Home Sweet Ukraine (OFReport.com)](/blog/2022-01-24-home-sweet-ukraine/)

--- a/content/blog/2022-04-08-back-to-the-borders.md
+++ b/content/blog/2022-04-08-back-to-the-borders.md
@@ -27,7 +27,7 @@ Europe.
 
 <div id="buzzsprout-player-10408239"></div><script src="https://www.buzzsprout.com/1953515/10408239-back-to-the-borders.js?container_id=buzzsprout-player-10408239&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for our next trip to L’viv this weekend (Joshua and Kelsie only) and for
   our Ukrainian residency documents. Also pray for our kids’ wellbeing while
@@ -39,12 +39,12 @@ Europe.
   minister to Ukrainians.
 - Pray for peace and liberty in Ukraine.
 
-### PayPal in Ukraine
+## PayPal in Ukraine
 
 - [Press Release (paypal-corp.com)](https://newsroom.paypal-corp.com/2022-03-Expanding-PayPals-Money-Services-To-Help-Ukraine-Humanitarian-Efforts)
 - [Ukrainian-language Instructions (tsn.ua)](https://tsn.ua/ukrayina/paypal-v-ukrayini-scho-ce-take-yak-koristuvatisya-2012557.html)
 
-### News Sources
+## News Sources
 
 - [Ukraine NOW [English] (Telegram)](https://t.me/ukrainenowenglish)
 - [The Kyiv Independent (Telegram)](https://t.me/KyivIndependent_official)

--- a/content/blog/2022-04-20-all-over-the-map.md
+++ b/content/blog/2022-04-20-all-over-the-map.md
@@ -26,7 +26,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-10477856"></div><script src="https://www.buzzsprout.com/1953515/10477856-all-over-the-map.js?container_id=buzzsprout-player-10477856&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for our next trip to L’viv to pick up residency cards. We expect that
   some time in early May.
@@ -40,7 +40,7 @@ Ukrainians in Eastern Europe.
   minister to Ukrainians.
 - Pray for peace and liberty in Ukraine.
 
-### Resources
+## Resources
 
 - [Humanitarian Aid and Rescue Project (harprescue.org)](https://www.harprescue.org/)
 - [SOF News - April 18 (sof.news)](https://sof.news/ukraine/20220418/)

--- a/content/blog/2022-05-02-on-the-road-again.md
+++ b/content/blog/2022-05-02-on-the-road-again.md
@@ -35,7 +35,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-10552421"></div><script src="https://www.buzzsprout.com/1953515/10552421-on-the-road-again.js?container_id=buzzsprout-player-10552421&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for our next trip into Ukraine to pick up our residency cards. Since
   recording this episode we’ve been notified that they are ready! 🥳

--- a/content/blog/2022-05-16-voices-from-ukraine-serhii-and-natallia-chepara.md
+++ b/content/blog/2022-05-16-voices-from-ukraine-serhii-and-natallia-chepara.md
@@ -51,7 +51,7 @@ After you finish the episode, check out the video of Serhii and Natallia’s reu
 
 {{< youtube XT1vhANNw8Y >}}
 
-### How You Can Pray
+## How You Can Pray
 
 - Praise the Lord that we received our Ukrainian residency cards! 🥳
 - Pray for Serhii and Natallia as they navigate difficult days ahead.

--- a/content/blog/2022-06-04-digging-in-looking-ahead-to-the-long-haul.md
+++ b/content/blog/2022-06-04-digging-in-looking-ahead-to-the-long-haul.md
@@ -27,7 +27,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-10731962"></div><script src="https://www.buzzsprout.com/1953515/10731962-digging-in-looking-ahead-to-the-long-haul.js?container_id=buzzsprout-player-10731962&player=small" type="text/javascript" charset="utf-8"></script>
 
-### 💙💛 Radekhivski Hospodyni
+## 💙💛 Radekhivski Hospodyni
 
 Also in this episode, we talk more about the charity foundation “Radekhivski
 Hospodyni”. Their volunteers are working hard to send aid to soldiers on the
@@ -52,7 +52,7 @@ gift.
 
 ✅  **Specify “Radekhivski Hospodyni” in the memo line.**
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for Serhii and Natallia and their children as they persevere through
   prolonged separation. Pray for Serhii as he finishes his training and heads to
@@ -69,7 +69,7 @@ gift.
   minister to Ukrainians.
 - Pray for peace and liberty in Ukraine.
 
-### Resources
+## Resources
 
 - ❤️
   [Radekhivski Hospodyni (facebook.com)](https://www.facebook.com/groups/404821584832741/)

--- a/content/blog/2022-06-27-moving-again.md
+++ b/content/blog/2022-06-27-moving-again.md
@@ -26,7 +26,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-10860990"></div><script src="https://www.buzzsprout.com/1953515/10860990-moving-again.js?container_id=buzzsprout-player-10860990&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray that God would bless our move to the new house!
 - Pray that our fingerprints would be accepted at the FBI and that we would be

--- a/content/blog/2022-07-21-russia-and-geopolitics.md
+++ b/content/blog/2022-07-21-russia-and-geopolitics.md
@@ -28,7 +28,7 @@ Ukrainians in Eastern Europe.
 
 {{< figure src="OFReport/2022-07-21-russia-and-geopolitics/thehordelands2-01_kwpubx" caption="The Eurasian Hordelands map from [*The Accidental Superpower*](https://zeihan.com/purchase-the-accidental-superpower/) by Peter Zeihan" >}}
 
-### How You Can Pray
+## How You Can Pray
 
 - Praise the Lord for the provision of a house for our family during our stay in
   Slovakia.
@@ -45,7 +45,7 @@ Ukrainians in Eastern Europe.
   again on the rise.
 - Pray for peace and liberty in Ukraine. 💙💛
 
-### Resources
+## Resources
 
 - [Vinnytsia Attack (facebook.com)](https://www.facebook.com/joshukraine/posts/pfbid0bxUBuzDuQMsYjkh7sHhToPS67UFDy8WEAmm7iaj5Q25htbAocHaNy96xP7X8gkqdl)
 - [The Accidental Superpower by Peter Zeihan (amazon.com)](https://www.amazon.com/gp/product/1455583685/)

--- a/content/blog/2022-09-15-and-we-re-back.md
+++ b/content/blog/2022-09-15-and-we-re-back.md
@@ -27,7 +27,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-11325975"></div><script src="https://www.buzzsprout.com/1953515/11325975-and-we-re-back.js?container_id=buzzsprout-player-11325975&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for salvation for the many children and adults who heard the Gospel at
   our recent music outreach.
@@ -42,14 +42,14 @@ Ukrainians in Eastern Europe.
 - Pray for health for our family. (Kids — chicken pox, Joshua — asthma)
 - Pray for peace and liberty in Ukraine. 💙💛
 
-### Videos
+## Videos
 
 - [The Ukrainians Strike Back](https://youtu.be/iAD684eczq8)
 - [How did Ukraine retake so much territory from Russia so fast?](https://youtu.be/rSLMuMjeZ38)
 - [Russian Military Front Lines Have COLLAPSED](https://youtu.be/bihU0FLH9To)
 - [Ukraine War: Ukrainians calling the shots](https://youtu.be/8OMT6mqItxE)
 
-### Links
+## Links
 
 - [Invasion Day 200 – Summary (militaryland.net)](https://militaryland.net/news/invasion-day-200-summary/)
 - [Liberators Greeted With Cheers, Tears Of Joy (thedrive.com)](https://www.thedrive.com/the-war-zone/ukraine-situation-report-liberators-greeted-with-cheers-tears-of-joy)

--- a/content/blog/2022-10-12-voices-from-ukraine-yura-petriv.md
+++ b/content/blog/2022-10-12-voices-from-ukraine-yura-petriv.md
@@ -31,7 +31,7 @@ Ukrainians in Eastern Europe.
 
 {{< figure src="OFReport/2022-10-12-voices-from-ukraine-yura-petriv/lviv-in-darkness_b7ktme" caption="L’viv in darkness after Russian missiles damage critical infrastructure on October 10, 2022." >}}
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for Yura as he continues his labor of love in Ukraine.
 - Pray for a speedy end to the war and a reuniting of separated Ukrainian
@@ -51,7 +51,7 @@ Ukrainians in Eastern Europe.
 - Pray that we would receive our residency status in Slovakia soon.
 - Pray for peace and liberty in Ukraine. 💙💛
 
-### Donations to Yura and Radekhivski Hospodyni
+## Donations to Yura and Radekhivski Hospodyni
 
 If you would like to donate to support Yura’s work with
 [Radekhivski Hospodyni](https://www.facebook.com/groups/404821584832741), you

--- a/content/blog/2022-11-10-good-and-evil-books-shipping.md
+++ b/content/blog/2022-11-10-good-and-evil-books-shipping.md
@@ -25,14 +25,14 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-11663771"></div><script src="https://www.buzzsprout.com/1953515/11663771-good-and-evil-books-shipping.js?container_id=buzzsprout-player-11663771&player=small" type="text/javascript" charset="utf-8"></script>
 
-### Links from the Episode
+## Links from the Episode
 
 - [Alert map of Ukraine (alerts.in.ua/en)](https://alerts.in.ua/en)
 - [Our Ukrainian distributor form](https://forms.gle/J5jGHkEKQRmqbjU36)
 - [Hebron IT Academy](https://hebron-academy.com/)
 - [Free Ukrainian Language Offer (pimsleur.com)](https://www.pimsleur.com/c/free-ukrainian)
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for quick, efficient, and widespread distribution of _Good and Evil_
   books in Ukraine.

--- a/content/blog/2022-12-02-the-yellow-van-rides-again.md
+++ b/content/blog/2022-12-02-the-yellow-van-rides-again.md
@@ -24,7 +24,7 @@ Ukrainians in Eastern Europe.
 
 <div id="buzzsprout-player-11803903"></div><script src="https://www.buzzsprout.com/1953515/11803903-the-yellow-van-rides-again.js?container_id=buzzsprout-player-11803903&player=small" type="text/javascript" charset="utf-8"></script>
 
-### How You Can Pray
+## How You Can Pray
 
 - Pray for safety as I travel to Ukraine.
 - Pray that the van would continue to operate well, both for my trip and for


### PR DESCRIPTION
## Summary

- Fixes the WCAG 1.3.1 / 2.4.6 `heading-order` failure flagged by the launch a11y gate: 46 legacy posts opened their first body section with `###`, producing an h1 (title) → h3 skip.
- Promotes every top-level section heading `###` → `##` across all 46 flagged posts so headings descend sequentially under the title h1.
- Content-only normalization — no template change (the template already emits the title as `<h1>`).

## Changes

- 46 articles in `content/blog/` updated: top-level section headings `###` → `##`.
  - **45 files** are flat "pure-h3" posts (no `##` at all); promoting their sibling sections preserves the relationship while removing the level skip.
  - **1 mixed file** (`2018-03-19-two-robes`) had a lone leading `###` among `##` siblings; the same rule corrects just that heading.

## How it was scoped

A fenced-code-aware scan over `content/blog/` (treating the rendered title as an implicit h1) found exactly the 46 posts that skip a heading level. The same scan is the verification oracle below. No file contains fenced code blocks or h4+ headings, so the transform is uniform and needs no cascade.

## Testing

- [x] Heading-skip scan reports **0** articles (was 46).
- [x] Diff is provably pure — every changed line is `### ` → `## `, zero off-pattern edits.
- [x] `hugo --gc --minify` builds clean (290 pages).
- [x] Cited post `2022-07-21-russia-and-geopolitics` renders `h1 → h2 → h2`; anchor IDs (`#how-you-can-pray`, `#resources`) preserved (slug is level-independent).
- [x] Lighthouse `heading-order` audit **passes** on that previously-failing post; accessibility category **95 → 100**.
- [x] Visual spot-check (russia + a dense "Pillars of Genesis" post): heading sizes/spacing render correctly.

## Notes

- Single PR rather than batched (#129/#162 cadence) because this is one uniform, mechanical transform — the diff is trivially reviewable and the scan + Lighthouse pass verify the whole set at once.
- Relates to #150 §6 (launch a11y gate), #129 (content/heading pass), #162 (alt-text pass). The other Lighthouse a11y failure (`color-contrast`) was tracked and fixed separately (#190).

Closes #165
