### PR TITLE
fix(blog): restore lightbox on legacy posts with raw-markdown body images

### DIFF
--- a/content/blog/2016-12-31-translators.md
+++ b/content/blog/2016-12-31-translators.md
@@ -30,15 +30,15 @@ Back in the mid-2000’s, the very first language group to receive a translation
 
 This fall, we hired Anatoliy Zhylaviy, a Ukrainian translator and philologist from our church, to begin a complete revision of our Ukrainian Bible First course. He is working through the entire course: editing, revising, and even retranslating as needed. Demand for Bible First amongst Ukrainians remains strong, and we are excited to bring these updated lessons to our students.
 
-![Anatoliy Zhylavyi](https://d21yo20tm8bmc2.cloudfront.net/2016/12/DSC_1007a-295x300.jpg)
+{{< image src="https://d21yo20tm8bmc2.cloudfront.net/2016/12/DSC_1007a-295x300.jpg" alt="Anatoliy Zhylavyi" >}}
 Anatoliy Zhylavyi
 
 ## French
 
 Meet Catherine Leavitt - a French national who has spent more than two decades living in Oregon. Catherine contacted us several months ago with a desire to translate Bible First into French. She’s been working diligently on the project and is making good progress. Her father, a French linguist who still lives in France, is assisting her as well. We are very grateful to their family, and we’re looking forward to making Bible First available as a ministry tool for believers in France!
 
-![Catherine Leavitt](https://d21yo20tm8bmc2.cloudfront.net/2016/12/IMG_3244-400x300.jpg)
-Catherin Leavitt
+{{< image src="https://d21yo20tm8bmc2.cloudfront.net/2016/12/IMG_3244-400x300.jpg" alt="Catherine Leavitt" >}}
+Catherine Leavitt
 
 ## Spanish
 
@@ -46,7 +46,7 @@ Several months ago, we received an email from a lady named Maria Sanchez. Maria 
 
 Over the past several months, Maria has kept us on our toes as she has sent email after email with new drafts, questions, corrections, and more. She has now completed translating up through Lesson 9 - almost halfway!
 
-![Maria Sanchez](https://d21yo20tm8bmc2.cloudfront.net/2016/12/mail_image_preview-400x300.png)
+{{< image src="https://d21yo20tm8bmc2.cloudfront.net/2016/12/mail_image_preview-400x300.png" alt="Maria Sanchez" >}}
 Maria Sanchez
 
 ## The Language of the Web
@@ -61,7 +61,7 @@ We’ll be writing more about this project in future updates, but for now, pleas
 
 Oh, and there’s one more thing: it’s almost baby time! Kelsie is due to deliver our first son in early January. Please pray for our family–and Kelsie in particular–as we prepare to welcome our new little boy!
 
-![Steele Kids](https://d21yo20tm8bmc2.cloudfront.net/2016/12/steele-girls-338x450.jpg)
+{{< image src="https://d21yo20tm8bmc2.cloudfront.net/2016/12/steele-girls-338x450.jpg" alt="Steele Kids" >}}
 
 ## How You Can Pray
 

--- a/content/blog/2017-08-04-meet-ralph.md
+++ b/content/blog/2017-08-04-meet-ralph.md
@@ -62,8 +62,7 @@ As you have likely inferred by now, we needed to move the text of *Bible First* 
 
 Ralph's first task would be to take every English lesson in the *Bible First* program and convert it into a plain-text format called [Markdown][md title]. From there he would go through the entire lesson, paragraph by paragraph, and ensure that all the content was present and displayed in its proper order. This also involved adding special formatting markers that would indicate which text should be bold or italic, which headings should be primary or secondary, and so on.
 
-[![Comparing Spanish and English versions of Bible First in Vim.](https://d21yo20tm8bmc2.cloudfront.net/2017/vim-markdown-550w.png)](https://d21yo20tm8bmc2.cloudfront.net/2017/vim-markdown-2300w.png)
-Comparing Spanish and English versions of Bible First in Vim.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/vim-markdown-2300w.png" caption="Comparing Spanish and English versions of Bible First in Vim." >}}
 
 Every step of the way, Ralph would save his work in Git - an operation known as *making a commit* - and upload it to a remote repository. When this process was completed for a given lesson, Ralph would send us a request for review. Once approved, the lesson would be merged into what is called the *master branch* - the main body of the repository where all content is kept.
 
@@ -92,8 +91,7 @@ Initially, we worked together formatting one of our Ukrainian lessons until Ralp
 
 Now, as new material is completed and placed under version control, Ralph has the skills to complete the cycle by formatting the lessons for print.
 
-[![Laying out pages for Bible First in Ukrainian](https://d21yo20tm8bmc2.cloudfront.net/2017/ralph-computer-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/ralph-computer-2000w.jpg)
-Laying out pages for Bible First in Ukrainian.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/ralph-computer-2000w.jpg" caption="Laying out pages for Bible First in Ukrainian." >}}
 
 <div class="link-target__container">
  <span class="link-target" id="skip-to-conclusion"></span>
@@ -114,11 +112,7 @@ Make no mistake: the God who searched the globe to find Abraham, David, Samuel, 
 
 ---
 
-[![Be like Ralph.](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-2000w.jpg)
-
-**This is Ralph.  
-Ralph is happy because he's chosen to follow God.  
-Be like Ralph.**
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/rope-course-04-2000w.jpg" caption="**This is Ralph.<br>Ralph is happy because he's chosen to follow God.<br>Be like Ralph.**" >}}
 
 [cli title]: https://en.wikipedia.org/wiki/Command-line_interface "Read more about command line interfaces."
 [vim title]: https://en.wikipedia.org/wiki/Vim_(text_editor) "Read more about Vim."

--- a/content/blog/2017-08-12-a-chance-to-give-back.md
+++ b/content/blog/2017-08-12-a-chance-to-give-back.md
@@ -18,21 +18,17 @@ slug: 2017-08-12-a-chance-to-give-back
 {{< callout pdf="OFR-Jul-Aug-2017.pdf" >}}
 {{< /callout >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/tamara-anatolivna-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/tamara-anatolivna-2000w.jpg)
-As people began arriving, we were glad to see Tamara Anatolivna—a long-time friend and one of the main organizers of the seminar.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/tamara-anatolivna-2000w.jpg" caption="As people began arriving, we were glad to see Tamara Anatolivna—a long-time friend and one of the main organizers of the seminar." >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/greeting-little-ones-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/greeting-little-ones-2000w.jpg)
-Greeting a couple of the younger attendees
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/greeting-little-ones-2000w.jpg" caption="Greeting a couple of the younger attendees" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/prayer-circle-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/prayer-circle-2000w.jpg)
-The ladies all gather for prayer before the first session.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/prayer-circle-2000w.jpg" caption="The ladies all gather for prayer before the first session." >}}
 
 About a month prior to this, I received a phone call inviting me to speak at a ladies’ seminar hosted by a local evangelical church. Many hours had been spent in preparation for this event, and my friend and ministry partner, Katelin Day, came along with me to offer ideas and moral support. Popping her head in the doorway to the room where I was catching a quick break, she cheerfully quipped, “You’re doing great, Kels!” I wished I had her confidence.
 
 Two doors down the hallway, about 15 moms were reconvening for the next session, eager to hear ideas, tips—anything that could help them in the demanding, exhausting, yet all-important work of mothering their babies and toddlers.
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/moms-listening-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/moms-listening-2000w.jpg)
-It's always an encouragement to engage with parents who are hungry to learn.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/moms-listening-2000w.jpg" caption="It's always an encouragement to engage with parents who are hungry to learn." >}}
 
 “God, please help me.” I hoped, of course, for God to give me words to communicate well and make my presentation more polished.
 
@@ -40,8 +36,7 @@ It's always an encouragement to engage with parents who are hungry to learn.
 
 This wasn’t about me. It was about these women, the next generation, and about honoring Christ Himself.
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/kels-kate-teaching-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kels-kate-teaching-2000w.jpg)
-Sharing practical tips and ideas on successful mothering
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/kels-kate-teaching-2000w.jpg" caption="Sharing practical tips and ideas on successful mothering" >}}
 
 Upon reengaging with the ladies, many questions and ideas were shared. “How do we handle screaming fits?” “What’s the balance between teaching a child to share and respecting their right to personal property?” “How do you deal with a violent child who damages property?” “How should I respond to my daughter who cries all the time?”
 
@@ -51,8 +46,7 @@ In the months leading up to the seminar, I had worked day-in and day-out with th
 
 Garnering help and ideas from Katelin, I had prepared two hour-long sessions which dealt with training in the early years. We especially wanted to expose the cultural norm of letting the child dictate the terms, and instead call on these moms to responsibly train each child in obedience. We hoped to empower them with the practical ideas and tools they would need. In a third session, we discussed time-management and maintaining order in the home. God blessed us with a wonderful group that day, and a beautiful spirit of learning in the moms present. It was a pleasure and a privilege to get to know them.
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/kate-kels-chatting-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kate-kels-chatting-2000w.jpg)
-Ministry is always better when you have a friend to stand beside you!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/kate-kels-chatting-2000w.jpg" caption="Ministry is always better when you have a friend to stand beside you!" >}}
 
 I can look back to my childhood and remember multiple times when I was the recipient of excellent teaching. Conferences, books, radio programs, and my own parents all spoke into my life, preparing me with the tools and encouragement I would need in raising my own family some day. Now, despite my sweaty palms and beating heart, it is a privilege to interact with other moms and be able to give back some of what I have been given.
 
@@ -60,17 +54,13 @@ I can look back to my childhood and remember multiple times when I was the recip
 Most gladly therefore will I rather glory in my infirmities, that the power of Christ may rest upon me. 2 Corinthians 12:9
 {{< /callout >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/chatting-at-the-table-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/chatting-at-the-table-2000w.jpg)
-After the seminar, a meal was provided, during which the conversation about motherhood continued.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/chatting-at-the-table-2000w.jpg" caption="After the seminar, a meal was provided, during which the conversation about motherhood continued." >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/bouncy-house-kids-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/bouncy-house-kids-2000w.jpg)
-While the moms met with Kelsie and Katelin, the kiddos did not lack for interesting activities outside!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/bouncy-house-kids-2000w.jpg" caption="While the moms met with Kelsie and Katelin, the kiddos did not lack for interesting activities outside!" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/cute-kid-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/cute-kid-2000w.jpg)
-This cute little guy was fascinated with Joshua's camera!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/cute-kid-2000w.jpg" caption="This cute little guy was fascinated with Joshua's camera!" >}}
 
-[![Description](https://d21yo20tm8bmc2.cloudfront.net/2017/kelsie-katelin-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/kelsie-katelin-2000w.jpg)
-This was the second mommy talk that Kelsie and Katelin have done together, and, Lord willing, it won't be their last!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/kelsie-katelin-2000w.jpg" caption="This was the second mommy talk that Kelsie and Katelin have done together, and, Lord willing, it won't be their last!" >}}
 
 ## How You Can Pray
 

--- a/content/blog/2017-11-08-grab-bag-report.md
+++ b/content/blog/2017-11-08-grab-bag-report.md
@@ -20,7 +20,7 @@ There are months when so much is going on, it's hard to find time to write newsl
 {{< callout pdf="OFR-Oct-Dec-2017.pdf" >}}
 {{< /callout >}}
 
-![Good and Evil](https://d21yo20tm8bmc2.cloudfront.net/2017/11/ge-cover-250h.jpg)
+{{< image src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/ge-cover-250h.jpg" alt="Good and Evil" >}}
 
 ## Good and Evil in Ukrainian
 
@@ -38,45 +38,37 @@ CMO 2018 will begin in mid-July and last through mid-August. We hope to have the
 
 We are very pleased to announce that ETO has gained a new staff family! Anatoli and his wife Anastasia have four children, and they joined our team as full-time missionaries in August. Anatoli is a Ukrainian philologist, and he is spear-heading our new translation of *Good and Evil* as well as revising our Ukrainian *Bible First* text. We'll be posting more about the Zhylavy's in a future update, but until then, please check out their bio page on the ETO web site: [www.euroteamoutreach.org/zhylavy][zhylavy title]
 
-[![The Zhylavy Family](https://d21yo20tm8bmc2.cloudfront.net/2017/11/zhylavy-family-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/zhylavy-family-2000w.jpg)
-Anatoli and Anastasia along with their four children: Kateryna, Valentyna, Hanna and Lukian.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/zhylavy-family-2000w.jpg" caption="Anatoli and Anastasia along with their four children: Kateryna, Valentyna, Hanna and Lukian." >}}
 
 ## Bible First Online
 
 Someday soon, it will be ready. The software that will allow coaches and students to use *Bible First* via the internet has been a long time in coming. But this October, we got a much needed boost.
 
-[![Hackers for Christ](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hackers-for-christ-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hackers-for-christ-2000w.jpg)
-Nathan, Trevor, Joshua — hackers for Christ!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/hackers-for-christ-2000w.jpg" caption="Nathan, Trevor, Joshua — hackers for Christ!" >}}
 
 [Trevor Brown][stratus3d title] is a software engineer from Florida, and he's been helping us build *Bible First Online* since its inception. During the month of October, he used every day of time off he could scrape together and flew to Lviv for a coding marathon. He and I, along with Nathan Day, spent pretty much every waking hour for two weeks writing code. As a result of this latest push, we are now very close to importing our own Ukrainian students into the new system. Once we've been able to test the app internally for a while, we'll release it publicly for others to use in their own ministries!
 
-[![The Import Script](https://d21yo20tm8bmc2.cloudfront.net/2017/11/the-import-script-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/the-import-script-2000w.jpg)
-On his very last night in Lviv, Trevor tests out the script that will import our existing Bible First students into Bible First Online. (Hacking always works better if you wear a black stocking cap. ;)
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/the-import-script-2000w.jpg" caption="On his very last night in Lviv, Trevor tests out the script that will import our existing Bible First students into Bible First Online. (Hacking always works better if you wear a black stocking cap. ;)" >}}
 
-[![Bible First Online Cookies](https://d21yo20tm8bmc2.cloudfront.net/2017/11/bible-first-online-cookie-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/bible-first-online-cookie-2000w.jpg)
-We even have Bible First Online cookies! (courtesy of Miss Denise Hutchison)
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/bible-first-online-cookie-2000w.jpg" caption="We even have Bible First Online cookies! (courtesy of Miss Denise Hutchison)" >}}
 
 ## Kids' Class
 
 I've written before about the kids' class I lead on Sundays at our church here in Lviv. This is one of those ministries I wasn't looking for — God just dropped it in my lap. I've been surprised at how much fun I've had with this group! Every week, we do sword drills, read through a section of *Bible First*, and work on memory verses. Inspired by my mom's memory program for her grandkids, I've been offering the kids modest financial incentives to memorize Scripture. That has really taken off! Even during the week, kids come to my house to say their verses. One girl even brought a friend from the neighborhood who has now started a memory project!
 
-[![Kids' Class](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-2000w.jpg)
-Sword drills are a fun time each week. The kids are getting pretty good at finding references quickly!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-2000w.jpg" caption="Sword drills are a fun time each week. The kids are getting pretty good at finding references quickly!" >}}
 
-[![Kid Reading](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kid-reading-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kid-reading-2000h.jpg)
-It's wonderful to see these kids learning to navigate their Bibles and reading passages aloud in class.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/kid-reading-2000h.jpg" caption="It's wonderful to see these kids learning to navigate their Bibles and reading passages aloud in class." >}}
 
 ## Family Update
 
 Let's start with the cold, hard facts: Kelsie Steele is my hero! The home environment she has crafted for us astounds me daily. Yes, like many large-ish homeschool families, our home often bears resemblance to Grand Central Station, but out of the chaos comes a sweet joy that I see in our children. It makes my heart glow!
 
-[![Hero Lady](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hero-lady-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hero-lady-2000w.jpg)
-This lady is my hero. I love you Kelsie!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/hero-lady-2000w.jpg" caption="This lady is my hero. I love you Kelsie!" >}}
 
 Abigail is now 12, Rebekah is nearly 10, Hosanna is 7, Kathryn is nearly 3, and little David is a 10-month-old toothy bundle of smiles who is going to crawl off any day now! I wish I had room to write more (maybe in the blog version?) but I'm happy to say God is guiding and blessing us. We are so grateful for your prayers and support for our family as we minister for Christ in Ukraine!
 
-[![David and Daddy](https://d21yo20tm8bmc2.cloudfront.net/2017/11/david-and-daddy-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/david-and-daddy-2000h.jpg)
-David brings us all so much joy. He'll be crawling any day now!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/david-and-daddy-2000h.jpg" caption="David brings us all so much joy. He'll be crawling any day now!" >}}
 
 {{< callout >}}
 Pssst! Lots more pictures if you scroll further down!
@@ -94,35 +86,25 @@ Pssst! Lots more pictures if you scroll further down!
 
 ## Don't go yet! Check out these bonus pictures...
 
-[![Shopping with Mama](https://d21yo20tm8bmc2.cloudfront.net/2017/11/helping-mama-shop-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/helping-mama-shop-2000h.jpg)
-Hosanna loves helping Mama shop. Especially when they have the kiddie carts for her to push!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/helping-mama-shop-2000h.jpg" caption="Hosanna loves helping Mama shop. Especially when they have the kiddie carts for her to push!" >}}
 
-[![Daddy Date with Abby](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-abby-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-abby-2000h.jpg)
-Daddy date with Abby
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-abby-2000h.jpg" caption="Daddy date with Abby" >}}
 
-[![Daddy Date with Beka](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-beka-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-beka-2000w.jpg)
-Daddy date with Rebekah
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-beka-2000w.jpg" caption="Daddy date with Rebekah" >}}
 
-[![Ice Skating Party](https://d21yo20tm8bmc2.cloudfront.net/2017/11/ice-skating-party-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/ice-skating-party-2000w.jpg)
-Abby recently had a birthday party and invited several friends to the local ice rink. Good times!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/ice-skating-party-2000w.jpg" caption="Abby recently had a birthday party and invited several friends to the local ice rink. Good times!" >}}
 
-[![Daddy Date with Hosanna](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-hosanna-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-hosanna-2000h.jpg)
-Daddy date with Hosanna
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/daddy-date-hosanna-2000h.jpg" caption="Daddy date with Hosanna" >}}
 
-[![Hello from Kathryn](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hello-from-kathryn-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/hello-from-kathryn-2000h.jpg)
-Kathryn says hello! This little girl is fireball of energy, and she keeps us on our toes. :)
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/hello-from-kathryn-2000h.jpg" caption="Kathryn says hello! This little girl is fireball of energy, and she keeps us on our toes. :)" >}}
 
-[![Kids' Class Selfie](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-selfie-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-selfie-2000w.jpg)
-Selfie time at the Sunday kids' class!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/kids-class-selfie-2000w.jpg" caption="Selfie time at the Sunday kids' class!" >}}
 
-[![Bohdan](https://d21yo20tm8bmc2.cloudfront.net/2017/11/bohdan-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/bohdan-2000w.jpg)
-Bohdan was the first in the class to complete a level 4 memory project (30 verses or more). He memorized all 33 verses of Proverbs 1!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/bohdan-2000w.jpg" caption="Bohdan was the first in the class to complete a level 4 memory project (30 verses or more). He memorized all 33 verses of Proverbs 1!" >}}
 
-[![Anya](https://d21yo20tm8bmc2.cloudfront.net/2017/11/anya-550h.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/anya-2000h.jpg)
-Not far behind Bohdan, Anya also completed Proverbs 1! These kids are on fire!
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/anya-2000h.jpg" caption="Not far behind Bohdan, Anya also completed Proverbs 1! These kids are on fire!" >}}
 
-[![Selfie in Lviv](https://d21yo20tm8bmc2.cloudfront.net/2017/11/lviv-selfie-550w.jpg)](https://d21yo20tm8bmc2.cloudfront.net/2017/11/lviv-selfie-2000w.jpg)
-While Trevor was here, we did a little sight-seeing. Here we snapped a quick selfie from the lookout on High Castle.
+{{< figure src="https://d21yo20tm8bmc2.cloudfront.net/2017/11/lviv-selfie-2000w.jpg" caption="While Trevor was here, we did a little sight-seeing. Here we snapped a quick selfie from the lookout on High Castle." >}}
 
 [cmo title]: http://www.cmoproject.org/ "Learn more about Carpathian Mountain Outreach."
 [zhylavy title]: https://euroteamoutreach.org/zhylavy/ "The Zhylavy Family"


### PR DESCRIPTION
## Summary

- Fixes the image lightbox on four legacy posts (2016–2017) whose body images were written as **raw Markdown** instead of the `{{< figure >}}` shortcode, so clicking a body image opened it in a new tab instead of zooming.
- Converts those images to the project's shortcodes — `{{< figure >}}` for zoomable photos, `{{< image >}}` for thumbnails with no larger version — leveraging the existing Cloudinary **fetch** path so the legacy CloudFront images get optimized + lightbox-ready **without any re-upload**.
- Pure content change: no template, shortcode, or config changes.

## Root cause

GLightbox only binds to anchors with `class="glightbox"` (emitted by the `figure` shortcode and, for covers, by `blog/single.html`). A raw Markdown linked image `[![alt](small)](large)` renders to a plain `<a href="large"><img></a>` — and `layouts/_default/_markup/render-link.html` then adds `target="_blank"` because the large CloudFront URL is an external host. That's exactly the "opens in a new tab" symptom. Covers worked because `single.html` wraps them in `class="glightbox block"` (which also loads the GLightbox library on the page). These posts predate the `<article-image>` convention, so migration passed their raw Markdown through, and the raw-**HTML** normalization pass (#133) didn't match Markdown linked-image syntax.

## Changes

- `2017-08-04-meet-ralph` — 3 zoom images → `figure`.
- `2017-08-12-a-chance-to-give-back` — 10 zoom images → `figure`.
- `2017-11-08-grab-bag-report` — 18 zoom images → `figure`; the "Good and Evil" book-cover thumbnail → `image`; the CMO logo left as an external-linked logo (links to cmoproject.org — intentionally not a lightbox).
- `2016-12-31-translators` — 4 headshot thumbnails (no larger version) → `image`; also fixed an incidental name typo ("Catherin" → "Catherine").

## Notes / decisions

- **Captions are authentic, not AI-generated.** Each image's real caption already existed as an orphaned paragraph directly beneath it (the `Description` text was only placeholder `alt`). Those original captions were relocated verbatim into each figure's `caption=`. No captions were fabricated.
- **No re-upload needed.** `partials/cloudinary-url.html` already delivers remote CloudFront URLs via Cloudinary fetch — a path already used in production by dozens of older `figure`-based posts. The larger (`-2000w`/`-2000h`) URL is used as `src`; the shortcode derives the inline (`w_1344`) and lightbox (`w_1600`) renditions from it.
- **Thumbnails get no lightbox** (`image` shortcode): there is no larger version to zoom into, so a lightbox would add nothing.
- The CMO logo is the one remaining raw Markdown image by design — it's an external link, not a zoom.

## Testing

- [x] `hugo --gc --minify` builds clean (290 pages, no warnings)
- [x] `npm run lint:md` passes (0 errors)
- [x] Rendered HTML: 3 / 10 / 18 figure `.glightbox` anchors with Cloudinary fetch URLs; **zero** CloudFront image anchors carry `target="_blank"` (only the CMO logo + in-text CMO links, correctly)
- [x] Sampled Cloudinary fetch URLs return HTTP 200; no raw shortcode leakage
- [x] Diff reviewed line-by-line — every removed prose line is a caption folded into a figure (plus the one documented typo fix); no prose corruption
- [x] Live browser click-test on the grab-bag post — verified: clicking a body image opens the GLightbox overlay (no new tab); relocated caption renders as the lightbox description

Closes #197