### PR TITLE
fix(lightbox): match in-copy caption typography

### DIFF
--- a/layouts/partials/glightbox.html
+++ b/layouts/partials/glightbox.html
@@ -23,6 +23,23 @@
     href="https://cdnjs.cloudflare.com/ajax/libs/glightbox/3.3.1/css/glightbox.min.css"
     integrity="sha512-T+KoG3fbDoSnlgEXFQqwcTC9AdkFIxhBlmoaFqYaIjq2ShhNwNao9AKaLUPMfwiBPL0ScxAtc+UYbHAgvd+sjQ=="
     crossorigin="anonymous">
+  {{- /* Mirror the in-copy <figcaption> typography (text-base / font-semibold /
+       font-serif; see layouts/shortcodes/figure.html) in the lightbox caption.
+       GLightbox's default .gslide-desc renders smaller (.86em ≈ 13.76px),
+       lighter (400), and in Arial. This targets the library's own selector, so
+       it ties on specificity and wins on source order — no !important — and
+       .glightbox-clean is present at every viewport, so it holds on mobile and
+       desktop. var(--font-serif) / 1rem are the same tokens the figcaption
+       resolves to, keeping the two in lockstep. Color is intentionally left to
+       the library (the lightbox panel is dark on mobile, white on desktop — see
+       issue #200). */ -}}
+  <style>
+    .glightbox-clean .gslide-desc {
+      font-family: var(--font-serif);
+      font-weight: 600;
+      font-size: 1rem;
+    }
+  </style>
   <script
     defer
     src="https://cdnjs.cloudflare.com/ajax/libs/glightbox/3.3.1/js/glightbox.min.js"


### PR DESCRIPTION
## Summary

- Makes the GLightbox caption mirror the in-copy `<figcaption>` typography — **16px / weight 600 / Noto Serif** — up from the library default (`.86em` ≈ 13.76px / 400 / Arial).
- One scoped `<style>` override in `layouts/partials/glightbox.html`, loaded only on the pages that already use the lightbox.

## Changes

- `layouts/partials/glightbox.html` — add a `.glightbox-clean .gslide-desc` override (`font-family: var(--font-serif)`, `font-weight: 600`, `font-size: 1rem`) immediately after the CDN stylesheet `<link>`. It ties the library's own rule on specificity and wins on source order, so no `!important` is needed, and `.glightbox-clean` is present at every viewport so the match holds on mobile and desktop. `var(--font-serif)` / `1rem` are the exact tokens the in-copy caption resolves to, keeping the two in lockstep if the serif ever changes.

## Testing

- [x] `hugo --gc --minify` builds cleanly (290 pages)
- [x] Override renders into the built HTML and loads only on lightbox-bearing pages
- [x] DevTools computed styles verified with the lightbox open at **1280px** and **375px** → both **16px / 600 / Noto Serif**, matching the in-copy `figcaption`
- [x] In-copy caption confirmed unchanged

## Notes

- **Caption color is intentionally out of scope.** The lightbox panel is a dark gradient on mobile (≤768px) but white on desktop, while the article page is always light — so a single ink color can't mirror the page without breaking one breakpoint. The library's mid-gray reads on both. Rationale documented in the issue.
- Noticed while testing (pre-existing, unrelated to this change): the sticky site header peeks above the lightbox overlay at the very top edge — a z-index layering quirk worth a separate look.

Closes #200
