### PR TITLE
feat(search): Pagefind indexing & build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ hugo --gc --minify
 
 Requires [Hugo](https://gohugo.io/installation/) (extended edition) and [Node.js](https://nodejs.org/) 20 or newer (production builds run on Node 22).
 
+### Previewing search locally
+
+Search uses [Pagefind](https://pagefind.app), which indexes the **built** `public/` directory — so it does not work against a bare `hugo server` (which serves from memory). To preview search, run a real build, generate the index, then serve the output:
+
+```bash
+hugo --minify && npx pagefind --site public && npx serve public
+```
+
+Only search-UI work needs this extra step; day-to-day content authoring with `hugo server -D` is unaffected.
+
 ## Project Structure
 
 ```text

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -205,7 +205,7 @@ First post-launch feature. Full spec in [`09-search.md`](./09-search.md).
 Self-hosted [Pagefind](https://pagefind.app) with a design-native ⌘K command
 palette; indexes blog article body + title + tags only.
 
-- [ ] Indexing & build pipeline — `pagefind` dependency, Netlify build command, `data-pagefind-*` attributes on `single.html`, index scoped to blog articles
+- [x] Indexing & build pipeline — `pagefind` dependency, Netlify build command, `data-pagefind-*` attributes on `single.html`, index scoped to blog articles
 - [ ] Command palette UI — header trigger (icon + ⌘K/Ctrl-K + `/`), Alpine modal from Tailwind Plus snippets, Pagefind JS API, keyboard nav, mobile sheet
 - [ ] Accessibility, polish & QA — focus trap, dialog/listbox ARIA, empty/no-results states, cross-device QA, Lighthouse re-check
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -45,10 +45,9 @@
     {{/* data-pagefind-body scopes the search index: once it exists on any page,
          Pagefind indexes ONLY pages that carry it — giving us "blog articles only"
          with no glob config. Site chrome (header/footer/nav in baseof.html) sits
-         outside this element and is never indexed. Regions inside it that are not
-         article content (prev/next nav, newsletter footer) carry
-         data-pagefind-ignore. (Phase 17 — → See docs/prd/09-search.md "Indexing
-         Design".) */}}
+         outside this element and is never indexed; non-article regions inside it
+         carry data-pagefind-ignore. (Phase 17 — → See docs/prd/09-search.md
+         "Indexing Design".) */}}
     <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if not .Params.cover }}pt-24 sm:pt-32{{ end }}" data-pagefind-body>
 
       {{/* Caption — sits tight under the cover (mt-2) and well clear of the

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -27,17 +27,29 @@
                  and title. The original used a background <div> whose height equalled
                  its min-height; a fixed height + object-cover reproduces that cap so
                  text below the hero always stays in view (#160). */ -}}
+          {{- /* data-pagefind-meta="image[src]": capture the cover URL as result
+                 metadata for richer search cards later (Phase 17). Captured now,
+                 not displayed in v1. Pagefind reads page-level meta even though the
+                 hero sits outside the data-pagefind-body wrapper below. */ -}}
           <img
             src="{{ $hero }}"
             alt="{{ $.Title }}"
             class="block w-full object-cover h-[250px] sm:h-[450px] md:h-[500px] lg:h-[600px] xl:h-[75vh]"
             loading="eager"
+            data-pagefind-meta="image[src]"
           >
         </a>
       </div>
     {{- end }}
 
-    <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if not .Params.cover }}pt-24 sm:pt-32{{ end }}">
+    {{/* data-pagefind-body scopes the search index: once it exists on any page,
+         Pagefind indexes ONLY pages that carry it — giving us "blog articles only"
+         with no glob config. Site chrome (header/footer/nav in baseof.html) sits
+         outside this element and is never indexed. Regions inside it that are not
+         article content (prev/next nav, newsletter footer) carry
+         data-pagefind-ignore. (Phase 17 — → See docs/prd/09-search.md "Indexing
+         Design".) */}}
+    <div class="mx-auto max-w-3xl px-6 lg:px-8 {{ if not .Params.cover }}pt-24 sm:pt-32{{ end }}" data-pagefind-body>
 
       {{/* Caption — sits tight under the cover (mt-2) and well clear of the
            title (which carries the larger top margin below), grouping it with
@@ -73,7 +85,16 @@
           <span aria-hidden="true">&middot;</span>
         {{- end }}
         {{- $isoDate := .Date.Format "2006-01-02" -}}
-        <time datetime="{{ $isoDate }}">{{ .Date.Format "January 2, 2006" }}</time>
+        {{- /* Pagefind captures the publish date from the ISO datetime attribute
+               (not the display text): "2026-06-13" sorts lexicographically correct,
+               whereas "January 2, 2026" would sort April before January.
+               data-pagefind-sort enables a future date-sort option; -meta makes the
+               date available for the result card. Both v1-captured, no UI yet. */ -}}
+        <time
+          datetime="{{ $isoDate }}"
+          data-pagefind-sort="date[datetime]"
+          data-pagefind-meta="date[datetime]"
+        >{{ .Date.Format "January 2, 2006" }}</time>
         <span aria-hidden="true">&middot;</span>
         <span>{{ .ReadingTime }} min read</span>
       </div>
@@ -81,12 +102,15 @@
       {{/* Tags — filled blue pills. The original faded them (opacity-50 until
            hover), but white-on-50%-blue was only 1.82:1; solid blue-800 reads at
            ~5.7:1 (WCAG AA) and deepens to blue-900 on hover (#184). */}}
+      {{/* data-pagefind-filter="tag" captures each tag so tag-filtered search can
+           be added later without re-indexing the archive. No tag-filter UI in v1. */}}
       {{- with .Params.tags }}
         <div class="mt-4 flex flex-wrap gap-2">
           {{- range . }}
             <a
               href="{{ "/tags/" | relURL }}{{ . | urlize }}/"
               class="inline-flex items-center rounded-full bg-blue-800 px-3 py-1 text-xs font-bold leading-none text-white transition-colors hover:bg-blue-900"
+              data-pagefind-filter="tag"
             >
               {{- . -}}
             </a>
@@ -106,7 +130,9 @@
       {{- $older := .NextInSection -}}
       {{- $newer := .PrevInSection -}}
       {{- if or $older $newer }}
-        <nav class="mt-16 border-t border-gray-200 pt-8" aria-label="Previous and next articles">
+        {{/* data-pagefind-ignore: the adjacent-article titles are navigation, not
+             this article's content — keep them out of the index and excerpts. */}}
+        <nav class="mt-16 border-t border-gray-200 pt-8" aria-label="Previous and next articles" data-pagefind-ignore>
           <div class="flex flex-col gap-6 sm:flex-row sm:justify-between">
             {{- if $older }}
               <a href="{{ $older.RelPermalink }}" class="group flex-1">

--- a/layouts/partials/article-footer.html
+++ b/layouts/partials/article-footer.html
@@ -9,7 +9,9 @@
   is the shared mailchimp-form.html partial (also used on the homepage and
   /subscribe/), so no form markup is duplicated here.
 */ -}}
-<section class="mt-16">
+{{- /* data-pagefind-ignore: the wordmark + newsletter CTA repeat on every post;
+       indexing them would pollute every article's search excerpt (Phase 17). */ -}}
+<section class="mt-16" data-pagefind-ignore>
   {{/* "To God be the Glory" script wordmark. Decorative lettering, so it carries
        its words as an accessible label rather than being hidden. The wide (≈7:1)
        SVG scales to the centered max-w-lg column, mirroring the original's

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "npm ci && hugo --gc --minify"
+  command = "npm ci && hugo --gc --minify && npx pagefind --site public"
 
 [build.environment]
   HUGO_VERSION = "0.163.0"
@@ -8,7 +8,7 @@
   NODE_VERSION = "22"
 
 [context.deploy-preview]
-  command = "npm ci && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+  command = "npm ci && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL && npx pagefind --site public"
 
 # "preview" makes hugo.IsProduction false, so seo.html emits noindex,nofollow
 # on preview/branch URLs. We avoid "development" so hugo.IsDevelopment stays
@@ -18,7 +18,7 @@
   HUGO_ENVIRONMENT = "preview"
 
 [context.branch-deploy]
-  command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL"
+  command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL && npx pagefind --site public"
 
 [context.branch-deploy.environment]
   HUGO_VERSION = "0.163.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "alpinejs": "^3.0.0",
         "markdownlint-cli2": "^0.22.1",
+        "pagefind": "^1.5.2",
         "tailwindcss": "^4.0.0"
       }
     },
@@ -100,6 +101,104 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -2207,6 +2306,25 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "alpinejs": "^3.0.0",
     "markdownlint-cli2": "^0.22.1",
+    "pagefind": "^1.5.2",
     "tailwindcss": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Stands up the [Pagefind](https://pagefind.app) static-search **index and build pipeline** — the first of three PRs for Phase 17 client-side search. **No search UI in this PR**; that's the follow-up command-palette work.
- Adds `data-pagefind-*` indexing attributes to the blog article template so the generated index is scoped to **blog articles only** — static pages, tag listings, and pagination are excluded with no glob config.
- Captures date (sort + meta), tag (filter), and cover-image metadata **now** so the future search UI and tag/date filtering can be added later without re-indexing the archive.

## Changes

**Build pipeline** (`chore`)
- Add `pagefind@^1.5.2` as a dev dependency.
- Append `&& npx pagefind --site public` to all three Netlify build commands (production, deploy-preview, branch-deploy) so the index is generated on every deploy, including previews.

**Template indexing attributes** (`feat`, `layouts/blog/single.html` + `layouts/partials/article-footer.html`)
- `data-pagefind-body` on the article content wrapper — the scoping mechanism (once present on any page, Pagefind indexes only pages that carry it).
- `data-pagefind-ignore` on the prev/next nav and the newsletter footer so repeated boilerplate never pollutes the index or result excerpts.
- `data-pagefind-sort` / `data-pagefind-meta` on the publish date, captured from the ISO `datetime` attribute (so date sorting is lexicographically correct).
- `data-pagefind-filter="tag"` on tag pills (future tag-filtered search; no UI yet).
- `data-pagefind-meta="image[src]"` on the cover image (future richer cards; hidden for now).

**Docs** (`docs`)
- Document the local `hugo --minify && npx pagefind --site public && npx serve public` preview step in the README.
- Check off the Phase 17 indexing-pipeline item in `docs/prd/ROADMAP.md`.

## Testing

Verified locally with a real build (`hugo --gc --minify && npx pagefind --site public`):

- [x] `public/pagefind/` is emitted; build succeeds.
- [x] **223 blog articles indexed** — Pagefind reports "ignoring pages without this tag"; the index contains zero `/tags/`, `/page/`, or static-page URLs.
- [x] Metadata captured: `date` (ISO), `image` (186 cover-bearing posts), `title` (auto), and `tag` filters.
- [x] **Live browser search**: body-only terms (`potatoes`, `proverbial` — not in any title) surface the correct article; every result across searches is a `/blog/` URL.
- [x] `markdownlint` passes (0 errors).

## Notes

- **`npm ci` vs `npm install`**: kept the repo's existing `npm ci` rather than the issue's literal `npm install`, and updated all three build commands (deploy previews must also generate the index).
- **Date capture from `datetime`**: capturing the ISO attribute (`date[datetime]`) instead of the display text avoids a sort bug where "January 2…" would sort before "April…".
- **Cover-image meta**: confirmed Pagefind reads page-level meta even though the hero `<img>` sits outside the `data-pagefind-body` wrapper.
- Ran `/simplify` after implementation — one redundant comment trimmed; the rest confirmed clean (the `npx`/multi-context "efficiency" flags were false positives).
- This is sub-issue 1 of epic #202; the epic stays open for the remaining UI and a11y/QA PRs.

Closes #203
