### PR TITLE
feat(search): palette accessibility, polish & QA

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -56,6 +56,19 @@
   color: var(--color-blue-900);
 }
 
+/* Respect prefers-reduced-motion for the search palette. Alpine's x-transition
+   drives the open/close fade + scale via Tailwind transition utilities; zeroing
+   the durations here makes the palette snap open/closed for readers who ask for
+   reduced motion, while leaving the transition machinery intact (Alpine still
+   gets its transitionend immediately). Scoped to the palette subtree. */
+@media (prefers-reduced-motion: reduce) {
+  .search-palette,
+  .search-palette * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
 /* The Typography plugin wraps blockquotes in curly quotation marks via
    ::before/::after. The original site never did this, and it reads as stray
    punctuation around content like the Donate mailing address, so suppress it. */

--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -27,7 +27,7 @@ links to the relevant PRD document for full requirements.
 | 14 | Analytics | Phase 3 | Complete |
 | 15 | Content Migration | Phase 6 | Complete |
 | 16 | Deployment | Phase 15 | Complete |
-| 17 | Client-Side Search | Phase 16 | Planned |
+| 17 | Client-Side Search | Phase 16 | Complete |
 
 ---
 
@@ -207,7 +207,7 @@ palette; indexes blog article body + title + tags only.
 
 - [x] Indexing & build pipeline — `pagefind` dependency, Netlify build command, `data-pagefind-*` attributes on `single.html`, index scoped to blog articles
 - [x] Command palette UI — header trigger (icon + ⌘K/Ctrl-K + `/`), Alpine modal from Tailwind Plus snippets, Pagefind JS API, keyboard nav, mobile sheet
-- [ ] Accessibility, polish & QA — focus trap, dialog/listbox ARIA, empty/no-results states, cross-device QA, Lighthouse re-check
+- [x] Accessibility, polish & QA — focus trap, dialog/listbox ARIA, empty/no-results states, cross-device QA, Lighthouse re-check
 
 **Key learning:** Static search indexing, Pagefind JS API, accessible modal/command-palette UI
 

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -16,16 +16,21 @@
   "unavailable" message (documented dev wrinkle, → See 09-search.md "Local
   Development Workflow").
 
-  Scope note: this is the UI issue (#204). The rigorous focus trap, full
-  listbox ARIA (role=listbox/option, aria-activedescendant), focus restoration,
-  and prefers-reduced-motion are #205. The cheap, testable basics live here:
-  role="dialog", autofocus on open, a simple open/close transition, Esc to close.
+  A11y (#205): the palette is a modal dialog (role="dialog", aria-modal) with a
+  focus trap (@keydown.tab → trapTab) and focus restoration to the trigger on
+  close. The input is a combobox (role="combobox", aria-controls/-expanded/
+  -activedescendant) over a results listbox (role="listbox" / role="option"), so
+  a screen reader announces the active result as ↑/↓ move it — focus stays on the
+  input throughout, per the WAI-ARIA combobox pattern. prefers-reduced-motion is
+  honored via a scoped rule in main.css.
 */ -}}
 <div
   x-data="searchPalette"
+  class="search-palette"
   @search-open.window="open($event.detail)"
   @keydown.window="onGlobalKey($event)"
   @keydown.escape.window="close()"
+  @keydown.tab="trapTab($event)"
 >
   {{- /* Overlay — present in the DOM only while open. Its own opacity transition
          keeps the whole layer (backdrop + panel) mounted through the leave
@@ -55,6 +60,7 @@
       @click.self="close()"
     >
       <div
+        x-ref="panel"
         x-show="isOpen"
         x-transition:enter="transition ease-out duration-300"
         x-transition:enter-start="opacity-0 scale-95"
@@ -83,6 +89,11 @@
             autocapitalize="off"
             spellcheck="false"
             aria-label="Search articles"
+            role="combobox"
+            aria-controls="search-results-list"
+            aria-autocomplete="list"
+            :aria-expanded="results.length > 0"
+            :aria-activedescendant="activeIndex >= 0 && results.length ? 'search-result-' + activeIndex : false"
             class="h-12 w-full border-0 bg-transparent px-3 text-base text-gray-900 outline-none placeholder:text-gray-400 sm:text-sm"
           />
           <button
@@ -102,12 +113,24 @@
                exactly one renders at a time. */ -}}
         <div x-ref="body" class="min-h-0 flex-1 overflow-y-auto sm:max-h-96 sm:flex-none">
 
-          {{- /* Results */ -}}
-          <div x-show="results.length > 0" class="p-3">
+          {{- /* Results listbox. Focus stays on the combobox input; each option
+                 carries a stable id the input's aria-activedescendant points at,
+                 and tabindex="-1" keeps options out of the tab order (the focus
+                 trap then cycles only input ↔ close button). */ -}}
+          <div
+            x-show="results.length > 0"
+            id="search-results-list"
+            role="listbox"
+            aria-label="Search results"
+            class="p-3"
+          >
             <template x-for="(r, i) in results" :key="r.url">
               <a
                 :href="r.url"
                 @mouseenter="activeIndex = i"
+                role="option"
+                :id="'search-result-' + i"
+                tabindex="-1"
                 :aria-selected="activeIndex === i"
                 :data-active="activeIndex === i"
                 class="group flex cursor-pointer rounded-xl p-3 select-none aria-selected:bg-blue-50"
@@ -186,7 +209,9 @@
       maxResults: 12,
 
       open(triggerEl) {
-        // Remember what to restore focus to on close (#205 hardens this).
+        // Remember what to restore focus to on close. The header button passes
+        // itself via the search-open event; ⌘K / "/" fall back to whatever held
+        // focus when the palette opened.
         this.trigger = triggerEl || document.activeElement;
         this.isOpen = true;
         document.body.style.overflow = 'hidden';
@@ -278,6 +303,36 @@
         if (!body) return;
         const el = body.querySelector('[data-active="true"]');
         if (el) el.scrollIntoView({ block: 'nearest' });
+      },
+
+      // Focus trap: keep Tab / Shift+Tab inside the panel while the dialog is
+      // open. In practice the only tabbable elements are the input and the close
+      // button (result options are tabindex="-1"), so this cycles between them
+      // and blocks Tab from escaping to the page behind the backdrop.
+      trapTab(e) {
+        if (!this.isOpen) return;
+        const items = this.focusable();
+        if (!items.length) return;
+        const first = items[0];
+        const last = items[items.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && (active === first || !this.$refs.panel.contains(active))) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && (active === last || !this.$refs.panel.contains(active))) {
+          e.preventDefault();
+          first.focus();
+        }
+      },
+
+      focusable() {
+        const panel = this.$refs.panel;
+        if (!panel) return [];
+        return Array.from(
+          panel.querySelectorAll(
+            'a[href]:not([tabindex="-1"]), button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter((el) => el.getClientRects().length > 0);
       },
 
       onEnter() {


### PR DESCRIPTION
## Summary

- Brings the ⌘K search command palette to the project's accessibility bar, completing the final issue of the Client-Side Search epic (#202) and Phase 17.
- Adds a focus trap, full combobox/listbox ARIA semantics, focus restoration, and `prefers-reduced-motion` support — the items the UI PR (#207) explicitly deferred.
- Verified via a real Pagefind build with cross-device QA and a Lighthouse re-check; scores are unchanged from baseline.

## Changes

**`layouts/partials/search.html`**
- **Focus trap:** a `@keydown.tab` handler (`trapTab`/`focusable`) cycles Tab and Shift+Tab within the panel so focus can't escape to the page behind the backdrop. Alpine is CDN core-only, so this is a manual trap rather than `@alpinejs/focus` — matching the component's existing vanilla-JS style with no new dependency.
- **Combobox + listbox semantics:** the input becomes `role="combobox"` with `aria-controls` / `aria-expanded` / `aria-activedescendant` / `aria-autocomplete`; the results container is `role="listbox"`; each result is `role="option"` with a stable id and `tabindex="-1"`. Focus stays on the input throughout, so a screen reader announces the active result as ↑/↓ move it (WAI-ARIA combobox pattern).
- Doc comments updated to reflect that a11y is now complete here rather than deferred.

**`assets/css/main.css`**
- A scoped `@media (prefers-reduced-motion: reduce)` rule zeroes the palette's transition/animation durations so it snaps open/closed for readers who request reduced motion, leaving Alpine's transition machinery intact.

**`docs/prd/ROADMAP.md`**
- Phase 17 "Accessibility, polish & QA" item checked off and the phase status set to Complete.

## Testing

Verified against a real build (`hugo --minify && npx pagefind --site public`), driven through Chrome DevTools with JS measurement (not just screenshots):

- [x] `hugo --gc --minify` build succeeds
- [x] **Keyboard:** ⌘K opens with focus on the input; ↑/↓ move the active result and update `aria-activedescendant`; Tab/Shift+Tab trapped at the panel boundaries; Esc closes and restores focus to the header trigger
- [x] **Screen-reader tracking:** `aria-activedescendant` follows the active `role="option"`, which toggles `aria-selected`
- [x] **Mobile (375px emulated viewport):** `innerWidth === 375`, `scrollWidth === 375` (zero horizontal overflow), panel is a full-screen sheet (full width/height, no border radius)
- [x] **Lazy-load:** zero `/pagefind/` resources load on initial article-page paint
- [x] **Lighthouse (desktop):** article page Accessibility/Best-Practices/SEO all 100; listing page 95/100/92 — the two listing failures (active nav-link contrast, generic "Read more" link text) are pre-existing baseline issues unrelated to search. Scores unchanged.

## Notes

- **Cross-browser:** automated QA was Chrome-only (the available tooling). The implementation uses only broadly-supported APIs (`import()`, `getClientRects`, ARIA combobox, `prefers-reduced-motion`). A manual Safari/VoiceOver spot-check before merge is optional belt-and-suspenders.
- **Out of scope (flagged, not fixed):** the listing page's "Read more" link text and active-nav-link contrast are real pre-existing a11y/SEO findings worth a future cleanup issue.

Closes #205
