### PR TITLE
fix(search): compensate scrollbar width to prevent palette layout shift

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -56,6 +56,25 @@
   color: var(--color-blue-900);
 }
 
+/* Search palette scroll lock + scrollbar compensation. While the palette is
+   open, the page behind it must not scroll, so body overflow is hidden. On a
+   layout-consuming scrollbar (e.g. macOS "Show scroll bars: Always", or any
+   mouse-connected setup) that removes ~15px of width and the page reflows wider
+   — content and the fixed header's right-aligned cluster lurch sideways. The
+   palette JS measures the scrollbar width into --sbw before locking; we replace
+   the lost width with equal padding so nothing moves. --sbw is 0 when the
+   scrollbar consumes no width (overlay scrollbars / none), making this a no-op.
+   scrollbar-gutter: stable would be the tidier fix but Blink collapses the
+   reserved gutter under overflow: hidden, so it doesn't help this lock. */
+html.search-lock body {
+  overflow: hidden;
+  padding-right: var(--sbw, 0px);
+}
+
+html.search-lock header {
+  padding-right: var(--sbw, 0px);
+}
+
 /* Respect prefers-reduced-motion for the search palette. Alpine's x-transition
    drives the open/close fade + scale via Tailwind transition utilities; zeroing
    the durations here makes the palette snap open/closed for readers who ask for

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -228,7 +228,7 @@
         // focus when the palette opened.
         this.trigger = triggerEl || document.activeElement;
         this.isOpen = true;
-        document.body.style.overflow = 'hidden';
+        this.lockScroll();
         this.$nextTick(() => {
           if (this.$refs.input) this.$refs.input.focus();
         });
@@ -238,10 +238,32 @@
       close() {
         if (!this.isOpen) return;
         this.isOpen = false;
-        document.body.style.overflow = '';
+        this.unlockScroll();
         if (this.trigger && typeof this.trigger.focus === 'function') {
           this.trigger.focus();
         }
+      },
+
+      // Lock page scroll behind the palette without the sideways "jolt": before
+      // hiding overflow we measure the scrollbar's layout width (0 with overlay
+      // scrollbars) and expose it as --sbw, which main.css turns into matching
+      // padding on body + the fixed header so content doesn't reflow. Idempotent
+      // — if we're already locked, re-measuring would read a now-absent scrollbar
+      // (width 0) and clobber --sbw, reintroducing the shift; the guard prevents
+      // that. Paired with unlockScroll(); the actual overflow/padding live in CSS
+      // (html.search-lock).
+      lockScroll() {
+        const root = document.documentElement;
+        if (root.classList.contains('search-lock')) return;
+        const sbw = window.innerWidth - root.clientWidth;
+        root.style.setProperty('--sbw', sbw + 'px');
+        root.classList.add('search-lock');
+      },
+
+      unlockScroll() {
+        const root = document.documentElement;
+        root.classList.remove('search-lock');
+        root.style.removeProperty('--sbw');
       },
 
       onGlobalKey(e) {


### PR DESCRIPTION
## Summary

- Eliminates the ~15px horizontal "lurch" when the ⌘K search palette opens/closes on desktop. The palette locked page scroll with `body { overflow: hidden }`, which removes the viewport scrollbar; on a layout-consuming scrollbar that frees ~15px of width, so the page (and the fixed header's right-aligned nav + search trigger) reflowed sideways.
- Compensates by measuring the scrollbar's layout width into a `--sbw` custom property before locking, then replacing the lost width with equal `padding-right` on `body` and the fixed `header` — the standard modal scroll-lock technique.
- Self-adjusting and a clean no-op where the scrollbar consumes no width (overlay scrollbars / touch devices): `--sbw` is `0`, so no padding is added and behavior is identical to before.

## Changes

- `layouts/partials/search.html` — replaced the inline `body.style.overflow` toggle in `open()`/`close()` with idempotent `lockScroll()` / `unlockScroll()` helpers. `lockScroll()` measures `innerWidth - documentElement.clientWidth`, sets `--sbw` on `<html>`, and adds a `search-lock` class; the idempotence guard prevents a re-entrant open from re-measuring a now-absent scrollbar (width `0`) and reintroducing the shift.
- `assets/css/main.css` — added `html.search-lock` rules that apply `overflow: hidden` + `padding-right: var(--sbw, 0px)` to `body`, and `padding-right: var(--sbw, 0px)` to `header`. The lock target (`body`) is unchanged from before; only the compensation is new.

## Why not `scrollbar-gutter: stable`

The tidier one-line CSS fix (permanently reserve the scrollbar gutter) was tested and ruled out: Blink collapses the reserved gutter under `overflow: hidden`, and overflow-propagation hands the viewport scrollbar to `body` (no stable gutter), so the content box still widened 1185 → 1200. Documented in the issue so it isn't re-attempted.

## Testing

- [x] `hugo --gc --minify` build passes (290 pages); compiled rules verified in the fingerprinted CSS the built HTML references.
- [x] Desktop (1200px, layout-consuming scrollbar): measured shift on the header search trigger + nav is **0px** (down from 15px) across all three open paths — header trigger, ⌘K/Ctrl-K, and `/`. Scroll is genuinely locked while open (`clientWidth` 1185→1200) and fully reverts on close (class removed, `--sbw` cleared).
- [x] Mobile (375px emulated, overlay scrollbar): clean no-op — `--sbw: 0px`, `body` padding-right `0px`, lock still applies, no horizontal overflow before/during/after. No regression.

Closes #212
