### PR TITLE
chore(claude): retire tutorial mode from the development approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,27 +10,21 @@ The original Nuxt.js 2 source lives in the sibling directory `../ofreport.com-nu
 
 ## Development Approach
 
-This project follows **developer-directed, AI-assisted** development. The developer (Joshua) directs all decisions and seeks to understand each step. **Explain Hugo concepts and rationale before generating code.** Present options with trade-offs and let the developer choose. See `docs/prd/00-overview.md` for details.
+**Developer-directed, AI-assisted.** Joshua directs the decisions and wants to follow the reasoning — surface trade-offs and rejected alternatives, and explain the _why_ behind a design choice. He is fluent in Hugo (this site has been live on it since 2026-06-23, and he has shipped others since); treat Hugo concepts as given rather than explaining them. Explain the decision, not the syntax. See `docs/prd/00-overview.md` for details.
 
 ## Development Workflow
 
 All work flows through GitHub Issues. The full pipeline is:
 
-1. **Plan**: When discussing new features or multi-step work, the output of planning
-   should be one or more GitHub issues. Each issue needs a clear title, description,
-   and acceptance criteria. Create the issues before starting implementation.
-2. **Implement**: Use `/resolve-issue <number>` to implement each issue on a feature
-   branch with a structured workflow.
-3. **Pull Request**: Use `/create-pr --issue <number>` to open a PR linking to the
-   resolved issue.
+1. **Plan**: When discussing new features or multi-step work, the output of planning should be one or more GitHub issues. Each issue needs a clear title, description, and acceptance criteria. Create the issues before starting implementation.
+2. **Implement**: Use `/resolve-issue <number>` to implement each issue on a feature branch with a structured workflow.
+3. **Pull Request**: Use `/create-pr --issue <number>` to open a PR linking to the resolved issue.
 4. **Merge**: PRs should pass build verification (`hugo --gc --minify`) before merging.
 
 Additional conventions:
 
-- Commit messages use Conventional Commits format but do NOT reference issue numbers.
-  Issue linking happens in the PR description via "Closes #N".
-- Small, unrelated housekeeping changes (typos, README updates) can be committed
-  directly to main without an issue or PR.
+- Commit messages use Conventional Commits format but do NOT reference issue numbers. Issue linking happens in the PR description via "Closes #N".
+- Small, unrelated housekeeping changes (typos, README updates) can be committed directly to main without an issue or PR.
 
 ## Build Commands
 


### PR DESCRIPTION
Applies the Q2 ruling from **joshukraine/dotfiles#252** (Phase 7) to this repo. No issue here — this is a working-agreement tweak, and the traceability lives on the dotfiles tracking issue.

## Why

`Explain Hugo concepts and rationale before generating code` was written during the Nuxt→Hugo rebuild, when Hugo was genuinely new. It is now stale: the site has been live on Hugo since **2026-06-23**, and two more Hugo sites have shipped since. The instruction was buying concept tutorials for a stack Joshua already ships in production.

`Present options with trade-offs and let the developer choose` goes too. Trade-offs still get surfaced — what's dropped is *stalling the decision* to ask when one option is clearly right.

## What replaces it

The calibration settled on #252: **explain the decision, not the syntax.** Joshua wants to follow the reasoning — trade-offs, rejected alternatives, the *why* behind a design choice — without being hand-held as a junior developer, and without over-correction into terseness that hides the logic. Hugo fluency is now assumed.

## Also in here

Unwrapped the hard-wrapped **Development Workflow** section. It broke prose mid-sentence at a fixed column, against the no-hard-wraps rule in the global config. MD013 is disabled, so nothing mechanical was catching it.

## Scope

Docs only — no template, layout, config, or content changes. Nothing to build-verify beyond the existing checks.
