### PR TITLE
fix(build): pin security.exec policy and align Hugo to 0.165.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.162.1"
+          hugo-version: "0.165.0"
           extended: true
 
       - run: hugo --gc --minify

--- a/hugo.toml
+++ b/hugo.toml
@@ -52,6 +52,22 @@ enableRobotsTXT = true
     scriptUrl = "https://lens.euroteamoutreach.org/script.js"
     websiteId = "34d2cfa4-e623-418a-936d-670c9d163ead"
 
+# Security policy — pinned rather than inherited.
+#
+# css.TailwindCSS shells out to the `tailwindcss` binary, which Hugo permits
+# only if it matches security.exec.allow. That list is a Hugo *default*, and the
+# default changed under us: 0.163 allowed `tailwindcss`, 0.165 does not, so a
+# routine Homebrew upgrade broke every local build with "access denied:
+# tailwindcss is not whitelisted".
+#
+# Declaring the list here decouples our build from whatever the installed Hugo
+# happens to default to. The value is 0.163's default, which is a superset of
+# 0.165's — it restores `tailwindcss` (required) and `sass-embedded` (unused
+# today, but dropping it would be an unrelated, silent narrowing).
+[security]
+  [security.exec]
+    allow = ['^(dart-)?sass(-embedded)?$', '^go$', '^git$', '^node$', '^postcss$', '^tailwindcss$']
+
 # Build stats for Tailwind CSS purging
 [build]
   [build.buildStats]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "npm ci && hugo --gc --minify && npx pagefind --site public"
 
 [build.environment]
-  HUGO_VERSION = "0.163.0"
+  HUGO_VERSION = "0.165.0"
   HUGO_ENVIRONMENT = "production"
   NODE_VERSION = "22"
 
@@ -14,14 +14,14 @@
 # on preview/branch URLs. We avoid "development" so hugo.IsDevelopment stays
 # false and the CSS pipeline keeps minifying/fingerprinting like production.
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.163.0"
+  HUGO_VERSION = "0.165.0"
   HUGO_ENVIRONMENT = "preview"
 
 [context.branch-deploy]
   command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL && npx pagefind --site public"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.163.0"
+  HUGO_VERSION = "0.165.0"
   HUGO_ENVIRONMENT = "preview"
 
 # Redirects for SEO continuity.


### PR DESCRIPTION
## Summary

Local builds have been broken since Homebrew moved to Hugo 0.165.0. `hugo --gc --minify` and `hugo server -D` both died in the Tailwind pipe with `access denied: "tailwindcss" is not whitelisted in policy "security.exec.allow"`.

Production was never affected, and that is the interesting part: CI (0.162.1) and Netlify (0.163.0) pin older Hugos whose defaults still allowed `tailwindcss`, so every automated check stayed green while local dev was unusable.

Closes #220

## Root cause

`hugo.toml` never declared a `[security]` block, so the build inherited whatever `security.exec.allow` the installed Hugo happened to default to — and that default changed between versions:

| Hugo | Default `security.exec.allow` |
| ---- | ----------------------------- |
| 0.163 | `['^(dart-)?sass(-embedded)?$', '^go$', '^git$', '^node$', '^postcss$', '^tailwindcss$']` |
| 0.165 | `['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']` |

0.165 drops `tailwindcss` (fatal for `css.TailwindCSS`) and also narrows the sass entry. Since `css.TailwindCSS` shells out to the `tailwindcss` binary, the build stopped the moment the allowlist no longer matched.

## Commits

| Commit | What |
| ------ | ---- |
| `fix(build): pin security.exec policy…` | The actual fix — declares the allowlist in `hugo.toml` |
| `chore(build): align Hugo to 0.165.0…` | Hygiene — converges the three version pins |

**The first commit is the durable fix; the second is not.** Pinning versions alone would only postpone this, because the next Homebrew upgrade re-opens the same hole. Declaring the policy decouples the build from the installed Hugo's defaults entirely, which is why it stands on its own.

The declared value is 0.163's default — a superset of 0.165's that restores `tailwindcss` (required) and `sass-embedded` (unused today, but silently dropping it would be an unrelated narrowing). Being a superset, it is a no-op on the older Hugos, so this is safe regardless of which version any environment lands on.

## Version alignment

Three environments were running three different Hugos. Only local floated, which is why local broke first and nothing automated noticed.

| Environment | Before | After |
| ----------- | ------ | ----- |
| Local | 0.165.0 (Homebrew, floats) | 0.165.0 |
| Netlify | 0.163.0 | 0.165.0 |
| CI | 0.162.1 | 0.165.0 |

0.165.0 is the current Hugo release, so this converges on latest rather than on an already-superseded pin.

## Verification

**Local build restored.** `hugo --gc --minify` and `hugo server -D` both succeed on 0.165.0 with no CLI flags or env overrides. The dev server serves 78KB of compiled Tailwind at `/css/main.css` (200, `text/css`), with expected utilities (`.mx-auto`, `.prose`, `.text-center`) present.

**Output-neutral, proven rather than assumed.** The version bump is the only part of this that could plausibly change the rendered site, so I tested it directly instead of trusting that a patch bump is inert: I extracted the Hugo 0.163.0 release (the outgoing Netlify pin) without installing it, built the site with it, built again with 0.165.0, and diffed the two `public/` trees.

- **417 files, 416 byte-for-byte identical.**
- The single difference is `<meta name=generator content="Hugo 0.163.0">` → `"Hugo 0.165.0"` on the home page — the only page in the site that carries the tag. Normalizing that one version string makes the file identical too.

**Checks to watch on this PR:** the CI `Hugo Build` job is the first run on 0.165.0, and the Netlify deploy preview is the first production-path build on it.

## Note for reviewers

This does not stop Homebrew from drifting local Hugo again — nothing in the repo can. What it changes is the consequence: drift is now inert, because the allowlist is ours rather than the installed binary's.
