### PR TITLE
feat: wedding live stream banner and announcement post

### DIFF
--- a/content/blog/2026-08-18-abbie-and-axel-wedding-live.md
+++ b/content/blog/2026-08-18-abbie-and-axel-wedding-live.md
@@ -11,11 +11,11 @@ caption: Abbie and Axel will be married on Saturday, August 22, 2026, in Houston
 slug: 2026-08-18-abbie-and-axel-wedding-live
 ---
 
-Back in May we shared the news that our eldest daughter, Abigail, was engaged to Axel Alvarenga. That day is now just around the corner.
+Back in May, we shared the news that our eldest daughter, Abigail, was engaged to Axel Alvarenga. Their wedding day is now just around the corner!
 
-This Saturday, August 22, Abbie and Axel will be married in Houston, Texas. Our whole family has traveled back from Ukraine to be here, and I have been given the joy of officiating the ceremony myself.
+This Saturday, August 22, Abbie and Axel will be married in Houston, Texas. Our whole family has traveled back from Ukraine to be here, and I have been given the joy of officiating the ceremony.
 
-So many of you have walked with our family for years — praying for us, supporting us, and following along from Ukraine, the United States, and beyond. We cannot gather all of you into one room, so we are doing the next best thing: the ceremony will be streamed live, and you are invited to join us.
+So many of you have walked with our family for years — praying for us, supporting us, and following along from Ukraine, the United States, and beyond. We know it’s not possible for everyone to attend in person, so we’ve decided to stream the ceremony live. You are cordially invited to join us!
 
 ## How to watch
 
@@ -34,6 +34,6 @@ If that timing does not work where you are, the same link will carry the recordi
 
 ## Please pray
 
-Would you pray with us this week? Pray for Abbie and Axel as they begin their life together, for safe travel for the family and friends gathering in Texas, and for a day that honors the Lord from beginning to end.
+Would you pray with us this week? Pray for Abbie and Axel as they begin their new life together, for safe travel for family and friends gathering in Texas, and for a day that honors the Lord Jesus Christ from beginning to end.
 
-We are grateful beyond words for each of you who has prayed our family through the years — and we are so glad you can be part of this day with us.
+We are grateful beyond words for each of you who has prayed for our family through the years — and we are so glad you can be part of this day with us.

--- a/content/blog/2026-08-18-abbie-and-axel-wedding-live.md
+++ b/content/blog/2026-08-18-abbie-and-axel-wedding-live.md
@@ -1,0 +1,39 @@
+---
+title: Abbie and Axel’s Wedding — Watch It Live
+date: '2026-08-18'
+author: Joshua Steele
+description: Our eldest daughter, Abigail, marries Axel Alvarenga this Saturday, August 22, in Houston, Texas. The ceremony will be streamed live at 2:00 PM CDT, and we would love to have you join us.
+tags:
+- family
+- announcements
+cover: https://res.cloudinary.com/dnkvsijzu/image/upload/v1779808026/Misc/abbie-axel_zrnm3s
+caption: Abbie and Axel will be married on Saturday, August 22, 2026, in Houston, Texas.
+slug: 2026-08-18-abbie-and-axel-wedding-live
+---
+
+Back in May we shared the news that our eldest daughter, Abigail, was engaged to Axel Alvarenga. That day is now just around the corner.
+
+This Saturday, August 22, Abbie and Axel will be married in Houston, Texas. Our whole family has traveled back from Ukraine to be here, and I have been given the joy of officiating the ceremony myself.
+
+So many of you have walked with our family for years — praying for us, supporting us, and following along from Ukraine, the United States, and beyond. We cannot gather all of you into one room, so we are doing the next best thing: the ceremony will be streamed live, and you are invited to join us.
+
+## How to watch
+
+The stream opens at **1:45 PM CDT** on Saturday, August 22, and the ceremony begins at **2:00 PM CDT**.
+
+For those joining from farther afield, that works out to:
+
+- **Kyiv** — 10:00 PM, Saturday
+- **El Salvador** — 1:00 PM, Saturday
+- **US Eastern** — 3:00 PM, Saturday
+- **US Pacific** — 12:00 noon, Saturday
+
+{{< button href="https://jsua.co/abbie-axel" text="Watch the Live Stream" external=true >}}
+
+If that timing does not work where you are, the same link will carry the recording afterward, so you can watch whenever you are able.
+
+## Please pray
+
+Would you pray with us this week? Pray for Abbie and Axel as they begin their life together, for safe travel for the family and friends gathering in Texas, and for a day that honors the Lord from beginning to end.
+
+We are grateful beyond words for each of you who has prayed our family through the years — and we are so glad you can be part of this day with us.

--- a/hugo.toml
+++ b/hugo.toml
@@ -52,6 +52,29 @@ enableRobotsTXT = true
     scriptUrl = "https://lens.euroteamoutreach.org/script.js"
     websiteId = "34d2cfa4-e623-418a-936d-670c9d163ead"
 
+# Site-wide announcement banner. Renders under the nav on every page until
+# `expires` passes. Two independent gates retire it: Hugo omits the markup at
+# build time once the deadline is past, and an inline script removes it
+# client-side between deploys (the one that matters — a static site can sit
+# undeployed for weeks).
+#
+# `expires` is a UTC instant, not a local date, so every reader gets the same
+# cutoff regardless of their own clock. 2026-08-23T05:00:00Z is midnight CDT at
+# the end of wedding day — CDT because the audience is primarily US-based. That
+# lands at 11:00 PM in El Salvador and 8:00 AM Sunday in Kyiv; the link survives
+# the deadline either way, since it serves the recording once the stream ends.
+#
+# `key` namespaces the "reader dismissed this" flag in localStorage. Bump it if
+# this block is ever reused for a different announcement, or everyone who
+# dismissed this one will silently never see the next one.
+[params.banner]
+  enabled = true
+  expires = "2026-08-23T05:00:00Z"
+  href = "https://jsua.co/abbie-axel"
+  text = "Abbie & Axel are getting married — Saturday, August 22."
+  linktext = "Watch the live stream"
+  key = "ofr-banner-abbie-axel-2026"
+
 # Security policy — pinned rather than inherited.
 #
 # css.TailwindCSS shells out to the `tailwindcss` binary, which Hugo permits

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
 <body class="min-h-screen bg-page font-sans text-gray-900 antialiased">
   {{ partial "header.html" . }}
   <main class="pt-16">
+    {{ partial "announcement-banner.html" . }}
     {{ block "main" . }}{{ end }}
   </main>
   {{ partial "footer.html" . }}

--- a/layouts/partials/announcement-banner.html
+++ b/layouts/partials/announcement-banner.html
@@ -1,0 +1,94 @@
+{{/* Site-wide announcement banner.
+
+     Placement: rendered as the first child of <main>, deliberately in normal
+     flow. The header is `fixed top-0` with an h-16 bar, and main's `pt-16` is
+     what clears it — so a banner placed here starts exactly under the nav, and
+     `sticky top-16` then pins it there on scroll.
+
+     The obvious alternative (a second fixed row under the header) would force
+     main's top padding to track a *variable* banner height — the copy wraps at
+     narrow widths — and that padding would then have to shrink again the moment
+     the banner is dismissed. Staying in flow means dismissal reflows the page
+     for free, with no measurement and no JS-managed padding.
+
+     Expiry runs on two independent gates:
+       - Build time (below): once `expires` is past, Hugo emits nothing at all,
+         so the next deploy ships HTML with no banner in it.
+       - Run time (the inline script): removes the element in the reader's
+         browser between deploys. This is the gate that actually retires the
+         banner, since nothing guarantees a deploy after the deadline.
+
+     The script is inline and synchronous, immediately after the markup, so an
+     expired or already-dismissed banner is gone before first paint instead of
+     flashing. Plain JS on purpose: Alpine is loaded from a CDN with `defer`, so
+     anything depending on it would flash first and could fail entirely if the
+     CDN is slow or blocked. */}}
+
+{{ with site.Params.banner }}
+  {{ if .enabled }}
+    {{ $expires := time.AsTime .expires }}
+    {{ if now.Before $expires }}
+      <div id="site-banner"
+           role="region"
+           aria-label="Site announcement"
+           data-expires="{{ .expires }}"
+           data-key="{{ .key }}"
+           class="sticky top-16 z-40 bg-blue-900 text-white">
+        <div class="flex items-center gap-x-3 px-4 py-2.5 sm:px-6 lg:px-8">
+          <p class="grow text-sm sm:text-base">
+            {{ .text }}
+            <a href="{{ .href }}"
+               class="font-semibold whitespace-nowrap underline decoration-blue-400 underline-offset-2 transition-colors hover:text-blue-100 hover:decoration-blue-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
+              {{ .linktext }}
+              <span aria-hidden="true">&rarr;</span>
+            </a>
+          </p>
+          <button type="button"
+                  data-banner-dismiss
+                  aria-label="Dismiss announcement"
+                  class="shrink-0 self-start rounded-md p-1.5 transition-colors hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:self-center">
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <script>
+        (function () {
+          var el = document.getElementById("site-banner");
+          if (!el) return;
+
+          var expires = Date.parse(el.dataset.expires);
+          var key = el.dataset.key;
+
+          if (!isNaN(expires) && Date.now() >= expires) {
+            el.remove();
+            return;
+          }
+
+          try {
+            if (key && window.localStorage.getItem(key) === "1") {
+              el.remove();
+              return;
+            }
+          } catch (e) {
+            /* localStorage throws in Safari private mode — fall through and
+               show the banner rather than failing closed. */
+          }
+
+          var button = el.querySelector("[data-banner-dismiss]");
+          if (!button) return;
+
+          button.addEventListener("click", function () {
+            try {
+              if (key) window.localStorage.setItem(key, "1");
+            } catch (e) {
+              /* Dismissal just won't persist; still remove it for this page. */
+            }
+            el.remove();
+          });
+        })();
+      </script>
+    {{ end }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary

Abbie & Axel are married on **Saturday, August 22** in Houston, with a YouTube live stream. This adds a self-retiring site-wide banner pointing readers at the stream, plus a post announcing it.

Closes #223

> [!IMPORTANT]
> The banner is **enabled**, so merging puts it on the live site immediately. It removes itself at `2026-08-23T05:00:00Z` with no follow-up deploy required.

## Commits

| Commit | What |
| ------ | ---- |
| `feat(banner): add expiring site-wide announcement banner` | The banner — config, partial, one line in `baseof.html` |
| `content(blog): announce Abbie and Axel's wedding live stream` | The post |

They are deliberately separate. The banner does not depend on the post, so if the post isn't wanted, drop that one commit and the banner ships unchanged.

## Banner design

**Placement is in normal flow**, as the first child of `<main>` with `sticky top-16`. The header is `fixed top-0` with an `h-16` bar and main's `pt-16` is what clears it, so a banner here starts exactly under the nav, and `sticky` pins it there on scroll.

The obvious alternative — a second *fixed* row under the header — would force main's top padding to track a banner height that **varies with text wrapping** (60px at 375px, 52px at 1280px), and then shrink again the instant the banner is dismissed. Staying in flow means dismissal reflows for free, with no measurement and no JS-managed padding.

**Two independent expiry gates.** Hugo omits the markup at build time once the deadline passes, and an inline script removes it in the browser between deploys. The runtime gate is the one that actually retires it — nothing guarantees a deploy after the deadline.

**`expires` is a UTC instant**, not a local date, so every reader gets the same cutoff regardless of their own clock:

| Zone | Ceremony | Banner expires |
| ---- | -------- | -------------- |
| Houston (CDT) | Sat 2:00 PM | Sun 12:00 AM |
| El Salvador | Sat 1:00 PM | Sat 11:00 PM |
| Kyiv | Sat 10:00 PM | Sun 8:00 AM |

Ten hours of runway after the ceremony starts, and the link keeps working past it — the landing page serves the recording once the broadcast ends.

**Plain JS, inline and synchronous, immediately after the markup.** Alpine loads deferred from a CDN, so an Alpine-based banner would flash before removing itself and would fail entirely if the CDN were blocked. `localStorage` is wrapped in `try`/`catch` — it throws in Safari private mode — and fails *open*, showing the banner rather than hiding it. Dismissal is stored under a versioned key so a future announcement reusing this block isn't suppressed for everyone who dismissed this one.

## Verification

**Responsive** — CSS-viewport emulation, not window resize. `innerWidth` confirmed first, then the overflow check:

| Width | `innerWidth` | `scrollWidth` | Overflow | Banner |
| ----- | ------------ | ------------- | -------- | ------ |
| 375 (mobile, touch) | 375 | 375 | none | top 64, height 60 |
| 1280 | 1280 | 1280 | none | top 64, height 52 |

**Gutters align with the header** — this caught a real bug. The banner first used a centered `max-w-6xl` container, which left its text inset 64px from the logo, because the header is deliberately full-width with the logo hard left. Now measured identical on both edges: left `32 / 32`, right `1248 / 1248` at desktop; `16 / 16` and `359 / 359` at mobile.

**Sticky actually pins** — after scrolling 1200px into an article, the banner's `top` is still exactly 64.

**Dismiss** — real click on the button: element removed from the DOM, `localStorage` flag set, still gone after reload, `main` padding unchanged at 64px.

**Runtime expiry** — the case that matters is a deploy made *before* the deadline, viewed *after* it. Simulated by shifting the page clock +5 days: the markup **was** present in the served HTML, and the element was **absent** from the DOM, with no dismissal flag involved. The script removed it purely on expiry.

**Every time in the post was checked against the IANA database** rather than computed by hand — Houston, Kyiv, El Salvador, US Eastern and Pacific all match what the post claims.

**Nothing else moved.** Built main and this branch with the banner expired, in clean worktrees: **405 HTML/XML files compared, 0 differ** once the stylesheet hash is normalized.

## One caveat worth knowing

**The banner's CSS ships even after the banner stops rendering.** Tailwind v4's automatic source detection scans `layouts/partials/announcement-banner.html` directly, so its utilities land in the stylesheet as long as that file exists — `@source "hugo_stats.json"` adds to detection rather than replacing it.

Measured cost: **1089 bytes raw, 181 bytes gzipped** (~1.8% of the stylesheet). Negligible, but it means the banner is not quite 100% self-cleaning. Deleting the partial and the `[params.banner]` block after the wedding is what reclaims it — no rush, and nothing breaks if it's never done.

## Note on the post

The factual scaffolding is verified, but the personal passages are my draft in your voice and should be read as a starting point — particularly the officiating line and the closing paragraph. Easy to rewrite or cut; nothing else depends on that wording.

Related: #217 (bundling Alpine) is deliberately untouched here — it should stay frozen until after the wedding rather than moving in the same week as the banner.
